### PR TITLE
LPS-38723  Removing escape methods that result in incorrect values for flagged emails

### DIFF
--- a/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
@@ -81,7 +81,7 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 
 		Group group = layout.getGroup();
 
-		String groupName = HtmlUtil.escape(group.getDescriptiveName());
+		String groupName = group.getDescriptiveName();
 
 		// Reporter user
 
@@ -111,10 +111,10 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 			flagsRequest.getReportedUserId());
 
 		if (reportedUser.isDefaultUser()) {
-			reportedUserName = HtmlUtil.escape(group.getDescriptiveName());
+			reportedUserName = group.getDescriptiveName();
 		}
 		else {
-			reportedUserName = HtmlUtil.escape(reportedUser.getFullName());
+			reportedUserName = reportedUser.getFullName();
 			reportedEmailAddress = reportedUser.getEmailAddress();
 			reportedURL = reportedUser.getDisplayURL(
 				serviceContext.getPortalURL(), serviceContext.getPathMain());

--- a/portal-web/docroot/html/portlet/flags/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/flags/edit_entry.jsp
@@ -111,10 +111,10 @@ long reportedUserId = ParamUtil.getLong(request, "reportedUserId");
 			'<liferay-portlet:actionURL portletName="<%= PortletKeys.FLAGS %>" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>"><portlet:param name="struts_action" value="/flags/edit_entry" /></liferay-portlet:actionURL>',
 			{
 				data: {
-					className: '<%= HtmlUtil.escape(className) %>',
+					className: '<%= className %>',
 					classPK: '<%= classPK %>',
-					contentTitle: '<%= HtmlUtil.escape(contentTitle) %>',
-					contentURL: '<%= HtmlUtil.escape(contentURL) %>',
+					contentTitle: '<%= contentTitle %>',
+					contentURL: '<%= contentURL %>',
 					reason: reason,
 					reportedUserId: '<%= reportedUserId %>',
 					reporterEmailAddress: reporterEmailAddress


### PR DESCRIPTION
LPP-8070 for your reference.

edit_entry.jsp
-removed the escape methods here for the different values because the escape method will cause any values here that contain special characters such as &<> to render incorrectly.
-although we are looking to escape this values on the jsp level, the values (contentTitle, contentUrl) are passed from edit_entry.jsp to the FlagsRequestMessageListener, so escaping them in edit_entry.jsp actually means that when it is used in FlagsRequestMessageListener, the values are incorrect.
-removed the escape method for the className
-removed it from the url because if you use &javascript=0 for example in the url, escaping it will cause the ampersand sign to result in ;amp and thus causing the URL to be incorrect

e.g. contentTitle displays as subject ba<>#$%^&, but because of our current implementation of taking the user to a dialog box, the values of contentTitle, contentURL are then escaped in edit_entry.jsp and thus values like contentTitle after being escaped, become subject ba&lt;&gt;#$%^&amp; 

FlagsRequestMessageListener.java
Removed escape methods for groupName and reportedUserName, because the doReceive method doesn't need these to be escaped.  In 114 and 117 of this class, the escape methods were added in by Wes Gong it seems to address the issue with needing to escape these values in jsp's.  The FlagsRequestMessageListener class does not need to have the reportedUserName values escaped as the values here will be used in the emails sent to the owner of the thread that is flagged.  Escaping reportedUserName doesn't do anything as it is already displaying the special characters correctly (this was the concern originally brought up by the LPS that added in those escape methods in this class).  Also, in a couple lines earlier, we are using the same method for getting the reporterUser and we do not escape the characters there, so removing the escape method from the reportedUser allows for more consistency.  
