### PR TITLE
Lps-38723

### DIFF
--- a/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
@@ -150,16 +150,16 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 
 		String contentTitle = HtmlUtil.unescape(flagsRequest.getContentTitle());
 		String contentURL = HtmlUtil.unescape(flagsRequest.getContentURL());
-		
+
 		for (User recipient : recipients) {
 			try {
 				notify(
 					company, groupName, reporterEmailAddress, reporterUserName,
 					reportedEmailAddress, reportedUserName, reportedURL,
-					flagsRequest.getClassPK(), contentTitle,
-					contentType, contentURL, reason, fromName,
-					fromAddress, recipient.getFullName(),
-					recipient.getEmailAddress(), subject, body, serviceContext);
+					flagsRequest.getClassPK(), contentTitle, contentType,
+					contentURL, reason, fromName, fromAddress,
+					recipient.getFullName(), recipient.getEmailAddress(),
+					subject, body, serviceContext);
 			}
 			catch (IOException ioe) {
 				if (_log.isWarnEnabled()) {


### PR DESCRIPTION
unescaping groupName, contentTitle, contentURL values as they have been escaped earlier in edit_entry.jsp and when passed in to this class, will display as incorrect form of its value (&amp instead of &).  Also removed unnecessary and inconsistent escape  methods from reportedUserName because the same logic is used for reporterUsername but without the escape method. 
