### PR TITLE
LPS-38723 unescaping groupName, contentTitle, contentURL values as they ...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
+++ b/portal-impl/src/com/liferay/portlet/flags/messaging/FlagsRequestMessageListener.java
@@ -81,7 +81,7 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 
 		Group group = layout.getGroup();
 
-		String groupName = HtmlUtil.escape(group.getDescriptiveName());
+		String groupName = HtmlUtil.unescape(group.getDescriptiveName());
 
 		// Reporter user
 
@@ -111,16 +111,19 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 			flagsRequest.getReportedUserId());
 
 		if (reportedUser.isDefaultUser()) {
-			reportedUserName = HtmlUtil.escape(group.getDescriptiveName());
+			reportedUserName = group.getDescriptiveName();
 		}
 		else {
-			reportedUserName = HtmlUtil.escape(reportedUser.getFullName());
+			reportedUserName = reportedUser.getFullName();
 			reportedEmailAddress = reportedUser.getEmailAddress();
 			reportedURL = reportedUser.getDisplayURL(
 				serviceContext.getPortalURL(), serviceContext.getPathMain());
 		}
 
 		// Content
+
+		String contentTitle = HtmlUtil.unescape(flagsRequest.getContentTitle());
+		String contentURL = HtmlUtil.unescape(flagsRequest.getContentURL());
 
 		String contentType = ResourceActionsUtil.getModelResource(
 			locale, flagsRequest.getClassName());
@@ -153,10 +156,10 @@ public class FlagsRequestMessageListener extends BaseMessageListener {
 				notify(
 					company, groupName, reporterEmailAddress, reporterUserName,
 					reportedEmailAddress, reportedUserName, reportedURL,
-					flagsRequest.getClassPK(), flagsRequest.getContentTitle(),
-					contentType, flagsRequest.getContentURL(), reason, fromName,
-					fromAddress, recipient.getFullName(),
-					recipient.getEmailAddress(), subject, body, serviceContext);
+					flagsRequest.getClassPK(), contentTitle, contentType,
+					contentURL, reason, fromName, fromAddress,
+					recipient.getFullName(), recipient.getEmailAddress(),
+					subject, body, serviceContext);
 			}
 			catch (IOException ioe) {
 				if (_log.isWarnEnabled()) {


### PR DESCRIPTION
...have been escaped earlier in JSP and when passed in to this class, will display as incorrect form of its value (&amp instead of &).  Also removed unnecessary escape  methods from reportedUserName.
