### PR TITLE
LPS-39678

### DIFF
--- a/portal-impl/src/com/liferay/portal/deploy/auto/WebAutoDeployer.java
+++ b/portal-impl/src/com/liferay/portal/deploy/auto/WebAutoDeployer.java
@@ -55,9 +55,11 @@ public class WebAutoDeployer extends WebDeployer implements AutoDeployer {
 
 			addExtJar(jars, "ext-util-bridges.jar");
 			addExtJar(jars, "ext-util-java.jar");
+			addExtJar(jars, "ext-util-slf4j.jar");
 			addExtJar(jars, "ext-util-taglib.jar");
 			addRequiredJar(jars, "util-bridges.jar");
 			addRequiredJar(jars, "util-java.jar");
+			addRequiredJar(jars, "util-slf4j.jar");
 			addRequiredJar(jars, "util-taglib.jar");
 
 			this.jars = jars;


### PR DESCRIPTION
LPS-25192 creates a util-slf4j.jar file which is a framework required by Solr. Without adding the dependency in GA3, NoSuchMethod exceptions occur and web-plugin deployment will fail.

Due to GA2 plugins within marketplace is the same as the GA3 plugins and util-slf4j.jar does not exist within GA2, we cannot add util-slf4j.jar as a "portal-dependency-jars" in liferay-plugin-package.properties file.

As an alternative, we would need to add it as a required jar upon deployment.
