### PR TITLE
LPS-40875 Close nodes after publish from staging

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/action/PublishLayoutsAction.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/action/PublishLayoutsAction.java
@@ -31,6 +31,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.security.auth.AuthException;
 import com.liferay.portal.security.auth.PrincipalException;
 import com.liferay.portal.security.auth.RemoteAuthException;
+import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.SessionTreeJSClicks;
 import com.liferay.portlet.sites.action.ActionUtil;
 
 import java.util.Date;
@@ -44,6 +46,8 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.apache.struts.action.ActionForm;
 import org.apache.struts.action.ActionForward;
@@ -108,6 +112,20 @@ public class PublishLayoutsAction extends EditLayoutsAction {
 				}
 				else if (cmd.equals("unschedule_publish_to_remote")) {
 					StagingUtil.unschedulePublishToRemote(actionRequest);
+				}
+
+				if (cmd.equals("publish_to_live") ||
+					cmd.equals("publish_to_remote") ||
+					cmd.equals("schedule_publish_to_live") ||
+					cmd.equals("schedule_publish_to_remote")) {
+
+					HttpServletRequest request =
+						PortalUtil.getHttpServletRequest(actionRequest);
+
+					String treeId = ParamUtil.getString(
+						actionRequest, "treeId");
+
+					SessionTreeJSClicks.closeNodes(request, treeId);
 				}
 
 				sendRedirect(

--- a/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/publish_layouts.jsp
@@ -173,6 +173,7 @@ portletURL.setParameter("closeRedirect", closeRedirect);
 portletURL.setParameter("groupId", String.valueOf(liveGroupId));
 portletURL.setParameter("stagingGroupId", String.valueOf(stagingGroupId));
 portletURL.setParameter("privateLayout", String.valueOf(privateLayout));
+portletURL.setParameter("treeId", treeId + "SelectedNode");
 
 PortletURL renderURL = renderResponse.createRenderURL();
 


### PR DESCRIPTION
This code removes the selected nodes from the preferences, so that when a user tries to publish from staging again, they will be able to select new pages they want to publish. This fix was made so that they do not have to deselect the previously published pages before selecting the pages they want to publish.

Thanks,
Eric
