### PR TITLE
LPS-40768

### DIFF
--- a/portal-web/docroot/html/portlet/dynamic_data_mapping/js/main.js
+++ b/portal-web/docroot/html/portlet/dynamic_data_mapping/js/main.js
@@ -666,7 +666,8 @@ AUI.add(
 					A.each(
 						str,
 						function(item, index, collection) {
-							if (!A.Text.Unicode.test(item, 'L') && !A.Text.Unicode.test(item, 'N')) {
+							if (!A.Text.Unicode.test(item, 'L') && !A.Text.Unicode.test(item, 'N') &&
+								!A.Text.Unicode.test(item,'Pd')) {
 								str = str.replace(item, STR_SPACE);
 							}
 						}


### PR DESCRIPTION
for LPS-40678. Added in the conditional a check for dash punctuation so that the hyphen ( - ) would NOT be replaced with a space and subsequently replaced by a underscore. Previously, the if condition was only taking into account letters ('L') and numbers ('N') so that if you used a hyphen or a dash, the character was being changed to a space.
