### PR TITLE
LPS-43215

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyCalendar.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyCalendar.java
@@ -71,7 +71,7 @@ public class VerifyCalendar extends VerifyProcess {
 		runSQL(
 			"update CalEvent set endDate = null where endDate is not null " +
 				"and (recurrence like '%\"until\":null%' or " +
-					"CAST_TEXT(recurrence) = 'null')");
+					"recurrence like 'null')");
 	}
 
 	protected void verifyNoAssets() throws Exception {


### PR DESCRIPTION
CAST_TEXT causes errors with Oracle due to comparison with a CLOB and VARCHAR(4000) if value has more than 4000 characters. 

Consulted with Minhchau and was told that CAST_TEXT isn't really required for the query. Made syntax changes and tested on both Master & ee-6.2.x, the upgrade was successful after the change.
