### PR TITLE
LPS-43991 setPasswordModifiedDate when silentUpdate is false and if value is null

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4625,11 +4625,16 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setPasswordUnencrypted(password1);
 		user.setPasswordEncrypted(true);
 		user.setPasswordReset(passwordReset);
-		user.setPasswordModifiedDate(new Date());
+
+		if (Validator.isNull(user.getPasswordModifiedDate())) {
+			user.setPasswordModifiedDate(new Date());
+		}
+
 		user.setDigest(StringPool.BLANK);
 		user.setGraceLoginCount(0);
 
 		if (!silentUpdate) {
+			user.setPasswordModifiedDate(new Date());
 			user.setPasswordModified(true);
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-43991

Modifying the passwordModifiedDate value in the database will trigger the Default Password Policy Expiration to occur. However, due to LDAP import, the passwordModifiedDate is updated everytime a user logs in. This renders Liferay's Default Password Policy functionality obsolete.

Manually tested all 5 scenarios listed on LPS-43991.
Ran "ant format-source". 
