### PR TITLE
LPS-43671  Plugins SDK builds invalid CSS successfully when using failonerror to true in build-common.xml for SassToCssBuilder, try/finally added to resolve stuck build process for Master

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/SassToCssBuilder.java
+++ b/portal-impl/src/com/liferay/portal/tools/SassToCssBuilder.java
@@ -98,7 +98,7 @@ public class SassToCssBuilder {
 		return fileName.substring(0, pos) + "_rtl" + fileName.substring(pos);
 	}
 
-	public static void main(String[] args) {
+	public static void main(String[] args) throws Exception {
 		Map<String, String> arguments = ArgumentsUtil.parseArguments(args);
 
 		List<String> dirNames = new ArrayList<String>();
@@ -124,12 +124,7 @@ public class SassToCssBuilder {
 		String docrootDirName = arguments.get("sass.docroot.dir");
 		String portalCommonDirName = arguments.get("sass.portal.common.dir");
 
-		try {
-			new SassToCssBuilder(dirNames, docrootDirName, portalCommonDirName);
-		}
-		catch (Exception e) {
-			e.printStackTrace();
-		}
+		new SassToCssBuilder(dirNames, docrootDirName, portalCommonDirName);
 	}
 
 	public static String parseStaticTokens(String content) {
@@ -196,11 +191,14 @@ public class SassToCssBuilder {
 			futures.add(executorService.submit(callable));
 		}
 
-		for (Future<String> future : futures) {
-			System.out.println(future.get());
+		try {
+			for (Future<String> future : futures) {
+				System.out.println(future.get());
+			}
 		}
-
-		executorService.shutdownNow();
+		finally {
+			executorService.shutdownNow();
+		}
 	}
 
 	private void _collectSassFiles(


### PR DESCRIPTION
- Ran "ant format-source"
- Ran "ant test-class -Dtest.class=SassToCssBuilderTest"
- Manually tested by modifying build-common.xml in liferay-plugins

Reference:
https://in.liferay.com/web/global.engineering/forums/-/message_boards/message/2280097#_19_message_2285124
