### PR TITLE
LPS-44142 since changes to the layoutRevision may be flushed by persiste...

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -473,7 +473,7 @@ public class LayoutRevisionLocalServiceImpl
 			layoutRevision.setWapColorSchemeId(wapColorSchemeId);
 			layoutRevision.setCss(css);
 
-			layoutRevisionPersistence.update(layoutRevision);
+			layoutRevision = layoutRevisionPersistence.update(layoutRevision);
 
 			_layoutRevisionId.set(layoutRevision.getLayoutRevisionId());
 		}
@@ -501,19 +501,12 @@ public class LayoutRevisionLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException, SystemException {
 
-		User user = userPersistence.findByPrimaryKey(userId);
-
 		LayoutRevision layoutRevision =
 			layoutRevisionPersistence.findByPrimaryKey(layoutRevisionId);
 
-		layoutRevision.setStatus(status);
-		layoutRevision.setStatusByUserId(user.getUserId());
-		layoutRevision.setStatusByUserName(user.getFullName());
-		layoutRevision.setStatusDate(new Date());
+		boolean head = false;
 
 		if (status == WorkflowConstants.STATUS_APPROVED) {
-			layoutRevision.setHead(true);
-
 			List<LayoutRevision> layoutRevisions =
 				layoutRevisionPersistence.findByL_P(
 					layoutRevision.getLayoutSetBranchId(),
@@ -528,10 +521,10 @@ public class LayoutRevisionLocalServiceImpl
 					layoutRevisionPersistence.update(curLayoutRevision);
 				}
 			}
+
+			head = true;
 		}
 		else {
-			layoutRevision.setHead(false);
-
 			List<LayoutRevision> layoutRevisions =
 				layoutRevisionPersistence.findByL_P_S(
 					layoutRevision.getLayoutSetBranchId(),
@@ -550,6 +543,17 @@ public class LayoutRevisionLocalServiceImpl
 				}
 			}
 		}
+
+		layoutRevision = layoutRevisionPersistence.findByPrimaryKey(
+			layoutRevisionId);
+
+		User user = userPersistence.findByPrimaryKey(userId);
+
+		layoutRevision.setHead(head);
+		layoutRevision.setStatus(status);
+		layoutRevision.setStatusByUserId(user.getUserId());
+		layoutRevision.setStatusByUserName(user.getFullName());
+		layoutRevision.setStatusDate(new Date());
 
 		layoutRevisionPersistence.update(layoutRevision);
 
@@ -634,6 +638,9 @@ public class LayoutRevisionLocalServiceImpl
 					parentLayoutRevision);
 			}
 		}
+
+		layoutRevision = layoutRevisionPersistence.findByPrimaryKey(
+			layoutRevision.getLayoutRevisionId());
 
 		layoutRevision.setParentLayoutRevisionId(parentLayoutRevisionId);
 		layoutRevision.setMajor(true);


### PR DESCRIPTION
...nce calls when inside a service method, we need to re-fetch the layoutRevision before calling update to prevent StaleStateExceptions; similar to LPS-43264 edc416dbe5fe8f2c69f13bcbd3afb1f4f52cc4cf
