### PR TITLE
LPS-45954

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/ldap/PortalLDAPUtil.java
+++ b/portal-impl/src/com/liferay/portal/security/ldap/PortalLDAPUtil.java
@@ -295,15 +295,20 @@ public class PortalLDAPUtil {
 			long companyId, String screenName, String emailAddress)
 		throws Exception {
 
-		long preferredLDAPServerId = LDAPSettingsUtil.getPreferredLDAPServerId(
-			companyId, screenName);
+		if (Validator.isNotNull(emailAddress) &&
+			Validator.isNotNull(screenName)) {
 
-		if (preferredLDAPServerId >= 0) {
-			if (hasUser(
-					preferredLDAPServerId, companyId, screenName,
-					emailAddress)) {
+			long preferredLDAPServerId =
+				LDAPSettingsUtil.getPreferredLDAPServerId(
+					companyId, screenName);
 
-				return preferredLDAPServerId;
+			if (preferredLDAPServerId >= 0) {
+				if (hasUser(
+						preferredLDAPServerId, companyId, screenName,
+						emailAddress)) {
+
+					return preferredLDAPServerId;
+				}
 			}
 		}
 


### PR DESCRIPTION
getPreferredLDAPServerId() will check if the user exists within the database. Only time a user should have one null parameter of screenName or emailAddress is during LDAP user creation. 
