### PR TITLE
LPS-46054

### DIFF
--- a/portal-web/docroot/html/portlet/journal/js/navigation.js
+++ b/portal-web/docroot/html/portlet/journal/js/navigation.js
@@ -381,8 +381,6 @@ AUI.add(
 							entriesContainer.html(searchingTPL);
 						}
 
-						instance._journalContainer.all('.article-entries-pagination').hide();
-
 						var requestParams = {};
 
 						requestParams[instance.ns(STRUTS_ACTION)] = '/journal/search';


### PR DESCRIPTION
_References:_
- LPS-34045: Upgraded paginator to pagination, there were additional UI API changes as well

Removing the following resolves the issue:
_instance._journalContainer.all('.article-entries-pagination').hide();_

---

Verified fix with the following manual tests:
- Control Panel Web Content search: test1, test, and blank search
- Control Panel Web Content search with a few web contents (no pagination): test1, test, and blank search
- Web Content Search portlet search: test1 and test
- Web Content Display (Select Web Content) search: test1, test, and blank search
- Add > Content (Recent) search: test1 and test
