### PR TITLE
LPS-47425 remote publishing may fail because of the remote file size lim...

### DIFF
--- a/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
+++ b/portal-impl/src/com/liferay/portal/staging/StagingImpl.java
@@ -649,10 +649,31 @@ public class StagingImpl implements Staging {
 			catch (Exception ex) {
 			}
 
-			errorMessage = LanguageUtil.format(
-				locale,
-				"please-enter-a-file-with-a-valid-file-size-no-larger-than-x",
-				TextFormatter.formatStorageSize(fileMaxSize, locale), false);
+			String cmd = null;
+
+			if (contextMap != null) {
+				cmd = (String)contextMap.get(Constants.CMD);
+			}
+
+			if (Validator.equals(cmd, Constants.PUBLISH)) {
+				errorMessage = LanguageUtil.format(
+					locale,
+					"file-size-limit-exceeded.-please-check-the-following-" +
+						"portal-properties-in-both-the-live-environment-" +
+							"and-the-staging-environment-x-x",
+					new String[] {
+						PropsKeys.DL_FILE_MAX_SIZE,
+						PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE
+					}, false);
+			}
+			else {
+				errorMessage = LanguageUtil.format(
+					locale,
+					"please-enter-a-file-with-a-valid-file-size-no-larger-" +
+						"than-x",
+					TextFormatter.formatStorageSize(fileMaxSize, locale),
+					false);
+			}
 			errorType = ServletResponseConstants.SC_FILE_SIZE_EXCEPTION;
 		}
 		else if (e instanceof LARTypeException) {

--- a/portal-impl/src/content/Language.properties
+++ b/portal-impl/src/content/Language.properties
@@ -2488,6 +2488,7 @@ file-list=File List
 file-location=File Location
 file-name=File Name
 file-size-is-larger-than-x-megabytes=File size is larger than {0} megabytes.
+file-size-limit-exceeded.-please-check-the-following-portal-properties-in-both-the-live-environment-and-the-staging-environment-x-x=File size limit exceeded. Please check the following portal properties in both the live environment and the staging environment {0} {1}.
 file-size-was-not-specified-in-the-request=File size was not specified in the request.
 file-type-is-invalid=File type is invalid.
 file-upload=File Upload


### PR DESCRIPTION
...its. The current error message does not specify that the remote instance could be at fault.
