### PR TITLE
LPS-49607 - An imported page template does not propagate changes to the ...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -80,6 +80,7 @@ import com.liferay.portlet.sites.util.SitesUtil;
 
 import java.io.IOException;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -535,6 +536,14 @@ public class LayoutStagedModelDataHandler
 			sb.append(parentLayoutId);
 
 			_log.debug(sb.toString());
+		}
+
+		if (layout.getLayoutPrototypeUuid() != null) {
+			UnicodeProperties prototypeTypeSettingsProperties =
+				layout.getTypeSettingsProperties();
+
+			prototypeTypeSettingsProperties.put(
+				"last-import-date", StringUtil.valueOf( (new Date()).getTime() ));
 		}
 
 		importedLayout.setCompanyId(portletDataContext.getCompanyId());

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1507,12 +1507,15 @@ public class SitesImpl implements Sites {
 
 		Date modifiedDate = layoutPrototypeLayout.getModifiedDate();
 
-		if (lastMergeTime >= modifiedDate.getTime()) {
-			return;
-		}
-
 		UnicodeProperties prototypeTypeSettingsProperties =
 			layoutPrototypeLayout.getTypeSettingsProperties();
+
+		Date lastImportDate = new Date (GetterUtil.getLong(
+			prototypeTypeSettingsProperties.get("last-import-date")));
+
+		if (lastMergeTime >= modifiedDate.getTime() || lastMergeTime >= lastImportDate.getTime()) {
+			return;
+		}
 
 		int mergeFailCount = GetterUtil.getInteger(
 			prototypeTypeSettingsProperties.getProperty(MERGE_FAIL_COUNT));


### PR DESCRIPTION
...associated pages. Importing templates does not update the modified date - so when updated liferay checks the modified date and uses the most recent template. The imported template will always be older modified date causing this bug. Use the prototypeTypeSettingsProperties to set the import date correctly.
