### PR TITLE
LPS-49607 - An imported page template does not propagate changes to the ...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -537,6 +537,15 @@ public class LayoutStagedModelDataHandler
 			_log.debug(sb.toString());
 		}
 
+		if (layout.getLayoutPrototypeUuid() != null) {
+			UnicodeProperties prototypeTypeSettingsProperties =
+				layout.getTypeSettingsProperties();
+
+			prototypeTypeSettingsProperties.put(
+					"last-import-date", String.valueOf(
+						System.currentTimeMillis()));
+		}
+
 		importedLayout.setCompanyId(portletDataContext.getCompanyId());
 		importedLayout.setParentLayoutId(parentLayoutId);
 		importedLayout.setName(layout.getName());

--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -1507,12 +1507,20 @@ public class SitesImpl implements Sites {
 
 		Date modifiedDate = layoutPrototypeLayout.getModifiedDate();
 
-		if (lastMergeTime >= modifiedDate.getTime()) {
-			return;
-		}
-
 		UnicodeProperties prototypeTypeSettingsProperties =
 			layoutPrototypeLayout.getTypeSettingsProperties();
+
+		long lastImportDate = GetterUtil.getLong(
+			prototypeTypeSettingsProperties.get("last-import-date"));
+
+		if (lastImportDate != 0) {
+			if (lastMergeTime >= lastImportDate) {
+				return;
+			}
+		}
+		else if (lastMergeTime >= modifiedDate.getTime()) {
+			return;
+		}
 
 		int mergeFailCount = GetterUtil.getInteger(
 			prototypeTypeSettingsProperties.getProperty(MERGE_FAIL_COUNT));


### PR DESCRIPTION
...associated pages. Importing templates does not update the modified date - so when updated liferay checks the modified date and uses the most recent template. The imported template will always be older modified date causing this bug. Use the prototypeTypeSettingsProperties to set the import date correctly.
