### PR TITLE
LPS-49741 verify typed model by not allowing null for classNameId

### DIFF
--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -48,6 +48,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		verify(new VerifyOrganization());
 		verify(new VerifyResourcePermissions());
 		verify(new VerifySocial());
+		verify(new VerifyTypedModel());
 		verify(new VerifyUser());
 		verify(new VerifyWiki());
 		verify(new VerifyWorkflow());

--- a/portal-impl/src/com/liferay/portal/verify/VerifyTypedModel.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyTypedModel.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Andrew Betts
+ */
+public class VerifyTypedModel extends VerifyProcess {
+
+	protected void doVerify() {
+		updateNullValuesForClassNameId();
+	}
+
+	protected void updateNullValuesForClassNameId() {
+		Connection con = null;
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			con = DataAccess.getUpgradeOptimizedConnection();
+
+			StringBundler sb = new StringBundler(2);
+
+			sb.append("select table_name from information_schema.columns");
+			sb.append(" where column_name = 'classNameId'");
+
+			String sql = sb.toString();
+
+			ps = con.prepareStatement(sql);
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				String tableName = rs.getString("table_name");
+
+				if (!isPortalTableName(tableName)) {
+					continue;
+				}
+
+				runSQL(
+					"update " + tableName + " set classNameId = 0 where " +
+						"classNameId is null");
+			}
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+		}
+		finally {
+			DataAccess.cleanUp(con, ps, rs);
+		}
+	}
+
+	private static Log _log = LogFactoryUtil.getLog(VerifyTypedModel.class);
+
+}


### PR DESCRIPTION
LpS-44802 already resolves the upgrade issue in 6.2.x but for clients that have already upgraded the problem still exists.

the reason that classNameId cannot be null in the DB is because of our dynamicQueries. We search for entities based on classNameId (e.g. = 0), if classNameId is set to null in the DB the query does not find the entity and therefore the return results are incorrect.

https://issues.liferay.com/browse/LPS-36407 is what adds the classNameId as a criterion for export dynamic queries
