### PR TITLE
LPS-49607 - An imported page template does not propagate changes to the ...

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/lar/LayoutStagedModelDataHandler.java
@@ -80,6 +80,7 @@ import com.liferay.portlet.sites.util.SitesUtil;
 
 import java.io.IOException;
 
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -535,6 +536,10 @@ public class LayoutStagedModelDataHandler
 			sb.append(parentLayoutId);
 
 			_log.debug(sb.toString());
+		}
+
+		if (layout.getLayoutPrototypeUuid() != null) {
+			importedLayout.setModifiedDate(new Date());
 		}
 
 		importedLayout.setCompanyId(portletDataContext.getCompanyId());


### PR DESCRIPTION
...associated pages. Importing templates does not update the modified date - so when updated liferay checks the modified date and uses the most recent template. The imported template will always be older modified date causing this bug.
