### PR TITLE
LPS-49928 Validator should be used for null check for strings

### DIFF
--- a/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
+++ b/portal-impl/src/com/liferay/portal/plugin/PluginPackageUtil.java
@@ -999,7 +999,7 @@ public class PluginPackageUtil {
 		String servletContextName = servletContext.getServletContextName();
 
 		if (_log.isInfoEnabled()) {
-			if (servletContextName == null) {
+			if (Validator.isNull(servletContextName)) {
 				_log.info("Reading plugin package for the root context");
 			}
 			else {

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletLocalServiceImpl.java
@@ -1147,7 +1147,8 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 			PortletApp portletApp = portlet.getPortletApp();
 
-			if ((servletContextName != null) && portletApp.isWARFile() &&
+			if (Validator.isNotNull(servletContextName) &&
+				portletApp.isWARFile() &&
 				portletId.endsWith(
 					PortletConstants.WAR_SEPARATOR +
 						PortalUtil.getJsSafePortletId(servletContextName)) &&
@@ -1155,7 +1156,7 @@ public class PortletLocalServiceImpl extends PortletLocalServiceBaseImpl {
 
 				undefinedPortletIds.add(portletId);
 			}
-			else if ((servletContextName == null) &&
+			else if (Validator.isNull(servletContextName) &&
 					 !portletApp.isWARFile() &&
 					 !portletId.contains(PortletConstants.WAR_SEPARATOR) &&
 					 !portletIds.contains(portletId)) {

--- a/portal-service/src/com/liferay/portal/kernel/portlet/PortletClassLoaderUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/portlet/PortletClassLoaderUtil.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermissio
 import com.liferay.portal.kernel.servlet.PluginContextListener;
 import com.liferay.portal.kernel.util.AutoResetThreadLocal;
 import com.liferay.portal.kernel.util.ClassLoaderPool;
+import com.liferay.portal.kernel.util.Validator;
 
 import javax.servlet.ServletContext;
 
@@ -51,7 +52,7 @@ public class PortletClassLoaderUtil {
 	public static String getServletContextName() {
 		String servletContextName = _servletContextName.get();
 
-		if (servletContextName == null) {
+		if (Validator.isNull(servletContextName)) {
 			throw new IllegalStateException(
 				"No servlet context name specified");
 		}

--- a/portal-service/src/com/liferay/portal/kernel/servlet/ServletContextPool.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/ServletContextPool.java
@@ -16,6 +16,7 @@ package com.liferay.portal.kernel.servlet;
 
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.util.PortalUtil;
 
 import java.util.Map;
@@ -60,7 +61,7 @@ public class ServletContextPool {
 	}
 
 	private boolean _containsKey(String servletContextName) {
-		if (servletContextName == null) {
+		if (Validator.isNull(servletContextName)) {
 			return false;
 		}
 


### PR DESCRIPTION
I looked for where we check servletContextName == null and replaced them with Validator.isNull()

I also looked at when we use != null, but i think that there might be a few cases for using that instead of Validator.isNotNull() so I left those cases alone (with one exception).

Searching for Validator.isNotNull(servletContextName) brought up a few instances so I think that there may be a reason we left some of the != null cases alone. If I was not sure about a change, I left it alone since this is to prevent errors and not cause them :+1: 
