### PR TITLE
LPS-50170

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
@@ -96,6 +96,8 @@ public class DDMImpl implements DDM {
 
 	public static final String TYPE_DDM_LINK_TO_PAGE = "ddm-link-to-page";
 
+	public static final String TYPE_DDM_TEXT_HTML = "ddm-text-html";
+
 	public static final String TYPE_RADIO = "radio";
 
 	public static final String TYPE_SELECT = "select";

--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMIndexerImpl.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.FastDateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
@@ -240,6 +241,10 @@ public class DDMIndexerImpl implements DDMIndexer {
 						sb.append(StringPool.SPACE);
 					}
 					else {
+						if (type.equals(DDMImpl.TYPE_DDM_TEXT_HTML)) {
+							valueString = HtmlUtil.extractText(valueString);
+						}
+
 						sb.append(valueString);
 						sb.append(StringPool.SPACE);
 					}


### PR DESCRIPTION
We use the same method (HtmlUtil.extractText) to remove HTML tags for default web content structures. I'm applying it to HTML fields for custom structures.

Also, see commit to plugins https://github.com/jonathanmccann/liferay-plugins/pull/52
