### PR TITLE
LPS-50864 close the zipReader when finished with it to free up its resou...

### DIFF
--- a/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
+++ b/portal-impl/src/com/liferay/portal/lar/ExportImportHelperImpl.java
@@ -487,7 +487,12 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 				group.getCompanyId(), groupId, parameterMap,
 				getUserIdStrategy(userId, userIdStrategy), zipReader);
 
-		return getManifestSummary(portletDataContext);
+		try {
+			return getManifestSummary(portletDataContext);
+		}
+		finally {
+			zipReader.close();
+		}
 	}
 
 	@Override
@@ -500,6 +505,8 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		InputStream inputStream = DLFileEntryLocalServiceUtil.getFileAsStream(
 			fileEntry.getFileEntryId(), fileEntry.getVersion(), false);
 
+		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
+
 		ManifestSummary manifestSummary = null;
 
 		try {
@@ -508,7 +515,6 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 			Group group = GroupLocalServiceUtil.getGroup(groupId);
 			String userIdStrategy = MapUtil.getString(
 				parameterMap, PortletDataHandlerKeys.USER_ID_STRATEGY);
-			ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
 
 			PortletDataContext portletDataContext =
 				PortletDataContextFactoryUtil.createImportPortletDataContext(
@@ -519,6 +525,8 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 		}
 		finally {
 			StreamUtil.cleanUp(inputStream);
+
+			zipReader.close();
 
 			FileUtil.delete(file);
 		}
@@ -1658,7 +1666,12 @@ public class ExportImportHelperImpl implements ExportImportHelper {
 				group.getCompanyId(), groupId, parameterMap,
 				getUserIdStrategy(userId, userIdStrategy), zipReader);
 
-		return validateMissingReferences(portletDataContext);
+		try {
+			return validateMissingReferences(portletDataContext);
+		}
+		finally {
+			zipReader.close();
+		}
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/LayoutImporter.java
@@ -137,13 +137,13 @@ public class LayoutImporter {
 			Map<String, String[]> parameterMap, File file)
 		throws Exception {
 
+		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
+
 		try {
 			ExportImportThreadLocal.setLayoutValidationInProcess(true);
 
 			LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(
 				groupId, privateLayout);
-
-			ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
 
 			validateFile(
 				layoutSet.getCompanyId(), groupId, parameterMap, zipReader);
@@ -177,6 +177,8 @@ public class LayoutImporter {
 		}
 		finally {
 			ExportImportThreadLocal.setLayoutValidationInProcess(false);
+
+			zipReader.close();
 		}
 	}
 

--- a/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
+++ b/portal-impl/src/com/liferay/portal/lar/PortletImporter.java
@@ -217,12 +217,12 @@ public class PortletImporter {
 			Map<String, String[]> parameterMap, File file)
 		throws Exception {
 
+		ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
+
 		try {
 			ExportImportThreadLocal.setPortletValidationInProcess(true);
 
 			Layout layout = LayoutLocalServiceUtil.getLayout(plid);
-
-			ZipReader zipReader = ZipReaderFactoryUtil.getZipReader(file);
 
 			validateFile(layout.getCompanyId(), groupId, portletId, zipReader);
 
@@ -255,6 +255,8 @@ public class PortletImporter {
 		}
 		finally {
 			ExportImportThreadLocal.setPortletValidationInProcess(false);
+
+			zipReader.close();
 		}
 	}
 


### PR DESCRIPTION
...rces. This allows for temp files to be deleted afterward, if they are used to create the zipReader.

i didn't know if I was supposed to fix the deprecated methods too, but i thought it couldn't hurt in case someone does try to call them.
