### PR TITLE
LPS-51099 force disable option should only be visible from the control p...

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/error_remote_export_exception.jspf
+++ b/portal-web/docroot/html/portlet/layouts_admin/error_remote_export_exception.jspf
@@ -23,7 +23,7 @@
 	<c:if test="<%= ree.getType() == RemoteExportException.BAD_CONNECTION %>">
 		<liferay-ui:message arguments='<%= "<em>" + ree.getURL() + "</em>" %>' key="could-not-connect-to-address-x.-please-verify-that-the-specified-port-is-correct-and-that-the-remote-server-is-configured-to-accept-requests-from-this-server" translateArguments="<%= false %>" />
 
-		<c:if test="<%= liveGroup.isStaged() && liveGroup.isStagedRemotely() %>">
+		<c:if test="<%= liveGroup.isStaged() && liveGroup.isStagedRemotely() && layout.isTypeControlPanel() %>">
 			<liferay-ui:message arguments='<%= "javascript:" + renderResponse.getNamespace() + "saveGroup(true);" %>' key="you-also-have-the-option-to-forcibly-disable-remote-staging" />
 		</c:if>
 	</c:if>


### PR DESCRIPTION
...anel: the javascript function saveGroup(forcedisable) is only defined in edit_site.jsp. so when viewed from edit_layout.jsp, edit_layout_set.jsp, or publish_layouts.jsp, the force disable link doesn't work.
