### PR TITLE
LPS-51401

### DIFF
--- a/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
+++ b/portal-impl/src/com/liferay/portlet/dynamicdatamapping/util/DDMImpl.java
@@ -41,6 +41,7 @@ import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.service.DLAppLocalServiceUtil;
 import com.liferay.portlet.documentlibrary.util.DLUtil;
@@ -111,6 +112,10 @@ public class DDMImpl implements DDM {
 
 		if (refererPortletName == null) {
 			refererPortletName = serviceContext.getPortletId();
+		}
+
+		if (refererPortletName == null) {
+			refererPortletName = PortletKeys.DYNAMIC_DATA_LISTS;
 		}
 
 		return DDMDisplayRegistryUtil.getDDMDisplay(refererPortletName);


### PR DESCRIPTION
Hi Jon,

This PR is to fix an issue with the ddmtemplate/add-template JSON webservice call, which throws a NPE. The NPE occurs because the JSON webservice call does not have a referer portlet name or a portlet id, so it uses a null value for the referer portlet name. 

My fix uses the portlet id of the dynamic data list portlet as the "default" referer portlet name.

Thanks,
Josh
