### PR TITLE
LPS-51488 truncation error on DLFolder name column during portlet import

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/TempFileEntryUtil.java
@@ -37,11 +37,12 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 
 import java.nio.charset.StandardCharsets;
+
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
@@ -149,7 +150,8 @@ public class TempFileEntryUtil {
 		return ArrayUtil.toStringArray(fileNames);
 	}
 
-	protected static String getTempFolderName(String folderName) throws PortalException {
+	protected static String getTempFolderName(String folderName)
+		throws PortalException {
 
 		try {
 			MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
@@ -162,7 +164,8 @@ public class TempFileEntryUtil {
 
 			for (int i = 0; i < hash.length; i++) {
 				String hex = Integer.toHexString(0xff & hash[i]);
-				if(hex.length() == 1) stringBuffer.append('0');
+
+				if (hex.length() == 1) stringBuffer.append('0');
 				stringBuffer.append(hex);
 			}
 

--- a/portal-service/test/unit/com/liferay/portal/kernel/util/TempFileEntryUtilTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/util/TempFileEntryUtilTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
 package com.liferay.portal.kernel.util;
 
 import com.liferay.portal.kernel.log.Log;
@@ -9,29 +23,35 @@ import org.junit.Test;
 /**
  * @author Kayleen Lim
  */
-
 public class TempFileEntryUtilTest {
 
-    @Test
-    public void testGetTempFolderNameWithLongPortletId() throws Exception{
-        String expected = "cabc7889bb678adaf651cbe68824ae7d4bfe0e859f00696c84549987207e5155";
-        String test = TempFileEntryUtil.getTempFolderName("com.liferay.portal.kernel.lar.ExportImportHelpertestajaxportlet_WAR_ajaxtestportlet_INSTANCE_ovCXcIQL242L");
-        Assert.assertEquals(expected, test);
-    }
+	@Test
+	public void testGetTempFolderNameWithLongPortletId() throws Exception {
+		Assert.assertEquals(
+			"cabc7889bb678adaf651cbe68824ae7d4bfe0e859f00696c84549987207e5155",
+			TempFileEntryUtil.getTempFolderName(
+				"com.liferay.portal.kernel.lar." +
+				"ExportImportHelpertestajaxportlet_WAR_ajaxtestportlet_" +
+				"INSTANCE_ovCXcIQL242L"));
+	}
+
+	@Test
+	public void testGetTempFolderNameWithNoPortletId() throws Exception {
+		Assert.assertEquals(
+			"1db25597ffc920e0a2e046daa0eb47f628da8797c0807e4027b8b5cb494f0d63",
+			TempFileEntryUtil.getTempFolderName(
+				"com.liferay.portal.kernel.lar.ExportImportHelper"));
+	}
 
 	@Test
 	public void testGetTempFolderNameWithShortPortletId() throws Exception {
-        String expected = "c04f8cdb685f7b905abc9e7e323c800ff8d08c2936c6b5ca153edfdd90850a0f";
-        String test = TempFileEntryUtil.getTempFolderName("com.liferay.portal.kernel.lar.ExportImportHelper86");
-        Assert.assertEquals(expected, test);
-    }
+		Assert.assertEquals(
+			"c04f8cdb685f7b905abc9e7e323c800ff8d08c2936c6b5ca153edfdd90850a0f",
+			TempFileEntryUtil.getTempFolderName(
+				"com.liferay.portal.kernel.lar.ExportImportHelper86"));
+	}
 
-    @Test
-    public void testGetTempFolderNameWithNoPortletId() throws Exception {
-        String expected = "1db25597ffc920e0a2e046daa0eb47f628da8797c0807e4027b8b5cb494f0d63";
-        String test = TempFileEntryUtil.getTempFolderName("com.liferay.portal.kernel.lar.ExportImportHelper");
-        Assert.assertEquals(expected, test);
-    }
+	private static final Log _log = LogFactoryUtil.getLog(
+		TempFileEntryUtilTest.class);
 
-    private static Log _log = LogFactoryUtil.getLog(TempFileEntryUtilTest.class);
 }


### PR DESCRIPTION
Hi Jonathan,
Currently, portlet imports fail when a truncation error occurs for the DLFolder name because the it exceeds 100 char.
Solution:
Protected method uses SHA-256 to create a hash to be stored in the db instead, so that 64 char will always be stored in the db for temp file entries.
There are three tests provided to test the reliability of the hash creation.
