### PR TITLE
LPS-52386 High CPU overhead when adding large zip files

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -576,6 +576,8 @@ public class PropsValues {
 
 	public static final long DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE = GetterUtil.getLong(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_PREVIEWABLE_PROCESSOR_MAX_SIZE));
 
+	public static final String[] DL_FILE_ENTRY_RAW_METADATA_PROCESSOR_EXCLUDE_MIME_TYPES = PropsUtil.getArray(PropsKeys.DL_FILE_ENTRY_RAW_METADATA_PROCESSOR_EXCLUDE_MIME_TYPES);
+
 	public static final int DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_HEIGHT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_HEIGHT));
 
 	public static final int DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_WIDTH = GetterUtil.getInteger(PropsUtil.get(PropsKeys.DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_WIDTH));

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/action/ActionUtil.java
@@ -115,7 +115,9 @@ public class ActionUtil {
 			fileVersion = fileEntry.getFileVersion();
 		}
 
-		RawMetadataProcessorUtil.generateMetadata(fileVersion);
+		if (RawMetadataProcessorUtil.isSupported(fileVersion)) {
+			RawMetadataProcessorUtil.generateMetadata(fileVersion);
+		}
 
 		String cmd = ParamUtil.getString(request, Constants.CMD);
 

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/RawMetadataProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/RawMetadataProcessorImpl.java
@@ -27,12 +27,14 @@ import com.liferay.portal.kernel.repository.model.FileVersion;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
 import com.liferay.portal.kernel.security.pacl.DoPrivileged;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileEntry;
 import com.liferay.portal.repository.liferayrepository.model.LiferayFileVersion;
 import com.liferay.portal.service.ServiceContext;
 import com.liferay.portal.util.PortalUtil;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.documentlibrary.model.DLFileEntryConstants;
 import com.liferay.portlet.documentlibrary.service.DLFileEntryMetadataLocalServiceUtil;
 import com.liferay.portlet.dynamicdatamapping.model.DDMStructure;
@@ -103,12 +105,14 @@ public class RawMetadataProcessorImpl
 
 	@Override
 	public boolean isSupported(FileVersion fileVersion) {
-		return true;
+		return isSupported(fileVersion.getMimeType());
 	}
 
 	@Override
 	public boolean isSupported(String mimeType) {
-		return true;
+		return !ArrayUtil.contains(
+			PropsValues.DL_FILE_ENTRY_RAW_METADATA_PROCESSOR_EXCLUDE_MIME_TYPES,
+			mimeType);
 	}
 
 	@Override

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9985,6 +9985,12 @@
     dl.file.entry.processors=com.liferay.portlet.documentlibrary.util.AudioProcessorImpl,com.liferay.portlet.documentlibrary.util.ImageProcessorImpl,com.liferay.portlet.documentlibrary.util.PDFProcessorImpl,com.liferay.portlet.documentlibrary.util.RawMetadataProcessorImpl,com.liferay.portlet.documentlibrary.util.VideoProcessorImpl
 
     #
+    # Input a list of comma delimited mime types to exclude from metadata
+    # extraction.
+    #
+    dl.file.entry.raw.metadata.processor.exclude.mime.types=application/zip
+
+    #
     # Set the maximum file size for preview and thumbnail generation. Files
     # larger than the value specified in this property will not result in the
     # execution of a processor that generates a preview. A value of -1 indicates

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -727,6 +727,8 @@ public interface PropsKeys {
 
 	public static final String DL_FILE_ENTRY_PROCESSORS = "dl.file.entry.processors";
 
+	public static final String DL_FILE_ENTRY_RAW_METADATA_PROCESSOR_EXCLUDE_MIME_TYPES = "dl.file.entry.raw.metadata.processor.exclude.mime.types";
+
 	public static final String DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_HEIGHT = "dl.file.entry.thumbnail.custom1.max.height";
 
 	public static final String DL_FILE_ENTRY_THUMBNAIL_CUSTOM_1_MAX_WIDTH = "dl.file.entry.thumbnail.custom1.max.width";


### PR DESCRIPTION
I wasn't sure about being more generous with the isSupported checks, I only put them where they're needed right now.

RawMetadataProcessorMessageListener calls saveMetadata but that is only done through DLProcessorRegistryImpl#trigger which is already calling isSupported.
