### PR TITLE
LPS-56364 make logic reusable

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -1875,7 +1875,16 @@ public class PortalImpl implements Portal {
 	public long[] getCurrentAndAncestorSiteGroupIds(long groupId)
 		throws PortalException {
 
-		List<Group> groups = getCurrentAndAncestorSiteGroups(groupId);
+		return getCurrentAndAncestorSiteGroupIds(groupId, false);
+	}
+
+	@Override
+	public long[] getCurrentAndAncestorSiteGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		List<Group> groups = getCurrentAndAncestorSiteGroups(
+			groupId, checkContentSharingWithChildrenEnabled);
 
 		long[] groupIds = new long[groups.size()];
 
@@ -1892,7 +1901,16 @@ public class PortalImpl implements Portal {
 	public long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
 		throws PortalException {
 
-		List<Group> groups = getCurrentAndAncestorSiteGroups(groupIds);
+		return getCurrentAndAncestorSiteGroupIds(groupIds, false);
+	}
+
+	@Override
+	public long[] getCurrentAndAncestorSiteGroupIds(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		List<Group> groups = getCurrentAndAncestorSiteGroups(
+			groupIds, checkContentSharingWithChildrenEnabled);
 
 		long[] currentAndAncestorSiteGroupIds = new long[groups.size()];
 
@@ -1909,6 +1927,14 @@ public class PortalImpl implements Portal {
 	public List<Group> getCurrentAndAncestorSiteGroups(long groupId)
 		throws PortalException {
 
+		return getCurrentAndAncestorSiteGroups(groupId, false);
+	}
+
+	@Override
+	public List<Group> getCurrentAndAncestorSiteGroups(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
 		Set<Group> groups = new LinkedHashSet<>();
 
 		Group siteGroup = doGetCurrentSiteGroup(groupId);
@@ -1917,7 +1943,9 @@ public class PortalImpl implements Portal {
 			groups.add(siteGroup);
 		}
 
-		groups.addAll(doGetAncestorSiteGroups(groupId, false));
+		groups.addAll(
+			doGetAncestorSiteGroups(
+				groupId, checkContentSharingWithChildrenEnabled));
 
 		return new ArrayList<>(groups);
 	}
@@ -1926,10 +1954,20 @@ public class PortalImpl implements Portal {
 	public List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
 		throws PortalException {
 
+		return getCurrentAndAncestorSiteGroups(groupIds, false);
+	}
+
+	@Override
+	public List<Group> getCurrentAndAncestorSiteGroups(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
 		Set<Group> groups = new LinkedHashSet<>();
 
 		for (int i = 0; i < groupIds.length; i++) {
-			groups.addAll(getCurrentAndAncestorSiteGroups(groupIds[i]));
+			groups.addAll(
+				getCurrentAndAncestorSiteGroups(
+					groupIds[i], checkContentSharingWithChildrenEnabled));
 		}
 
 		return new ArrayList<>(groups);

--- a/portal-impl/src/com/liferay/portlet/assetpublisher/context/AssetPublisherDisplayContext.java
+++ b/portal-impl/src/com/liferay/portlet/assetpublisher/context/AssetPublisherDisplayContext.java
@@ -15,6 +15,7 @@
 package com.liferay.portlet.assetpublisher.context;
 
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.model.PortletConstants;
 import com.liferay.portal.theme.PortletDisplay;
 import com.liferay.portal.theme.ThemeDisplay;
+import com.liferay.portal.util.PortalUtil;
 import com.liferay.portal.util.PortletKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.WebKeys;
@@ -436,6 +438,21 @@ public class AssetPublisherDisplayContext {
 		}
 
 		return _portletResource;
+	}
+
+	public long[] getReferencedEntitiesGroupIds() throws PortalException {
+
+		// Referenced entites are asset subtypes, tags or categories that
+		// are used to filter assets and can belong to a different scope of
+		// the asset they are associated to
+
+		if (_referencedEntitiesGroupIds == null) {
+			_referencedEntitiesGroupIds =
+				PortalUtil.getCurrentAndAncestorSiteGroupIds(
+					getGroupIds(), true);
+		}
+
+		return _referencedEntitiesGroupIds;
 	}
 
 	public String getRootPortletId() {
@@ -1060,6 +1077,7 @@ public class AssetPublisherDisplayContext {
 	private Long _portletDisplayDDMTemplateId;
 	private final PortletPreferences _portletPreferences;
 	private String _portletResource;
+	private long[] _referencedEntitiesGroupIds;
 	private final HttpServletRequest _request;
 	private String _rootPortletId;
 	private Integer _rssDelta;

--- a/portal-service/src/com/liferay/portal/util/Portal.java
+++ b/portal-service/src/com/liferay/portal/util/Portal.java
@@ -539,13 +539,29 @@ public interface Portal {
 	public long[] getCurrentAndAncestorSiteGroupIds(long groupId)
 		throws PortalException;
 
+	public long[] getCurrentAndAncestorSiteGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException;
+
 	public long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
+		throws PortalException;
+
+	public long[] getCurrentAndAncestorSiteGroupIds(
+			long[] groupId, boolean checkContentSharingWithChildrenEnabled)
 		throws PortalException;
 
 	public List<Group> getCurrentAndAncestorSiteGroups(long groupId)
 		throws PortalException;
 
+	public List<Group> getCurrentAndAncestorSiteGroups(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException;
+
 	public List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
+		throws PortalException;
+
+	public List<Group> getCurrentAndAncestorSiteGroups(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
 		throws PortalException;
 
 	public String getCurrentCompleteURL(HttpServletRequest request);

--- a/portal-service/src/com/liferay/portal/util/PortalUtil.java
+++ b/portal-service/src/com/liferay/portal/util/PortalUtil.java
@@ -713,10 +713,26 @@ public class PortalUtil {
 		return getPortal().getCurrentAndAncestorSiteGroupIds(groupId);
 	}
 
+	public static long[] getCurrentAndAncestorSiteGroupIds(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroupIds(
+			groupId, checkContentSharingWithChildrenEnabled);
+	}
+
 	public static long[] getCurrentAndAncestorSiteGroupIds(long[] groupIds)
 		throws PortalException {
 
 		return getPortal().getCurrentAndAncestorSiteGroupIds(groupIds);
+	}
+
+	public static long[] getCurrentAndAncestorSiteGroupIds(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroupIds(
+			groupIds, checkContentSharingWithChildrenEnabled);
 	}
 
 	public static List<Group> getCurrentAndAncestorSiteGroups(long groupId)
@@ -725,10 +741,26 @@ public class PortalUtil {
 		return getPortal().getCurrentAndAncestorSiteGroups(groupId);
 	}
 
+	public static List<Group> getCurrentAndAncestorSiteGroups(
+			long groupId, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroups(
+			groupId, checkContentSharingWithChildrenEnabled);
+	}
+
 	public static List<Group> getCurrentAndAncestorSiteGroups(long[] groupIds)
 		throws PortalException {
 
 		return getPortal().getCurrentAndAncestorSiteGroups(groupIds);
+	}
+
+	public static List<Group> getCurrentAndAncestorSiteGroups(
+			long[] groupIds, boolean checkContentSharingWithChildrenEnabled)
+		throws PortalException {
+
+		return getPortal().getCurrentAndAncestorSiteGroups(
+			groupIds, checkContentSharingWithChildrenEnabled);
 	}
 
 	public static String getCurrentCompleteURL(HttpServletRequest request) {

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
@@ -22,7 +22,8 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 String redirect = (String)request.getAttribute("configuration.jsp-redirect");
 String selectScope = (String)request.getAttribute("configuration.jsp-selectScope");
 String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle");
-long[] groupIds = AssetPublisherUtil.getGroupIds(portletPreferences, scopeGroupId, layout);
+
+long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDisplayContext.getGroupIds());
 %>
 
 <liferay-ui:tabs
@@ -114,7 +115,7 @@ long[] groupIds = AssetPublisherUtil.getGroupIds(portletPreferences, scopeGroupI
 					for (AssetRendererFactory assetRendererFactory : assetRendererFactories) {
 						ClassTypeReader classTypeReader = assetRendererFactory.getClassTypeReader();
 
-						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
+						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(groupIds, locale);
 
 						if (classTypes.isEmpty()) {
 							continue;
@@ -298,7 +299,7 @@ long[] groupIds = AssetPublisherUtil.getGroupIds(portletPreferences, scopeGroupI
 							String categoryIds = ParamUtil.getString(request, "queryCategoryIds" + queryLogicIndex, queryValues);
 
 							if (Validator.isNotNull(tagNames) || Validator.isNotNull(categoryIds) || (queryLogicIndexes.length == 1)) {
-								request.setAttribute("configuration.jsp-categorizableGroupIds", _getCategorizableGroupIds(assetPublisherDisplayContext.getGroupIds()));
+								request.setAttribute("configuration.jsp-categorizableGroupIds", _getCategorizableGroupIds(groupIds));
 								request.setAttribute("configuration.jsp-index", String.valueOf(index));
 								request.setAttribute("configuration.jsp-queryLogicIndex", String.valueOf(queryLogicIndex));
 
@@ -573,7 +574,7 @@ long[] groupIds = AssetPublisherUtil.getGroupIds(portletPreferences, scopeGroupI
 		<%
 		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
+		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(groupIds, locale);
 
 		if (assetAvailableClassTypes.isEmpty()) {
 			continue;

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
@@ -22,6 +22,7 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 String redirect = (String)request.getAttribute("configuration.jsp-redirect");
 String selectScope = (String)request.getAttribute("configuration.jsp-selectScope");
 String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle");
+long[] groupIds = AssetPublisherUtil.getGroupIds(portletPreferences, scopeGroupId, layout);
 %>
 
 <liferay-ui:tabs
@@ -113,7 +114,7 @@ String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle
 					for (AssetRendererFactory assetRendererFactory : assetRendererFactories) {
 						ClassTypeReader classTypeReader = assetRendererFactory.getClassTypeReader();
 
-						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(PortalUtil.getSharedContentSiteGroupIds(company.getCompanyId(), scopeGroupId, user.getUserId()), locale);
+						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
 
 						if (classTypes.isEmpty()) {
 							continue;
@@ -572,7 +573,7 @@ String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle
 		<%
 		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(PortalUtil.getSharedContentSiteGroupIds(company.getCompanyId(), scopeGroupId, user.getUserId()), locale);
+		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
 
 		if (assetAvailableClassTypes.isEmpty()) {
 			continue;

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_dynamic.jsp
@@ -22,8 +22,6 @@ PortletURL configurationRenderURL = (PortletURL)request.getAttribute("configurat
 String redirect = (String)request.getAttribute("configuration.jsp-redirect");
 String selectScope = (String)request.getAttribute("configuration.jsp-selectScope");
 String selectStyle = (String)request.getAttribute("configuration.jsp-selectStyle");
-
-long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDisplayContext.getGroupIds());
 %>
 
 <liferay-ui:tabs
@@ -115,7 +113,7 @@ long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDis
 					for (AssetRendererFactory assetRendererFactory : assetRendererFactories) {
 						ClassTypeReader classTypeReader = assetRendererFactory.getClassTypeReader();
 
-						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(groupIds, locale);
+						List<ClassType> classTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedEntitiesGroupIds(), locale);
 
 						if (classTypes.isEmpty()) {
 							continue;
@@ -299,7 +297,7 @@ long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDis
 							String categoryIds = ParamUtil.getString(request, "queryCategoryIds" + queryLogicIndex, queryValues);
 
 							if (Validator.isNotNull(tagNames) || Validator.isNotNull(categoryIds) || (queryLogicIndexes.length == 1)) {
-								request.setAttribute("configuration.jsp-categorizableGroupIds", _getCategorizableGroupIds(groupIds));
+								request.setAttribute("configuration.jsp-categorizableGroupIds", assetPublisherDisplayContext.getReferencedEntitiesGroupIds());
 								request.setAttribute("configuration.jsp-index", String.valueOf(index));
 								request.setAttribute("configuration.jsp-queryLogicIndex", String.valueOf(queryLogicIndex));
 
@@ -574,7 +572,7 @@ long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDis
 		<%
 		ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(groupIds, locale);
+		List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(assetPublisherDisplayContext.getReferencedEntitiesGroupIds(), locale);
 
 		if (assetAvailableClassTypes.isEmpty()) {
 			continue;
@@ -767,22 +765,6 @@ long[] groupIds = PortalUtil.getCurrentAndAncestorSiteGroupIds(assetPublisherDis
 </aui:script>
 
 <%!
-private long[] _getCategorizableGroupIds(long[] groupIds) throws Exception {
-	Set<Long> categorizableGroupIds = new HashSet<Long>(groupIds.length);
-
-	for (long groupId : groupIds) {
-		Group group = GroupLocalServiceUtil.getGroup(groupId);
-
-		if (group.isLayout()) {
-			groupId = group.getParentGroupId();
-		}
-
-		categorizableGroupIds.add(groupId);
-	}
-
-	return ArrayUtil.toLongArray(categorizableGroupIds);
-}
-
 private String _getSectionId(String name) {
 	return TextFormatter.format(name, TextFormatter.M);
 }

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
@@ -160,7 +160,7 @@ String eventName = "_" + HtmlUtil.escapeJS(assetPublisherDisplayContext.getPortl
 								else {
 									ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-									List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(PortalUtil.getSharedContentSiteGroupIds(company.getCompanyId(), scopeGroupId, user.getUserId()), locale);
+									List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
 
 									for (ClassType assetAvailableClassType : assetAvailableClassTypes) {
 										assetBrowserURL.setParameter("subtypeSelectionId", String.valueOf(assetAvailableClassType.getClassTypeId()));

--- a/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/configuration_manual.jsp
@@ -160,7 +160,7 @@ String eventName = "_" + HtmlUtil.escapeJS(assetPublisherDisplayContext.getPortl
 								else {
 									ClassTypeReader classTypeReader = curRendererFactory.getClassTypeReader();
 
-									List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(ArrayUtil.unique(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupIds)), locale);
+									List<ClassType> assetAvailableClassTypes = classTypeReader.getAvailableClassTypes(PortalUtil.getCurrentAndAncestorSiteGroupIds(groupId), locale);
 
 									for (ClassType assetAvailableClassType : assetAvailableClassTypes) {
 										assetBrowserURL.setParameter("subtypeSelectionId", String.valueOf(assetAvailableClassType.getClassTypeId()));


### PR DESCRIPTION
Hey @jonathanmccann 

we are moving away all the logic from the JSPs into the DisplayContext object, so I tried to move this logic there too.

Doing so, I realized that we were also including those sites that don't share their content which was wrong, so I added the parameter to the API to filter by those (I tend to think the default should be true anyway....)

Then I realized that this method already handles that we include the parent site for layout scopes.

Can you please verify if these changes make sense to you and test that they cover the use case from your customer?

thanks!