### PR TITLE
LPS-53444 Unable to add message board attachment via JSON

### DIFF
--- a/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/http/MBMessageServiceHttp.java
@@ -205,6 +205,42 @@ public class MBMessageServiceHttp {
 	}
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		HttpPrincipal httpPrincipal, long categoryId, java.lang.String subject,
+		java.lang.String body, java.lang.String fileName, java.io.File file,
+		boolean indexingEnabled,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
+					"addMessage", _addMessageParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					categoryId, subject, body, fileName, file, indexingEnabled,
+					serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.messageboards.model.MBMessage)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		HttpPrincipal httpPrincipal, long parentMessageId,
 		java.lang.String subject, java.lang.String body,
 		java.lang.String format,
@@ -214,7 +250,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"addMessage", _addMessageParameterTypes4);
+					"addMessage", _addMessageParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					parentMessageId, subject, body, format, inputStreamOVPs,
@@ -242,6 +278,35 @@ public class MBMessageServiceHttp {
 		}
 	}
 
+	public static void addMessageAttachment(HttpPrincipal httpPrincipal,
+		long messageId, java.lang.String fileName, java.io.File file,
+		boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		try {
+			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
+					"addMessageAttachment", _addMessageAttachmentParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					messageId, fileName, file, indexingEnabled);
+
+			try {
+				TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static void deleteDiscussionMessage(HttpPrincipal httpPrincipal,
 		long groupId, java.lang.String className, long classPK,
 		java.lang.String permissionClassName, long permissionClassPK,
@@ -250,7 +315,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"deleteDiscussionMessage",
-					_deleteDiscussionMessageParameterTypes5);
+					_deleteDiscussionMessageParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -278,7 +343,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"deleteMessage", _deleteMessageParameterTypes6);
+					"deleteMessage", _deleteMessageParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -306,7 +371,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"deleteMessageAttachments",
-					_deleteMessageAttachmentsParameterTypes7);
+					_deleteMessageAttachmentsParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -334,7 +399,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getCategoryMessages", _getCategoryMessagesParameterTypes8);
+					"getCategoryMessages", _getCategoryMessagesParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, start, end);
@@ -366,7 +431,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCategoryMessagesCount",
-					_getCategoryMessagesCountParameterTypes9);
+					_getCategoryMessagesCountParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status);
@@ -399,7 +464,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCategoryMessagesRSS",
-					_getCategoryMessagesRSSParameterTypes10);
+					_getCategoryMessagesRSSParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, status, max, type, version, displayStyle,
@@ -436,7 +501,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getCompanyMessagesRSS",
-					_getCompanyMessagesRSSParameterTypes11);
+					_getCompanyMessagesRSSParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					companyId, status, max, type, version, displayStyle,
@@ -469,7 +534,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getGroupMessagesCount",
-					_getGroupMessagesCountParameterTypes12);
+					_getGroupMessagesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status);
@@ -500,7 +565,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes13);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					status, max, type, version, displayStyle, feedURL,
@@ -537,7 +602,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes14);
+					"getGroupMessagesRSS", _getGroupMessagesRSSParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					userId, status, max, type, version, displayStyle, feedURL,
@@ -570,7 +635,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getMessage", _getMessageParameterTypes15);
+					"getMessage", _getMessageParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -602,7 +667,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getMessageDisplay", _getMessageDisplayParameterTypes16);
+					"getMessageDisplay", _getMessageDisplayParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, status, threadView, includePrevAndNext);
@@ -634,7 +699,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadAnswersCount",
-					_getThreadAnswersCountParameterTypes17);
+					_getThreadAnswersCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId);
@@ -662,7 +727,7 @@ public class MBMessageServiceHttp {
 		long threadId, int status, int start, int end) {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"getThreadMessages", _getThreadMessagesParameterTypes18);
+					"getThreadMessages", _getThreadMessagesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status, start, end);
@@ -690,7 +755,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadMessagesCount",
-					_getThreadMessagesCountParameterTypes19);
+					_getThreadMessagesCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					categoryId, threadId, status);
@@ -722,7 +787,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"getThreadMessagesRSS",
-					_getThreadMessagesRSSParameterTypes20);
+					_getThreadMessagesRSSParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					threadId, status, max, type, version, displayStyle,
@@ -756,7 +821,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"restoreMessageAttachmentFromTrash",
-					_restoreMessageAttachmentFromTrashParameterTypes21);
+					_restoreMessageAttachmentFromTrashParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, fileName);
@@ -784,7 +849,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"subscribeMessage", _subscribeMessageParameterTypes22);
+					"subscribeMessage", _subscribeMessageParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -811,7 +876,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"unsubscribeMessage", _unsubscribeMessageParameterTypes23);
+					"unsubscribeMessage", _unsubscribeMessageParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, messageId);
 
@@ -838,7 +903,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"updateAnswer", _updateAnswerParameterTypes24);
+					"updateAnswer", _updateAnswerParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, answer, cascade);
@@ -871,7 +936,7 @@ public class MBMessageServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
 					"updateDiscussionMessage",
-					_updateDiscussionMessageParameterTypes25);
+					_updateDiscussionMessageParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					className, classPK, permissionClassName, permissionClassPK,
@@ -909,7 +974,7 @@ public class MBMessageServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(MBMessageServiceUtil.class,
-					"updateMessage", _updateMessageParameterTypes26);
+					"updateMessage", _updateMessageParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					messageId, subject, body, inputStreamOVPs, existingFiles,
@@ -963,87 +1028,96 @@ public class MBMessageServiceHttp {
 		};
 	private static final Class<?>[] _addMessageParameterTypes4 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
+			java.lang.String.class, java.io.File.class, boolean.class,
+			com.liferay.portal.service.ServiceContext.class
+		};
+	private static final Class<?>[] _addMessageParameterTypes5 = new Class[] {
+			long.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, java.util.List.class, boolean.class,
 			double.class, boolean.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteDiscussionMessageParameterTypes5 = new Class[] {
+	private static final Class<?>[] _addMessageAttachmentParameterTypes6 = new Class[] {
+			long.class, java.lang.String.class, java.io.File.class,
+			boolean.class
+		};
+	private static final Class<?>[] _deleteDiscussionMessageParameterTypes7 = new Class[] {
 			long.class, java.lang.String.class, long.class,
 			java.lang.String.class, long.class, long.class, long.class
 		};
-	private static final Class<?>[] _deleteMessageParameterTypes6 = new Class[] {
+	private static final Class<?>[] _deleteMessageParameterTypes8 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes7 = new Class[] {
+	private static final Class<?>[] _deleteMessageAttachmentsParameterTypes9 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getCategoryMessagesParameterTypes8 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesParameterTypes10 = new Class[] {
 			long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesCountParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesCountParameterTypes11 = new Class[] {
 			long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getCategoryMessagesRSSParameterTypes12 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getCompanyMessagesRSSParameterTypes13 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesCountParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesCountParameterTypes14 = new Class[] {
 			long.class, int.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes15 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupMessagesRSSParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupMessagesRSSParameterTypes16 = new Class[] {
 			long.class, long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getMessageParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getMessageParameterTypes17 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getMessageDisplayParameterTypes16 = new Class[] {
+	private static final Class<?>[] _getMessageDisplayParameterTypes18 = new Class[] {
 			long.class, int.class, java.lang.String.class, boolean.class
 		};
-	private static final Class<?>[] _getThreadAnswersCountParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getThreadAnswersCountParameterTypes19 = new Class[] {
 			long.class, long.class, long.class
 		};
-	private static final Class<?>[] _getThreadMessagesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesParameterTypes20 = new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesCountParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesCountParameterTypes21 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getThreadMessagesRSSParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getThreadMessagesRSSParameterTypes22 = new Class[] {
 			long.class, int.class, int.class, java.lang.String.class,
 			double.class, java.lang.String.class, java.lang.String.class,
 			java.lang.String.class, com.liferay.portal.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _restoreMessageAttachmentFromTrashParameterTypes21 =
+	private static final Class<?>[] _restoreMessageAttachmentFromTrashParameterTypes23 =
 		new Class[] { long.class, java.lang.String.class };
-	private static final Class<?>[] _subscribeMessageParameterTypes22 = new Class[] {
+	private static final Class<?>[] _subscribeMessageParameterTypes24 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _unsubscribeMessageParameterTypes23 = new Class[] {
+	private static final Class<?>[] _unsubscribeMessageParameterTypes25 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateAnswerParameterTypes24 = new Class[] {
+	private static final Class<?>[] _updateAnswerParameterTypes26 = new Class[] {
 			long.class, boolean.class, boolean.class
 		};
-	private static final Class<?>[] _updateDiscussionMessageParameterTypes25 = new Class[] {
+	private static final Class<?>[] _updateDiscussionMessageParameterTypes27 = new Class[] {
 			java.lang.String.class, long.class, java.lang.String.class,
 			long.class, long.class, long.class, java.lang.String.class,
 			java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateMessageParameterTypes26 = new Class[] {
+	private static final Class<?>[] _updateMessageParameterTypes28 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			java.util.List.class, java.util.List.class, double.class,
 			boolean.class, com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/messageboards/service/impl/MBMessageLocalServiceImpl.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -101,6 +102,7 @@ import com.liferay.portlet.social.model.SocialActivityConstants;
 import com.liferay.portlet.trash.util.TrashUtil;
 import com.liferay.util.SerializableUtil;
 
+import java.io.File;
 import java.io.InputStream;
 import java.io.Serializable;
 
@@ -467,6 +469,23 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		return addMessage(
 			userId, userName, groupId, categoryId, subject, body,
 			serviceContext);
+	}
+
+	public void addMessageAttachment(
+			long messageId, String fileName, File file, boolean indexingEnabled)
+		throws PortalException {
+
+		MBMessage message = mbMessagePersistence.findByPrimaryKey(messageId);
+
+		Folder folder = message.addAttachmentsFolder();
+
+		String mimeType = MimeTypesUtil.getContentType(file);
+
+		PortletFileRepositoryUtil.addPortletFileEntry(
+			message.getGroupId(), message.getUserId(),
+			MBMessage.class.getName(), message.getMessageId(),
+			PortletKeys.MESSAGE_BOARDS, folder.getFolderId(), file, fileName,
+			mimeType, indexingEnabled);
 	}
 
 	@Override
@@ -1931,6 +1950,13 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 				"message_boards/view_message/" + message.getMessageId();
 		}
 		else {
+			if (serviceContext.getThemeDisplay() == null) {
+				return PortalUtil.getControlPanelFullURL(
+						serviceContext.getScopeGroupId(),
+						PortletKeys.MESSAGE_BOARDS,
+						null);
+			}
+
 			long controlPanelPlid = PortalUtil.getControlPanelPlid(
 				serviceContext.getCompanyId());
 

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalService.java
@@ -105,6 +105,10 @@ public interface MBMessageLocalService extends BaseLocalService,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
+	public void addMessageAttachment(long messageId, java.lang.String fileName,
+		java.io.File file, boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
 	public void addMessageResources(
 		com.liferay.portlet.messageboards.model.MBMessage message,
 		boolean addGroupPermissions, boolean addGuestPermissions)

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceUtil.java
@@ -124,6 +124,13 @@ public class MBMessageLocalServiceUtil {
 			priority, allowPingbacks, serviceContext);
 	}
 
+	public static void addMessageAttachment(long messageId,
+		java.lang.String fileName, java.io.File file, boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.addMessageAttachment(messageId, fileName, file, indexingEnabled);
+	}
+
 	public static void addMessageResources(
 		com.liferay.portlet.messageboards.model.MBMessage message,
 		boolean addGroupPermissions, boolean addGuestPermissions)

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageLocalServiceWrapper.java
@@ -120,6 +120,14 @@ public class MBMessageLocalServiceWrapper implements MBMessageLocalService,
 	}
 
 	@Override
+	public void addMessageAttachment(long messageId, java.lang.String fileName,
+		java.io.File file, boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_mbMessageLocalService.addMessageAttachment(messageId, fileName, file,
+			indexingEnabled);
+	}
+
+	@Override
 	public void addMessageResources(
 		com.liferay.portlet.messageboards.model.MBMessage message,
 		boolean addGroupPermissions, boolean addGuestPermissions)

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageService.java
@@ -57,6 +57,12 @@ public interface MBMessageService extends BaseService {
 
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long categoryId, java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file, boolean indexingEnabled,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long categoryId, java.lang.String subject, java.lang.String body,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
@@ -89,6 +95,10 @@ public interface MBMessageService extends BaseService {
 		java.util.List<com.liferay.portal.kernel.util.ObjectValuePair<java.lang.String, java.io.InputStream>> inputStreamOVPs,
 		boolean anonymous, double priority, boolean allowPingbacks,
 		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public void addMessageAttachment(long messageId, java.lang.String fileName,
+		java.io.File file, boolean indexingEnabled)
 		throws com.liferay.portal.kernel.exception.PortalException;
 
 	public void deleteDiscussionMessage(long groupId,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceUtil.java
@@ -55,6 +55,16 @@ public class MBMessageServiceUtil {
 
 	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long categoryId, java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file, boolean indexingEnabled,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService()
+				   .addMessage(categoryId, subject, body, fileName, file,
+			indexingEnabled, serviceContext);
+	}
+
+	public static com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long categoryId, java.lang.String subject, java.lang.String body,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return getService().addMessage(categoryId, subject, body, serviceContext);
@@ -102,6 +112,13 @@ public class MBMessageServiceUtil {
 		return getService()
 				   .addMessage(parentMessageId, subject, body, format,
 			inputStreamOVPs, anonymous, priority, allowPingbacks, serviceContext);
+	}
+
+	public static void addMessageAttachment(long messageId,
+		java.lang.String fileName, java.io.File file, boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.addMessageAttachment(messageId, fileName, file, indexingEnabled);
 	}
 
 	public static void deleteDiscussionMessage(long groupId,

--- a/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/messageboards/service/MBMessageServiceWrapper.java
@@ -48,6 +48,16 @@ public class MBMessageServiceWrapper implements MBMessageService,
 	@Override
 	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
 		long categoryId, java.lang.String subject, java.lang.String body,
+		java.lang.String fileName, java.io.File file, boolean indexingEnabled,
+		com.liferay.portal.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _mbMessageService.addMessage(categoryId, subject, body,
+			fileName, file, indexingEnabled, serviceContext);
+	}
+
+	@Override
+	public com.liferay.portlet.messageboards.model.MBMessage addMessage(
+		long categoryId, java.lang.String subject, java.lang.String body,
 		com.liferay.portal.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		return _mbMessageService.addMessage(categoryId, subject, body,
@@ -98,6 +108,14 @@ public class MBMessageServiceWrapper implements MBMessageService,
 		return _mbMessageService.addMessage(parentMessageId, subject, body,
 			format, inputStreamOVPs, anonymous, priority, allowPingbacks,
 			serviceContext);
+	}
+
+	@Override
+	public void addMessageAttachment(long messageId, java.lang.String fileName,
+		java.io.File file, boolean indexingEnabled)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_mbMessageService.addMessageAttachment(messageId, fileName, file,
+			indexingEnabled);
 	}
 
 	@Override

--- a/portal-web/docroot/html/js/liferay/liferay.js
+++ b/portal-web/docroot/html/js/liferay/liferay.js
@@ -133,8 +133,15 @@ Liferay = window.Liferay || {};
 				var form = args[1];
 
 				if (isNode(form)) {
+
 					ioConfig.form = form;
+
+					if (ioConfig.form.enctype == 'multipart/form-data') {
+						ioConfig.contentType = false;
+						ioConfig.processData = false;
+					}
 				}
+
 			},
 
 			parseStringPayload: function(args) {
@@ -160,24 +167,37 @@ Liferay = window.Liferay || {};
 	Service.invoke = function(payload, ioConfig) {
 		var instance = this;
 
+		var cmd = JSON.stringify(payload);
+		var p_auth = Liferay.authToken;
+
 		_.defaults(
 			ioConfig,
 			{
-				data: {
-					cmd: JSON.stringify(payload),
-					p_auth: Liferay.authToken
-				},
+				data: {},
 				dataType: 'JSON'
 			}
 		);
 
 		if (ioConfig.form) {
-			_.forEach(
-				$(ioConfig.form).serializeArray(),
-				function(item, index) {
-					ioConfig.data[item.name] = item.value;
-				}
-			);
+			if (ioConfig.form.enctype == 'multipart/form-data') {
+				ioConfig.data = new FormData(ioConfig.form);
+
+				ioConfig.data.append('cmd', cmd);
+				ioConfig.data.append('p_auth', p_auth);
+			}
+			else {
+				ioConfig.data = {
+					cmd: cmd,
+					p_auth: p_auth
+				};
+
+				_.forEach(
+					$(ioConfig.form).serializeArray(),
+					function(item, index) {
+						ioConfig.data[item.name] = item.value;
+					}
+				);
+			}
 
 			delete ioConfig.form;
 		}


### PR DESCRIPTION
Hi Jonathan,
To address concerns from the last pull request:
1. How do other asset APIs handle not having a Theme Display to craft the Workflow URL to notify subscribers?

Other methods in the JSON API that call a similar method to the startWorkflowInstance include /blogsentry/add-entry and /journalarticle/add-article.
I found that /blogsentry/add-entry is broken because ImageSelector is not converted to a value properly:
"Conversion failed: com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector"
However, looking at BlogsEntryLocalServiceImpl, the startWorkflowInstance method does check for a null ThemeDisplay. If Theme Display is null, then the workflow URL is blank.
/journalarticle/add-article
It uses PortalUtil.getControlPanelFullURL(serviceContext.getScopeGroupId(), PortletKeys.JOURNAL, null)) as its workflow URL in all cases, even when Theme Display is null. This works in MBMessageService, so I have used it here.

2. The Javascript changes seem to break all other APIs that don't have a file upload.

The logic is changed so that forms with file uploads do not interfere with how other form types are currently handled correctly.
Tested the changes using methods:
/journalarticle/add-article
/dlapp/add-file-entry
/user/get-user-by-email-address
/dlfolder/add-folder