### PR TITLE
LPS-51545-master:A validation message should be displayed, if uploaded file size exceeds defined size.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
+++ b/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
@@ -91,7 +91,6 @@ public class UploadImageAction extends PortletAction {
 		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
 
 		long maxFileSize = ParamUtil.getLong(actionRequest, "maxFileSize");
-		boolean isFileSizeValid=false;
 
 		try {
 			UploadException uploadException =
@@ -128,7 +127,7 @@ public class UploadImageAction extends PortletAction {
 					if (fileEntry.getSize() > maxFileSize) {
 						throw new FileSizeException();
 					}else {
-						isFileSizeValid=validateImageSize(actionRequest);
+						validateImageSize(actionRequest,fileEntry);
 					}
 				}
 
@@ -139,7 +138,7 @@ public class UploadImageAction extends PortletAction {
 		}
 		catch (Exception e) {
 			handleUploadException(
-				actionRequest, actionResponse, cmd, maxFileSize, e,isFileSizeValid);
+				actionRequest, actionResponse, cmd, maxFileSize, e);
 		}
 	}
 
@@ -250,7 +249,7 @@ public class UploadImageAction extends PortletAction {
 
 	protected void handleUploadException(
 			ActionRequest actionRequest, ActionResponse actionResponse,
-			String cmd, long maxFileSize, Exception e,boolean isFileSizeValid)
+			String cmd, long maxFileSize, Exception e)
 		throws Exception {
 
 		if (e instanceof PrincipalException) {
@@ -317,9 +316,6 @@ public class UploadImageAction extends PortletAction {
 				writeJSON(actionRequest, actionResponse, jsonObject);
 			}
 			else {
-				if (!isFileSizeValid) {
-					SessionErrors.add(actionRequest, "dlFileMaxSize", isFileSizeValid);
-				}
 				SessionErrors.add(actionRequest, e.getClass(), e);
 			}
 		}
@@ -424,40 +420,23 @@ public class UploadImageAction extends PortletAction {
 
 		PortletResponseUtil.write(mimeResponse, bytes);
 	}
-
-	protected boolean validateImageSize(ActionRequest actionRequest)
+	
+	protected void validateImageSize(ActionRequest actionRequest,FileEntry fileEntry)
 			throws Exception {
-
-			FileEntry tempFileEntry = null;
-
-			InputStream tempImageStream = null;
 
 			String fileName = ParamUtil.getString(actionRequest, "tempImageFileName");
 
 			try {
-				tempFileEntry = getTempImageFileEntry(actionRequest);
-
-				tempImageStream = tempFileEntry.getContentStream();
-
-				ImageBag imageBag = ImageToolUtil.read(tempImageStream);
-
-				RenderedImage renderedImage = imageBag.getRenderedImage();
-
-				byte[] bytes = ImageToolUtil.getBytes(
-					renderedImage, imageBag.getType());
+				byte[] bytes = FileUtil.getBytes(fileEntry.getContentStream());
 
 				DLStoreUtil.validate(fileName, true, bytes);
 				
-				return true;
 			}
 			catch (NoSuchFileEntryException nsfee) {
 				throw new UploadException(nsfee);
 			}
 			catch (NoSuchRepositoryException nsre) {
 				throw new UploadException(nsre);
-			}
-			finally {
-				StreamUtil.cleanUp(tempImageStream);
 			}
 		}
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
+++ b/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
@@ -54,6 +54,7 @@ import com.liferay.portlet.documentlibrary.FileSizeException;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
 import com.liferay.portlet.documentlibrary.antivirus.AntivirusScannerException;
+import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
 
 import java.awt.image.RenderedImage;
 
@@ -90,6 +91,7 @@ public class UploadImageAction extends PortletAction {
 		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
 
 		long maxFileSize = ParamUtil.getLong(actionRequest, "maxFileSize");
+		boolean isFileSizeValid=false;
 
 		try {
 			UploadException uploadException =
@@ -125,6 +127,8 @@ public class UploadImageAction extends PortletAction {
 
 					if (fileEntry.getSize() > maxFileSize) {
 						throw new FileSizeException();
+					}else {
+						isFileSizeValid=validateImageSize(actionRequest);
 					}
 				}
 
@@ -135,7 +139,7 @@ public class UploadImageAction extends PortletAction {
 		}
 		catch (Exception e) {
 			handleUploadException(
-				actionRequest, actionResponse, cmd, maxFileSize, e);
+				actionRequest, actionResponse, cmd, maxFileSize, e,isFileSizeValid);
 		}
 	}
 
@@ -246,7 +250,7 @@ public class UploadImageAction extends PortletAction {
 
 	protected void handleUploadException(
 			ActionRequest actionRequest, ActionResponse actionResponse,
-			String cmd, long maxFileSize, Exception e)
+			String cmd, long maxFileSize, Exception e,boolean isFileSizeValid)
 		throws Exception {
 
 		if (e instanceof PrincipalException) {
@@ -313,6 +317,9 @@ public class UploadImageAction extends PortletAction {
 				writeJSON(actionRequest, actionResponse, jsonObject);
 			}
 			else {
+				if (!isFileSizeValid) {
+					SessionErrors.add(actionRequest, "dlFileMaxSize", isFileSizeValid);
+				}
 				SessionErrors.add(actionRequest, e.getClass(), e);
 			}
 		}
@@ -418,6 +425,41 @@ public class UploadImageAction extends PortletAction {
 		PortletResponseUtil.write(mimeResponse, bytes);
 	}
 
+	protected boolean validateImageSize(ActionRequest actionRequest)
+			throws Exception {
+
+			FileEntry tempFileEntry = null;
+
+			InputStream tempImageStream = null;
+
+			String fileName = ParamUtil.getString(actionRequest, "tempImageFileName");
+
+			try {
+				tempFileEntry = getTempImageFileEntry(actionRequest);
+
+				tempImageStream = tempFileEntry.getContentStream();
+
+				ImageBag imageBag = ImageToolUtil.read(tempImageStream);
+
+				RenderedImage renderedImage = imageBag.getRenderedImage();
+
+				byte[] bytes = ImageToolUtil.getBytes(
+					renderedImage, imageBag.getType());
+
+				DLStoreUtil.validate(fileName, true, bytes);
+				
+				return true;
+			}
+			catch (NoSuchFileEntryException nsfee) {
+				throw new UploadException(nsfee);
+			}
+			catch (NoSuchRepositoryException nsre) {
+				throw new UploadException(nsre);
+			}
+			finally {
+				StreamUtil.cleanUp(tempImageStream);
+			}
+		}
 	private static final Log _log = LogFactoryUtil.getLog(
 		UploadImageAction.class);
 

--- a/portal-web/docroot/html/portlet/image_uploader/view.jsp
+++ b/portal-web/docroot/html/portlet/image_uploader/view.jsp
@@ -19,7 +19,7 @@
 <%
 String currentImageURL = ParamUtil.getString(request, "currentLogoURL");
 long maxFileSize = ParamUtil.getLong(request, "maxFileSize");
-long fileMaxSize=0;
+long fileMaxSize = 0;
 String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 %>
@@ -65,16 +65,13 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= FileSizeException.class %>">
-			<% if (SessionErrors.contains(renderRequest, "dlFileMaxSize")) {
-				fileMaxSize = PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE);
+			<% fileMaxSize = PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE);
 
-				if (fileMaxSize == 0) {
-					fileMaxSize = PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE);
-				}
-			}else {
-				fileMaxSize = maxFileSize;
+			if (fileMaxSize == 0) {
+				fileMaxSize = PrefsPropsUtil.getLong(
+					PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE);
 			} %>
-			<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize(fileMaxSize, locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
+				<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize((maxFileSize<fileMaxSize ? maxFileSize : fileMaxSize), locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= NoSuchFileException.class %>" message="an-unexpected-error-occurred-while-uploading-your-file" />

--- a/portal-web/docroot/html/portlet/image_uploader/view.jsp
+++ b/portal-web/docroot/html/portlet/image_uploader/view.jsp
@@ -19,6 +19,7 @@
 <%
 String currentImageURL = ParamUtil.getString(request, "currentLogoURL");
 long maxFileSize = ParamUtil.getLong(request, "maxFileSize");
+long fileMaxSize=0;
 String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 %>
@@ -64,7 +65,16 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= FileSizeException.class %>">
-				<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize(maxFileSize, locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
+			<% if (SessionErrors.contains(renderRequest, "dlFileMaxSize")) {
+				fileMaxSize = PrefsPropsUtil.getLong(PropsKeys.DL_FILE_MAX_SIZE);
+
+				if (fileMaxSize == 0) {
+					fileMaxSize = PrefsPropsUtil.getLong(PropsKeys.UPLOAD_SERVLET_REQUEST_IMPL_MAX_SIZE);
+				}
+			}else {
+				fileMaxSize = maxFileSize;
+			} %>
+			<liferay-ui:message arguments="<%= TextFormatter.formatStorageSize(fileMaxSize, locale) %>" key="please-enter-a-file-with-a-valid-file-size-no-larger-than-x" translateArguments="<%= false %>" />
 			</liferay-ui:error>
 
 			<liferay-ui:error exception="<%= NoSuchFileException.class %>" message="an-unexpected-error-occurred-while-uploading-your-file" />


### PR DESCRIPTION
While uploading the image (user portrait) it first crops(scale) the image and validates this cropped(scaled) image with the value defined in dl.file.max.size . So it throws the exception when we specified the less size in dl.file.max.size.
In this situation the validation message should contain the value of dl.file.max.size.

As an implementation it will validate the size(dl.file.max.size) with DLStoreUtil and will show the minimum threshold value as validation message. 