### PR TITLE
LPS 53249 : Recent navigation should show the recently uploaded, edited documents.

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -578,6 +578,8 @@ public class PropsValues {
 
 	public static final long DL_FILE_MAX_SIZE = GetterUtil.getLong(PropsUtil.get(PropsKeys.DL_FILE_MAX_SIZE));
 
+	public static final int DL_RECENT_FILE_MAX_DISPLAY_ITEMS = GetterUtil.getInteger(PropsUtil.get(PropsKeys.DL_RECENT_FILE_MAX_DISPLAY_ITEMS));
+	
 	public static final boolean DL_FILE_RANK_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.DL_FILE_RANK_ENABLED));
 
 	public static final int DL_FILE_RANK_MAX_SIZE = GetterUtil.getInteger(PropsUtil.get(PropsKeys.DL_FILE_RANK_MAX_SIZE));

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/DLImpl.java
@@ -639,6 +639,17 @@ public class DLImpl implements DL {
 	}
 
 	@Override
+	public int getEndLimit(int end) {
+		int maxDisplayItems = PropsValues.DL_RECENT_FILE_MAX_DISPLAY_ITEMS;
+
+		if (end > maxDisplayItems) {
+			return maxDisplayItems;
+		}
+
+		return end;
+	}
+
+	@Override
 	public List<Object> getEntries(Hits hits) {
 		List<Object> entries = new ArrayList<>();
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -9649,6 +9649,13 @@
     #dl.file.max.size=3072000
 
     #
+    # Configure maximum number of items to display on the recent navigation in
+    # document and media portlet. A value of 0 will show all the records available.
+    #
+    dl.recent.file.max.display.items=5
+
+
+    #
     # A file extension of * will permit all file extensions.
     #
     dl.file.extensions=*

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -755,6 +755,8 @@ public interface PropsKeys {
 
 	public static final String DL_RATINGS_ENABLED = "dl.ratings.enabled";
 
+	public static final String DL_RECENT_FILE_MAX_DISPLAY_ITEMS = "dl.recent.file.max.display.items";
+
 	public static final String DL_RELATED_ASSETS_ENABLED = "dl.related.assets.enabled";
 
 	public static final String DL_REPOSITORY_CMIS_DELETE_DEPTH = "dl.repository.cmis.delete.depth";

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/DL.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/DL.java
@@ -129,6 +129,8 @@ public interface DL {
 		PortletRequest portletRequest, String emailFromAddress,
 		String emailFromName);
 
+	public int getEndLimit(int end);
+
 	public List<Object> getEntries(Hits hits);
 
 	public List<FileEntry> getFileEntries(Hits hits);

--- a/portal-service/src/com/liferay/portlet/documentlibrary/util/DLUtil.java
+++ b/portal-service/src/com/liferay/portlet/documentlibrary/util/DLUtil.java
@@ -183,6 +183,10 @@ public class DLUtil {
 			request, emailFromAddress, emailFromName);
 	}
 
+	public static int getEndLimit(int end) {
+		return getDL().getEndLimit(end);
+	}
+
 	public static List<Object> getEntries(Hits hits) {
 		return getDL().getEntries(hits);
 	}

--- a/portal-web/docroot/html/portlet/document_library/toolbar.jsp
+++ b/portal-web/docroot/html/portlet/document_library/toolbar.jsp
@@ -26,6 +26,8 @@ long folderId = GetterUtil.getLong((String)request.getAttribute("view.jsp-folder
 long repositoryId = GetterUtil.getLong((String)request.getAttribute("view.jsp-repositoryId"));
 
 String keywords = ParamUtil.getString(request, "keywords");
+
+String navigation = ParamUtil.getString(request, "navigation", "home");
 %>
 
 <aui:nav-bar>
@@ -84,7 +86,9 @@ String keywords = ParamUtil.getString(request, "keywords");
 
 		<liferay-util:include page="/html/portlet/document_library/add_button.jsp" />
 
-		<liferay-util:include page="/html/portlet/document_library/sort_button.jsp" />
+		<c:if test='<%= !navigation.equals("recent") %>'>
+			<liferay-util:include page="/html/portlet/document_library/sort_button.jsp" />
+		</c:if>
 
 		<c:if test="<%= !user.isDefaultUser() %>">
 			<aui:nav-item dropdown="<%= true %>" label="manage">

--- a/portal-web/docroot/html/portlet/document_library/view_entries.jsp
+++ b/portal-web/docroot/html/portlet/document_library/view_entries.jsp
@@ -55,6 +55,7 @@ portletURL.setParameter("struts_action", "/document_library/view");
 portletURL.setParameter("curFolder", currentFolder);
 portletURL.setParameter("deltaFolder", deltaFolder);
 portletURL.setParameter("folderId", String.valueOf(folderId));
+portletURL.setParameter("navigation", navigation);
 
 SearchContainer dlSearchContainer = new SearchContainer(liferayPortletRequest, null, null, "curEntry", SearchContainer.DEFAULT_DELTA, portletURL, null, null);
 
@@ -68,7 +69,6 @@ String orderByCol = GetterUtil.getString((String)request.getAttribute("view.jsp-
 String orderByType = GetterUtil.getString((String)request.getAttribute("view.jsp-orderByType"));
 
 OrderByComparator<?> orderByComparator = DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType);
-
 dlSearchContainer.setOrderByCol(orderByCol);
 dlSearchContainer.setOrderByComparator(orderByComparator);
 dlSearchContainer.setOrderByType(orderByType);
@@ -158,7 +158,30 @@ else {
 			results = DLAppServiceUtil.getFoldersAndFileEntriesAndFileShortcuts(repositoryId, folderId, status, false, dlSearchContainer.getStart(), dlSearchContainer.getEnd(), dlSearchContainer.getOrderByComparator());
 		}
 	}
-	else if (navigation.equals("mine") || navigation.equals("recent")) {
+	else if (navigation.equals("recent")) {
+		long groupFileEntriesUserId = 0;
+
+		total=PropsValues.DL_RECENT_FILE_MAX_DISPLAY_ITEMS;
+
+		int end = dlSearchContainer.getEnd();
+
+		if (total <= 0) {
+			total = DLAppServiceUtil.getGroupFileEntriesCount(repositoryId, groupFileEntriesUserId, folderId, null, status);
+		}else {
+			end= DLUtil.getEndLimit(end);
+		}
+
+		dlSearchContainer.setTotal(total);
+
+		orderByCol="modifiedDate";
+		orderByType="desc";
+		orderByComparator = DLUtil.getRepositoryModelOrderByComparator(orderByCol, orderByType);
+
+		dlSearchContainer.setOrderByComparator(orderByComparator);
+
+		results = DLAppServiceUtil.getGroupFileEntries(repositoryId, groupFileEntriesUserId, folderId, null, status, dlSearchContainer.getStart(), end, dlSearchContainer.getOrderByComparator());
+	}
+	else if (navigation.equals("mine")) {
 		long groupFileEntriesUserId = 0;
 
 		if (navigation.equals("mine") && themeDisplay.isSignedIn()) {


### PR DESCRIPTION
Hi,

This PR includes:
1) Showing the document which is recently created/uploaded/modified in recent navigation of DL portlet. 
2) A new property is introduced, whose value will determine what number of items needs to be displayed in recent navigation.
3) Value of the property is 0 will show all the documents based on its creation/modification.
4) Recent navigation will show all the data based on its creation/modification (whatever is recent), no other sorting will be applicable.

While working on this i found another issue which is :
If we select the recent navigation and apply the pagination and go to page 2, then "Home" navigation gets selected by default whereas "recent" navigation should be selected.

This issue is also resolved with this PR.

Thanks,
Mohit