### PR TITLE
Lps 51545 master : Image uploaded from Image uploader should validate the img uploader property instead of DL 

### DIFF
--- a/portal-impl/src/META-INF/util-spring.xml
+++ b/portal-impl/src/META-INF/util-spring.xml
@@ -916,6 +916,11 @@
 			<bean class="com.liferay.portlet.documentlibrary.util.DLValidatorImpl" />
 		</property>
 	</bean>
+	<bean id="com.liferay.portlet.imageuploader.util.ImageUploaderValidatorUtil" class="com.liferay.portlet.imageuploader.util.ImageUploaderValidatorUtil">
+		<property name="ImageUploaderValidator">
+			<bean class="com.liferay.portlet.imageuploader.util.ImageUploaderValidatorImpl" />
+		</property>
+	</bean>
 	<bean id="com.liferay.portlet.dynamicdatalists.util.DDLExporterFactory" class="com.liferay.portlet.dynamicdatalists.util.DDLExporterFactory">
 		<property name="DDLExporters">
 			<map>

--- a/portal-impl/src/com/liferay/portal/image/DLHook.java
+++ b/portal-impl/src/com/liferay/portal/image/DLHook.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Image;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
 import com.liferay.portlet.documentlibrary.store.DLStoreUtil;
-import com.liferay.portlet.documentlibrary.util.DLValidatorUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -76,8 +75,6 @@ public class DLHook extends BaseHook {
 		throws PortalException {
 
 		String fileName = getFileName(image.getImageId(), image.getType());
-
-		DLValidatorUtil.validateFileSize(fileName, bytes);
 
 		if (DLStoreUtil.hasFile(_COMPANY_ID, _REPOSITORY_ID, fileName)) {
 			DLStoreUtil.deleteFile(_COMPANY_ID, _REPOSITORY_ID, fileName);

--- a/portal-impl/src/com/liferay/portal/service/impl/ImageLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/ImageLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.model.Image;
 import com.liferay.portal.service.base.ImageLocalServiceBaseImpl;
 import com.liferay.portal.webserver.WebServerServletTokenUtil;
+import com.liferay.portlet.imageuploader.util.ImageUploaderValidatorUtil;
 
 import java.io.File;
 import java.io.IOException;
@@ -169,6 +170,9 @@ public class ImageLocalServiceImpl extends ImageLocalServiceBaseImpl {
 		image.setHeight(height);
 		image.setWidth(width);
 		image.setSize(size);
+
+		ImageUploaderValidatorUtil.validateFileSize(
+			image.getImageId(), image.getType(), bytes);
 
 		Hook hook = HookFactory.getInstance();
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -733,6 +733,8 @@ public class PropsValues {
 	public static final boolean IMAGE_IO_USE_DISK_CACHE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.IMAGE_IO_USE_DISK_CACHE));
 
 	public static final boolean IMAGEMAGICK_ENABLED = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.IMAGEMAGICK_ENABLED));
+	
+	public static final long IMAGE_UPLOADER_MAX_SIZE = GetterUtil.getLong(PropsUtil.get(PropsKeys.IMAGE_UPLOADER_MAX_SIZE));
 
 	public static final String INDEX_DATE_FORMAT_PATTERN = PropsUtil.get(PropsKeys.INDEX_DATE_FORMAT_PATTERN);
 

--- a/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
+++ b/portal-impl/src/com/liferay/portlet/imageuploader/action/UploadImageAction.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.imageuploader.action;
 import com.liferay.portal.ImageTypeException;
 import com.liferay.portal.NoSuchRepositoryException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.flash.FlashMagicBytesUtil;
 import com.liferay.portal.kernel.image.ImageBag;
 import com.liferay.portal.kernel.image.ImageToolUtil;
@@ -54,10 +55,12 @@ import com.liferay.portlet.documentlibrary.FileSizeException;
 import com.liferay.portlet.documentlibrary.NoSuchFileEntryException;
 import com.liferay.portlet.documentlibrary.NoSuchFileException;
 import com.liferay.portlet.documentlibrary.antivirus.AntivirusScannerException;
+import com.liferay.portlet.imageuploader.util.ImageUploaderValidatorUtil;
 
 import java.awt.image.RenderedImage;
 
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 
 import javax.portlet.ActionRequest;
@@ -89,7 +92,8 @@ public class UploadImageAction extends PortletAction {
 
 		String cmd = ParamUtil.getString(actionRequest, Constants.CMD);
 
-		long maxFileSize = ParamUtil.getLong(actionRequest, "maxFileSize");
+		long maxFileSize = PrefsPropsUtil.getLong(
+			PropsKeys.USERS_IMAGE_MAX_SIZE);
 
 		try {
 			UploadException uploadException =
@@ -123,9 +127,7 @@ public class UploadImageAction extends PortletAction {
 				if (imageUploaded) {
 					fileEntry = saveTempImageFileEntry(actionRequest);
 
-					if (fileEntry.getSize() > maxFileSize) {
-						throw new FileSizeException();
-					}
+					validateImageSize(actionRequest, fileEntry, maxFileSize);
 				}
 
 				SessionMessages.add(actionRequest, "imageUploaded", fileEntry);
@@ -416,6 +418,29 @@ public class UploadImageAction extends PortletAction {
 		mimeResponse.setContentType(contentType);
 
 		PortletResponseUtil.write(mimeResponse, bytes);
+	}
+
+	protected void validateImageSize(
+			ActionRequest actionRequest, FileEntry fileEntry, long maxFileSize)
+		throws PortalException {
+
+		if (fileEntry.getSize() > maxFileSize) {
+			throw new FileSizeException();
+		}
+
+		String fileName = ParamUtil.getString(
+			actionRequest, "tempImageFileName");
+
+		byte[] bytes = null;
+
+		try {
+			bytes = FileUtil.getBytes(fileEntry.getContentStream());
+		}
+		catch (IOException ioe) {
+			throw new SystemException(ioe);
+		}
+
+		ImageUploaderValidatorUtil.validateFileSize(fileName, bytes);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-impl/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidatorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidatorImpl.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.imageuploader.util;
+
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.util.PrefsPropsUtil;
+import com.liferay.portlet.documentlibrary.FileSizeException;
+
+/**
+ * @author Mohit Soni
+ */
+public final class ImageUploaderValidatorImpl
+	implements ImageUploaderValidator {
+
+	@Override
+	public void validateFileSize(long imageId, String imageType, byte[] bytes)
+		throws FileSizeException {
+
+		String fileName = getFileName(imageId, imageType);
+
+		if (bytes == null) {
+			throw new FileSizeException(fileName);
+		}
+
+		validateFileSize(fileName, bytes.length);
+	}
+
+	@Override
+	public void validateFileSize(String fileName, byte[] bytes)
+		throws FileSizeException {
+
+		if (bytes == null) {
+			throw new FileSizeException(fileName);
+		}
+
+		validateFileSize(fileName, bytes.length);
+	}
+
+	@Override
+	public void validateFileSize(String fileName, long size)
+		throws FileSizeException {
+
+		long maxSize = PrefsPropsUtil.getLong(
+			PropsKeys.IMAGE_UPLOADER_MAX_SIZE);
+
+		if ((maxSize > 0) && (size > maxSize)) {
+			throw new FileSizeException(fileName);
+		}
+	}
+
+	protected String getFileName(long imageId, String type) {
+		return imageId + StringPool.PERIOD + type;
+	}
+
+}

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -5377,6 +5377,13 @@
     #
     image.io.use.disk.cache=true
 
+
+ 	#
+    # Set the maximum file size and valid file extensions for the document which
+    # is being uploaded from the image uploader. A value of 0 for the maximum file size and can be used to
+    # indicate unlimited file size.
+    #
+    image.uploader.max.size=307200
 ##
 ## Editors
 ##

--- a/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -967,6 +967,8 @@ public interface PropsKeys {
 
 	public static final String IMAGE_IO_USE_DISK_CACHE = "image.io.use.disk.cache";
 
+	public static final String IMAGE_UPLOADER_MAX_SIZE = "image.uploader.max.size";
+
 	public static final String IMAGEMAGICK_ENABLED = "imagemagick.enabled";
 
 	public static final String IMAGEMAGICK_GLOBAL_SEARCH_PATH = "imagemagick.global.search.path";

--- a/portal-service/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidator.java
+++ b/portal-service/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidator.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.imageuploader.util;
+
+import com.liferay.portlet.documentlibrary.FileSizeException;
+
+/**
+ * @author Mohit Soni
+ */
+public interface ImageUploaderValidator {
+
+	public void validateFileSize(long imageId, String imageType, byte[] bytes)
+		throws FileSizeException;
+
+	public void validateFileSize(String fileName, byte[] bytes)
+		throws FileSizeException;
+
+	public void validateFileSize(String fileName, long size)
+		throws FileSizeException;
+
+}

--- a/portal-service/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidatorUtil.java
+++ b/portal-service/src/com/liferay/portlet/imageuploader/util/ImageUploaderValidatorUtil.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.imageuploader.util;
+
+import com.liferay.portal.kernel.security.pacl.permission.PortalRuntimePermission;
+import com.liferay.portlet.documentlibrary.FileSizeException;
+
+/**
+ * @author Mohit Soni
+ */
+public class ImageUploaderValidatorUtil {
+
+	public static ImageUploaderValidator getImageUploaderValidator() {
+		PortalRuntimePermission.checkGetBeanProperty(
+			ImageUploaderValidatorUtil.class);
+
+		return _imageUploaderValidator;
+	}
+
+	public static void validateFileSize(
+			long imageId, String imageType, byte[] bytes)
+		throws FileSizeException {
+
+		getImageUploaderValidator().validateFileSize(imageId, imageType, bytes);
+	}
+
+	public static void validateFileSize(String fileName, byte[] bytes)
+		throws FileSizeException {
+
+			getImageUploaderValidator().validateFileSize(fileName, bytes);
+	}
+
+	public static void validateFileSize(String fileName, long size)
+		throws FileSizeException {
+
+		getImageUploaderValidator().validateFileSize(fileName, size);
+	}
+
+	public void setImageUploaderValidator(
+		ImageUploaderValidator imageUploaderValidator) {
+
+		PortalRuntimePermission.checkSetBeanProperty(getClass());
+
+		_imageUploaderValidator = imageUploaderValidator;
+	}
+
+	private static ImageUploaderValidator _imageUploaderValidator;
+
+}

--- a/portal-web/docroot/html/portlet/image_uploader/view.jsp
+++ b/portal-web/docroot/html/portlet/image_uploader/view.jsp
@@ -21,6 +21,12 @@ String currentImageURL = ParamUtil.getString(request, "currentLogoURL");
 long maxFileSize = ParamUtil.getLong(request, "maxFileSize");
 String tempImageFileName = ParamUtil.getString(request, "tempImageFileName");
 String randomNamespace = ParamUtil.getString(request, "randomNamespace");
+
+long uploaderMaxSize = PrefsPropsUtil.getLong(PropsKeys.IMAGE_UPLOADER_MAX_SIZE);
+
+if (maxFileSize > uploaderMaxSize) {
+	maxFileSize = uploaderMaxSize;
+}
 %>
 
 <liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" var="previewURL">

--- a/portal-web/docroot/html/portlet/image_uploader/view.jsp
+++ b/portal-web/docroot/html/portlet/image_uploader/view.jsp
@@ -24,7 +24,7 @@ String randomNamespace = ParamUtil.getString(request, "randomNamespace");
 
 long uploaderMaxSize = PrefsPropsUtil.getLong(PropsKeys.IMAGE_UPLOADER_MAX_SIZE);
 
-if (maxFileSize > uploaderMaxSize) {
+if ((uploaderMaxSize > 0) && (maxFileSize > uploaderMaxSize)) {
 	maxFileSize = uploaderMaxSize;
 }
 %>

--- a/portal-web/docroot/html/portlet/users_admin/user/details.jsp
+++ b/portal-web/docroot/html/portlet/users_admin/user/details.jsp
@@ -179,7 +179,6 @@ else {
 							defaultLogo="<%= selUser.getPortraitId() == 0 %>"
 							defaultLogoURL="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), selUser.isMale(), 0, null) %>"
 							logoDisplaySelector=".user-logo"
-							maxFileSize="<%= PrefsPropsUtil.getLong(PropsKeys.USERS_IMAGE_MAX_SIZE) %>"
 							tempImageFileName="<%= String.valueOf(selUser.getUserId()) %>"
 						/>
 					</c:when>


### PR DESCRIPTION
Following points have been considered in this PR:
1) Validation against Document and Library is removed.
2) A new property for image uploader has been introduced (image.uploader.max.size), which will hold the maximum upload size for the image uploader.
3) maxFileSize is retrieved from the PropsKeys instead of Request.
5) initially in the  Label "Upload images no larger than x-size" the x-size shows the size defined in "users.image.max.size" but from user point of view it should show least value among  image.uploader.max.size and users.image.max.size which is implemented.
6) Validation message will show the least value among image.uploader.max.size and users.image.max.size i.e. just like the label.
7) Flow checks two properties to validate "users.image.max.size" and then "image.uploader.max.size"

Thanks,
Mohit