### PR TITLE
LPS-54628 MAX_AGE should be in seconds, not milliseconds. Used  (Time.YE...

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
+++ b/portal-service/src/com/liferay/portal/kernel/util/CookieKeys.java
@@ -44,7 +44,7 @@ public class CookieKeys {
 
 	public static final String LOGIN = "LOGIN";
 
-	public static final int MAX_AGE = (int)Time.YEAR;
+	public static final int MAX_AGE = (int)(Time.YEAR / 1000);
 
 	public static final String PASSWORD = "PASSWORD";
 


### PR DESCRIPTION
...AR / 1000) over (Time.YEAR / Time.SECOND) because it's more obvious that we are converting from milliseconds.