### PR TITLE
LPS-53155:Publishing a Wiki page from Staging should be deleted on Live ...

### DIFF
--- a/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
+++ b/modules/apps/wiki/wiki-service/src/com/liferay/wiki/service/impl/WikiPageLocalServiceImpl.java
@@ -1672,7 +1672,7 @@ public class WikiPageLocalServiceImpl extends WikiPageLocalServiceBaseImpl {
 
 		TrashEntry trashEntry = trashEntryLocalService.addTrashEntry(
 			userId, page.getGroupId(), WikiPage.class.getName(),
-			page.getResourcePrimKey(), pageResource.getUuid(), null, oldStatus,
+			page.getResourcePrimKey(), page.getUuid(), null, oldStatus,
 			pageVersionStatusOVPs, typeSettingsProperties);
 
 		String trashTitle = TrashUtil.getTrashTitle(trashEntry.getEntryId());


### PR DESCRIPTION
if a wiki child page gets deleted from staging then while publishing the page should be deleted from live as well. But it was not happening the reason was that deleteStagedModel method of WikiPageStagedModelDataHandler was getting the uuid of wikipageresource (which was pointing to trashed entry) thus it was not resulting any WikiPage to delete.

In this case , the value of uuid was incorrect, as it should point to wikipage's uuid instead of wikipageresource.

