### PR TITLE
LPS-55731 if InvokerFilter is used before liferay is initialized, the…

### DIFF
--- a/portal-service/src/com/liferay/portal/kernel/servlet/HttpOnlyCookieServletResponse.java
+++ b/portal-service/src/com/liferay/portal/kernel/servlet/HttpOnlyCookieServletResponse.java
@@ -55,15 +55,25 @@ public class HttpOnlyCookieServletResponse extends HttpServletResponseWrapper {
 
 	@Override
 	public void addCookie(Cookie cookie) {
-		if (!_cookieHttpOnlyCookieNamesExcludes.contains(cookie.getName())) {
+		Set<String> httpOnlyCookieNamesExcludes =
+			getCookieHttpOnlyCookieNamesExcludes();
+
+		if (!httpOnlyCookieNamesExcludes.contains(cookie.getName())) {
 			cookie.setHttpOnly(true);
 		}
 
 		super.addCookie(cookie);
 	}
 
-	private static final Set<String> _cookieHttpOnlyCookieNamesExcludes =
-		SetUtil.fromArray(
-			PropsUtil.getArray(PropsKeys.COOKIE_HTTP_ONLY_NAMES_EXCLUDES));
+	private Set<String> getCookieHttpOnlyCookieNamesExcludes() {
+		if (_cookieHttpOnlyCookieNamesExcludes == null) {
+			_cookieHttpOnlyCookieNamesExcludes = SetUtil.fromArray(
+				PropsUtil.getArray(PropsKeys.COOKIE_HTTP_ONLY_NAMES_EXCLUDES));
+		}
+
+		return _cookieHttpOnlyCookieNamesExcludes;
+	}
+
+	private static Set<String> _cookieHttpOnlyCookieNamesExcludes;
 
 }


### PR DESCRIPTION
… classloader will fail to load HttpOnlyCookieServletResponse because PropsUtil will throw an NPE