### PR TITLE
LPS-41067 Surpress unnecessary warnings, SF, use static variables

### DIFF
--- a/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigProvider.java
+++ b/portal-impl/src/com/liferay/portal/editor/configuration/EditorConfigProvider.java
@@ -67,8 +67,7 @@ public class EditorConfigProvider
 	}
 
 	private static final ServiceReferenceMapper<String, EditorConfigContributor>
-		_serviceReferenceMapper =
-			new EditorServiceReferenceMapper<EditorConfigContributor>();
+		_serviceReferenceMapper = new EditorServiceReferenceMapper<>();
 	private static final ServiceTrackerMap
 		<String, List<EditorConfigContributor>>
 			_serviceTrackerMap = ServiceTrackerCollections.multiValueMap(

--- a/portal-impl/src/com/liferay/portal/editor/configuration/EditorOptionsProvider.java
+++ b/portal-impl/src/com/liferay/portal/editor/configuration/EditorOptionsProvider.java
@@ -64,8 +64,7 @@ public class EditorOptionsProvider
 
 	private static final ServiceReferenceMapper
 		<String, EditorOptionsContributor>
-			_serviceReferenceMapper =
-				new EditorServiceReferenceMapper<EditorOptionsContributor>();
+			_serviceReferenceMapper = new EditorServiceReferenceMapper<>();
 	private static final ServiceTrackerMap
 		<String, List<EditorOptionsContributor>> _serviceTrackerMap =
 			ServiceTrackerCollections.multiValueMap(

--- a/portal-service/src/com/liferay/portal/kernel/process/local/LocalProcessExecutor.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/local/LocalProcessExecutor.java
@@ -137,6 +137,7 @@ public class LocalProcessExecutor implements ProcessExecutor {
 			commands.add(processConfig.getJavaExecutable());
 			commands.add("-cp");
 			commands.add(processConfig.getBootstrapClassPath());
+			commands.add("-Dsystem.properties.quiet=true");
 			commands.addAll(arguments);
 			commands.add(LocalProcessLauncher.class.getName());
 

--- a/portal-service/src/com/liferay/portal/kernel/process/local/LocalProcessExecutor.java
+++ b/portal-service/src/com/liferay/portal/kernel/process/local/LocalProcessExecutor.java
@@ -35,6 +35,7 @@ import com.liferay.portal.kernel.util.ClassLoaderObjectInputStream;
 import com.liferay.portal.kernel.util.NamedThreadFactory;
 import com.liferay.portal.kernel.util.PortalClassLoaderUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
+import com.liferay.portal.kernel.util.SystemProperties;
 
 import java.io.EOFException;
 import java.io.File;
@@ -137,7 +138,8 @@ public class LocalProcessExecutor implements ProcessExecutor {
 			commands.add(processConfig.getJavaExecutable());
 			commands.add("-cp");
 			commands.add(processConfig.getBootstrapClassPath());
-			commands.add("-Dsystem.properties.quiet=true");
+			commands.add(
+				"-D" + SystemProperties.SYSTEM_PROPERTIES_QUIET + "=true");
 			commands.addAll(arguments);
 			commands.add(LocalProcessLauncher.class.getName());
 

--- a/portal-service/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
+++ b/portal-service/test/unit/com/liferay/portal/kernel/process/local/LocalProcessExecutorTest.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.SocketUtil;
 import com.liferay.portal.kernel.util.SocketUtil.ServerSocketConfigurator;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.io.ByteArrayOutputStream;
@@ -1474,9 +1473,6 @@ public class LocalProcessExecutorTest {
 
 	private static List<String> _createArguments(String jpdaOptions) {
 		List<String> arguments = new ArrayList<>();
-
-		arguments.add(
-			"-D" + SystemProperties.SYSTEM_PROPERTIES_QUIET + "=true");
 
 		if (Boolean.getBoolean("junit.debug")) {
 			arguments.add(jpdaOptions);


### PR DESCRIPTION
1) Use the constant
2) Remove that line from the test