### PR TITLE
LPS-56313

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
+++ b/modules/apps/asset/asset-publisher-web/src/com/liferay/asset/publisher/web/util/AssetPublisherUtil.java
@@ -620,6 +620,8 @@ public class AssetPublisherUtil {
 			allAssetCategoryIds = overrideAllAssetCategoryIds;
 		}
 
+		allAssetCategoryIds = _checkAssetCategories(allAssetCategoryIds);
+
 		assetEntryQuery.setAllCategoryIds(allAssetCategoryIds);
 
 		if (overrideAllAssetTagNames != null) {
@@ -1302,6 +1304,28 @@ public class AssetPublisherUtil {
 		AssetEntryQueryProcessor assetEntryQueryProcessor) {
 
 		_assetEntryQueryProcessors.remove(assetEntryQueryProcessor);
+	}
+
+	private static long[] _checkAssetCategories(long[] assetCategoryIds) {
+		List<Long> assetCategoryIdsList = new ArrayList<>();
+
+		for (long assetCategoryId : assetCategoryIds) {
+			AssetCategory category =
+				AssetCategoryLocalServiceUtil.fetchAssetCategory(
+					assetCategoryId);
+
+			if (category != null) {
+				assetCategoryIdsList.add(assetCategoryId);
+			}
+		}
+
+		long[] assetCategoryIdsArray = new long[assetCategoryIdsList.size()];
+
+		for (int i = 0; i < assetCategoryIdsList.size(); i++) {
+			assetCategoryIdsArray[i] = assetCategoryIdsList.get(i);
+		}
+
+		return assetCategoryIdsArray;
 	}
 
 	private static void _checkAssetEntries(


### PR DESCRIPTION
it might not be clear how this fix works so just a little explaination...
if youre filtering an AP using categories, and you delete a category, the AP configurations dont get updated until you save them again. so its still going to be using the deleted categoryId as an argument in the search. so in the case of an ALL type search (using an AND operator), its going to return no results. so we just filter out the non existant ids before calling assetEntryQuery.setAllCategoryIds(). we dont have to worry about the assetEntryQuery.setAnyCategoryIds() because thats an ANY (OR operator) search. if its still not clear just let me know