### PR TITLE
LPS-57900 Only use strict mode for login portlet

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -570,23 +570,26 @@ public class PortletPreferencesFactoryImpl
 		long siteGroupId, Layout layout, String portletId,
 		String defaultPreferences) {
 
-		try {
-			LayoutTypePortlet layoutTypePortlet =
-				(LayoutTypePortlet)layout.getLayoutType();
+		if (Validator.equals(portletId, PortletKeys.LOGIN)) {
+			try {
+				LayoutTypePortlet layoutTypePortlet =
+					(LayoutTypePortlet)layout.getLayoutType();
 
-			if (layoutTypePortlet.hasPortletId(portletId)) {
-				return getPortletSetup(
-					siteGroupId, layout, portletId, defaultPreferences, false);
+				if (!layoutTypePortlet.hasPortletId(portletId)) {
+					return getPortletSetup(
+						siteGroupId, layout, portletId, defaultPreferences,
+						true);
+				}
 			}
-		}
-		catch (PortalException pe) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(pe, pe);
+			catch (PortalException pe) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(pe, pe);
+				}
 			}
 		}
 
 		return getPortletSetup(
-			siteGroupId, layout, portletId, defaultPreferences, true);
+			siteGroupId, layout, portletId, defaultPreferences, false);
 	}
 
 	@Override


### PR DESCRIPTION
Hey Jonathan,

This issue basically fixes the regression caused by LPS-52365.  I spoke with Bejond and he told me his fix was really only designed to resolve an issue with the login portlet.  So, I basically wrap his logic around a condition to make sure it only applies to login portlets.

I'm not sure if this is needed for any other portlet types, but I have not ran into any issues with it so far.  Let me know if I can answer any questions for you.