### PR TITLE
LPS-58141 Add all available network interface IPs on portal startup

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -224,8 +224,10 @@ import java.io.Serializable;
 
 import java.lang.reflect.Method;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.NetworkInterface;
 import java.net.UnknownHostException;
 
 import java.sql.Connection;
@@ -236,6 +238,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -347,6 +350,27 @@ public class PortalImpl implements Portal {
 		}
 
 		_computerAddress = computerAddress;
+
+		try {
+			List<NetworkInterface> networkInterfaces = Collections.list(
+				NetworkInterface.getNetworkInterfaces());
+
+			for (NetworkInterface networkInterface : networkInterfaces) {
+				List<InetAddress> inetAddresses = Collections.list(
+					networkInterface.getInetAddresses());
+
+				for (InetAddress inetAddress : inetAddresses) {
+					if (inetAddress instanceof Inet4Address) {
+						_computerAddresses.add(inetAddress.getHostAddress());
+					}
+				}
+			}
+		}
+		catch (Exception e) {
+			_log.error("Unable to read local server's IP addresses");
+
+			_log.error(e, e);
+		}
 
 		// Paths
 
@@ -893,9 +917,8 @@ public class PortalImpl implements Portal {
 
 				String hostAddress = inetAddress.getHostAddress();
 
-				String serverIp = getComputerAddress();
-
-				boolean serverIpIsHostAddress = serverIp.equals(hostAddress);
+				boolean serverIpIsHostAddress = _computerAddresses.contains(
+					hostAddress);
 
 				for (String ip : allowedIps) {
 					if ((serverIpIsHostAddress && ip.equals("SERVER_IP")) ||
@@ -8441,6 +8464,7 @@ public class PortalImpl implements Portal {
 		PropsValues.PORTLET_RESOURCE_ID_BANNED_PATHS_REGEXP,
 		Pattern.CASE_INSENSITIVE);
 	private final String _computerAddress;
+	private final Set<String> _computerAddresses = new ConcurrentHashSet<>();
 	private final String _computerName;
 	private String[] _customSqlKeys;
 	private String[] _customSqlValues;

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -121,7 +121,7 @@
         portal-impl/src/com/liferay/portal/fabric/netty/client/NettyFabricClientConfig.java@69,\
         portal-impl/src/com/liferay/portal/spring/hibernate/PortalHibernateConfiguration.java@263,\
         portal-impl/src/com/liferay/portal/tools/WebXML23Converter.java@81,\
-        portal-impl/src/com/liferay/portal/util/PortalImpl.java@541,\
+        portal-impl/src/com/liferay/portal/util/PortalImpl.java@565,\
         portal-impl/src/com/liferay/portal/util/WebKeys.java,\
         portal-impl/src/com/liferay/portlet/exportimport/lar/PortletDataHandlerBackgroundTaskStatusMessage.java@67,\
         portal-impl/test/integration/com/liferay/portal/editor/configuration/EditorConfigContributorTest.java,\


### PR DESCRIPTION
On Linux machines, the computer name cannot be retrieved, so by default the computer address is set to the loop back address. Instead we should iterate through all available network interfaces and add them to a set which is available in portalImpl.