### PR TITLE
LPS-58511 override doGet method for TunnelServlet and XmlRpcServlet a…

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/TunnelServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/TunnelServlet.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.security.auth.HttpPrincipal;
+import com.liferay.portal.util.PortalUtil;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -30,6 +31,7 @@ import java.io.ObjectOutputStream;
 
 import java.lang.reflect.InvocationTargetException;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -39,6 +41,18 @@ import javax.servlet.http.HttpServletResponse;
  * @author Brian Wing Shun Chan
  */
 public class TunnelServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+		HttpServletRequest request, HttpServletResponse response)
+	throws IOException, ServletException {
+
+		IllegalArgumentException e = new IllegalArgumentException(
+			"method GET is not supported by this URL");
+
+		PortalUtil.sendError(
+			HttpServletResponse.SC_NOT_FOUND, e, request, response);
+	}
 
 	@Override
 	public void doPost(HttpServletRequest request, HttpServletResponse response)

--- a/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcServlet.java
+++ b/portal-impl/src/com/liferay/portal/xmlrpc/XmlRpcServlet.java
@@ -28,10 +28,12 @@ import com.liferay.portal.kernel.xmlrpc.XmlRpcConstants;
 import com.liferay.portal.kernel.xmlrpc.XmlRpcException;
 import com.liferay.portal.kernel.xmlrpc.XmlRpcUtil;
 import com.liferay.portal.util.PortalInstances;
+import com.liferay.portal.util.PortalUtil;
 
 import java.io.IOException;
 import java.io.InputStream;
 
+import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -41,6 +43,18 @@ import javax.servlet.http.HttpServletResponse;
  * @author Brian Wing Shun Chan
  */
 public class XmlRpcServlet extends HttpServlet {
+
+	@Override
+	protected void doGet(
+		HttpServletRequest request, HttpServletResponse response)
+	throws IOException, ServletException {
+
+		IllegalArgumentException e = new IllegalArgumentException(
+			"method GET is not supported by this URL");
+
+		PortalUtil.sendError(
+			HttpServletResponse.SC_NOT_FOUND, e, request, response);
+	}
 
 	@Override
 	protected void doPost(


### PR DESCRIPTION
…nd redirect these requests to liferay status page


The doGet method is not implemented in the servlets causing Apache to default to its implementation, which throws a 405 error.