### PR TITLE
LPS 58702: Site Templates should be deleted if its not referenced as an organization site

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -118,8 +118,12 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			layoutSet = initLayoutSet(layoutSet);
 
 			layoutSet.setLogoId(layoutSet.getLogoId());
+			layoutSet.setLayoutSetPrototypeLinkEnabled(Boolean.FALSE);
+			layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
 
 			layoutSetPersistence.update(layoutSet);
+
+			updatePageCount(groupId, privateLayout);
 		}
 		else {
 			layoutSetPersistence.removeByG_P(groupId, privateLayout);

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetPrototypeLocalServiceImpl.java
@@ -20,10 +20,12 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.model.Group;
 import com.liferay.portal.model.GroupConstants;
 import com.liferay.portal.model.LayoutConstants;
+import com.liferay.portal.model.LayoutSet;
 import com.liferay.portal.model.LayoutSetPrototype;
 import com.liferay.portal.model.ResourceConstants;
 import com.liferay.portal.model.SystemEventConstants;
@@ -149,9 +151,34 @@ public class LayoutSetPrototypeLocalServiceImpl
 
 		// Group
 
-		if (layoutSetPersistence.countByLayoutSetPrototypeUuid(
-				layoutSetPrototype.getUuid()) > 0) {
+		List<LayoutSet> layoutSetList =
+			layoutSetPersistence.findByLayoutSetPrototypeUuid(
+				layoutSetPrototype.getUuid());
 
+		boolean isLayoutSetExist = false;
+
+		if (layoutSetList.size() > 0) {
+			for (LayoutSet layoutSet : layoutSetList) {
+				Group layoutSetGroup = layoutSet.getGroup();
+
+				if (!layoutSetGroup.isSite() &&
+					layoutSetGroup.isOrganization()) {
+
+					layoutSet.setLayoutSetPrototypeLinkEnabled(Boolean.FALSE);
+					layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
+
+					layoutSetPersistence.update(layoutSet);
+
+					layoutSetLocalService.updatePageCount(
+						layoutSet.getGroupId(), layoutSet.getPrivateLayout());
+				}
+				else {
+					isLayoutSetExist = true;
+				}
+			}
+		}
+
+		if (isLayoutSetExist) {
 			throw new RequiredLayoutSetPrototypeException();
 		}
 


### PR DESCRIPTION
While deleting the Site Templates it looks for reference in layoutset table, if any reference found then it doesn't delete the template and says a validation message that template is in use which is correct.
In this case , Organization Site was created with Site template and when we delete that site then it doesn't update the layoutsetprototypeuuid and layoutSetPrototypeLinkEnabled column from layoutset table which should be updated as BLANK and false respectively.
So i have added parameters to make the desired changes while deleting the sites.
But this change will still won't work for existing site templates whose reference is still in layoutset table.
So i have to make modification while deleting site template as an additional validation.
Which will check if reference is not in use then update that and delete the template.
