### PR TITLE
LPS 58702: Site Templates should be deleted if its not referenced as an organization site

### DIFF
--- a/portal-impl/src/META-INF/portal-spring.xml
+++ b/portal-impl/src/META-INF/portal-spring.xml
@@ -50,6 +50,7 @@
 	<bean id="com.liferay.portal.service.LayoutSetLocalService" class="com.liferay.portal.service.impl.LayoutSetLocalServiceImpl" />
 	<bean id="com.liferay.portal.service.LayoutSetService" class="com.liferay.portal.service.impl.LayoutSetServiceImpl" />
 	<bean id="com.liferay.portal.service.persistence.LayoutSetPersistence" class="com.liferay.portal.service.persistence.impl.LayoutSetPersistenceImpl" parent="basePersistence" />
+	<bean id="com.liferay.portal.service.persistence.LayoutSetFinder" class="com.liferay.portal.service.persistence.impl.LayoutSetFinderImpl" parent="basePersistence" />
 	<bean id="com.liferay.portal.service.LayoutSetBranchLocalService" class="com.liferay.portal.service.impl.LayoutSetBranchLocalServiceImpl" />
 	<bean id="com.liferay.portal.service.LayoutSetBranchService" class="com.liferay.portal.service.impl.LayoutSetBranchServiceImpl" />
 	<bean id="com.liferay.portal.service.persistence.LayoutSetBranchPersistence" class="com.liferay.portal.service.persistence.impl.LayoutSetBranchPersistenceImpl" parent="basePersistence" />

--- a/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CompanyLocalServiceBaseImpl.java
@@ -44,6 +44,7 @@ import com.liferay.portal.service.persistence.GroupFinder;
 import com.liferay.portal.service.persistence.GroupPersistence;
 import com.liferay.portal.service.persistence.ImagePersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.OrganizationFinder;
@@ -743,6 +744,24 @@ public abstract class CompanyLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set prototype local service.
 	 *
 	 * @return the layout set prototype local service
@@ -1433,6 +1452,8 @@ public abstract class CompanyLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeLocalService.class)
 	protected com.liferay.portal.service.LayoutSetPrototypeLocalService layoutSetPrototypeLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/CompanyServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/CompanyServiceBaseImpl.java
@@ -31,6 +31,7 @@ import com.liferay.portal.service.persistence.GroupFinder;
 import com.liferay.portal.service.persistence.GroupPersistence;
 import com.liferay.portal.service.persistence.ImagePersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.OrganizationFinder;
@@ -498,6 +499,24 @@ public abstract class CompanyServiceBaseImpl extends BaseServiceImpl
 	public void setLayoutSetPersistence(
 		LayoutSetPersistence layoutSetPersistence) {
 		this.layoutSetPersistence = layoutSetPersistence;
+	}
+
+	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
 	}
 
 	/**
@@ -1187,6 +1206,8 @@ public abstract class CompanyServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeLocalService.class)
 	protected com.liferay.portal.service.LayoutSetPrototypeLocalService layoutSetPrototypeLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/GroupLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/GroupLocalServiceBaseImpl.java
@@ -46,6 +46,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.MembershipRequestPersistence;
@@ -2192,6 +2193,24 @@ public abstract class GroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -3560,6 +3579,8 @@ public abstract class GroupLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/GroupServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/GroupServiceBaseImpl.java
@@ -33,6 +33,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.MembershipRequestPersistence;
@@ -1424,6 +1425,24 @@ public abstract class GroupServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -2788,6 +2807,8 @@ public abstract class GroupServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutLocalServiceBaseImpl.java
@@ -46,6 +46,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutFriendlyURLPersistence;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.PluginSettingPersistence;
@@ -1245,6 +1246,24 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set prototype local service.
 	 *
 	 * @return the layout set prototype local service
@@ -1789,6 +1808,8 @@ public abstract class LayoutLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeLocalService.class)
 	protected com.liferay.portal.service.LayoutSetPrototypeLocalService layoutSetPrototypeLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.PortletPreferencesFinder;
 import com.liferay.portal.service.persistence.PortletPreferencesPersistence;
@@ -629,6 +630,24 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -988,6 +1007,8 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionServiceBaseImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.PortletPreferencesFinder;
 import com.liferay.portal.service.persistence.PortletPreferencesPersistence;
@@ -378,6 +379,24 @@ public abstract class LayoutRevisionServiceBaseImpl extends BaseServiceImpl
 	public void setLayoutSetPersistence(
 		LayoutSetPersistence layoutSetPersistence) {
 		this.layoutSetPersistence = layoutSetPersistence;
+	}
+
+	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
 	}
 
 	/**
@@ -736,6 +755,8 @@ public abstract class LayoutRevisionServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutServiceBaseImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutFriendlyURLPersistence;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutPrototypePersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.PluginSettingPersistence;
@@ -884,6 +885,24 @@ public abstract class LayoutServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set prototype local service.
 	 *
 	 * @return the layout set prototype local service
@@ -1424,6 +1443,8 @@ public abstract class LayoutServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeLocalService.class)
 	protected com.liferay.portal.service.LayoutSetPrototypeLocalService layoutSetPrototypeLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetPrototypeService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchLocalServiceBaseImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.UserFinder;
 import com.liferay.portal.service.persistence.UserPersistence;
@@ -684,6 +685,24 @@ public abstract class LayoutSetBranchLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the resource local service.
 	 *
 	 * @return the resource local service
@@ -878,6 +897,8 @@ public abstract class LayoutSetBranchLocalServiceBaseImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.ResourceLocalService.class)
 	protected com.liferay.portal.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.service.UserLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetBranchServiceBaseImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.UserFinder;
 import com.liferay.portal.service.persistence.UserPersistence;
@@ -435,6 +436,24 @@ public abstract class LayoutSetBranchServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the resource local service.
 	 *
 	 * @return the resource local service
@@ -625,6 +644,8 @@ public abstract class LayoutSetBranchServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.ResourceLocalService.class)
 	protected com.liferay.portal.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.service.UserLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetLocalServiceBaseImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.service.persistence.ImagePersistence;
 import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.PluginSettingPersistence;
 import com.liferay.portal.service.persistence.VirtualHostPersistence;
@@ -356,6 +357,24 @@ public abstract class LayoutSetLocalServiceBaseImpl extends BaseLocalServiceImpl
 	public void setLayoutSetPersistence(
 		LayoutSetPersistence layoutSetPersistence) {
 		this.layoutSetPersistence = layoutSetPersistence;
+	}
+
+	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
 	}
 
 	/**
@@ -801,6 +820,8 @@ public abstract class LayoutSetLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.counter.service.CounterLocalService.class)
 	protected com.liferay.counter.service.CounterLocalService counterLocalService;
 	@BeanReference(type = com.liferay.portal.service.GroupLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeLocalServiceBaseImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.service.persistence.GroupFinder;
 import com.liferay.portal.service.persistence.GroupPersistence;
 import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.UserFinder;
@@ -678,6 +679,24 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the resource local service.
 	 *
 	 * @return the resource local service
@@ -862,6 +881,8 @@ public abstract class LayoutSetPrototypeLocalServiceBaseImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.ResourceLocalService.class)
 	protected com.liferay.portal.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.service.UserLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetPrototypeServiceBaseImpl.java
@@ -28,6 +28,7 @@ import com.liferay.portal.service.persistence.GroupFinder;
 import com.liferay.portal.service.persistence.GroupPersistence;
 import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.LayoutSetPrototypePersistence;
 import com.liferay.portal.service.persistence.UserFinder;
@@ -338,6 +339,24 @@ public abstract class LayoutSetPrototypeServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the resource local service.
 	 *
 	 * @return the resource local service
@@ -518,6 +537,8 @@ public abstract class LayoutSetPrototypeServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.ResourceLocalService.class)
 	protected com.liferay.portal.service.ResourceLocalService resourceLocalService;
 	@BeanReference(type = com.liferay.portal.service.UserLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutSetServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutSetServiceBaseImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.service.persistence.ImagePersistence;
 import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.PluginSettingPersistence;
 import com.liferay.portal.service.persistence.VirtualHostPersistence;
@@ -111,6 +112,24 @@ public abstract class LayoutSetServiceBaseImpl extends BaseServiceImpl
 	public void setLayoutSetPersistence(
 		LayoutSetPersistence layoutSetPersistence) {
 		this.layoutSetPersistence = layoutSetPersistence;
+	}
+
+	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
 	}
 
 	/**
@@ -552,6 +571,8 @@ public abstract class LayoutSetServiceBaseImpl extends BaseServiceImpl
 	protected LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.counter.service.CounterLocalService.class)
 	protected com.liferay.counter.service.CounterLocalService counterLocalService;
 	@BeanReference(type = com.liferay.portal.service.GroupLocalService.class)

--- a/portal-impl/src/com/liferay/portal/service/base/VirtualHostLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/VirtualHostLocalServiceBaseImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.service.VirtualHostLocalService;
 import com.liferay.portal.service.persistence.CompanyPersistence;
 import com.liferay.portal.service.persistence.GroupFinder;
 import com.liferay.portal.service.persistence.GroupPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.VirtualHostPersistence;
 import com.liferay.portal.util.PortalUtil;
@@ -543,6 +544,24 @@ public abstract class VirtualHostLocalServiceBaseImpl
 		this.layoutSetPersistence = layoutSetPersistence;
 	}
 
+	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
 	public void afterPropertiesSet() {
 		persistedModelLocalServiceRegistry.register("com.liferay.portal.model.VirtualHost",
 			virtualHostLocalService);
@@ -631,6 +650,8 @@ public abstract class VirtualHostLocalServiceBaseImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = PersistedModelLocalServiceRegistry.class)
 	protected PersistedModelLocalServiceRegistry persistedModelLocalServiceRegistry;
 	private String _beanIdentifier;

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -118,8 +118,12 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 			layoutSet = initLayoutSet(layoutSet);
 
 			layoutSet.setLogoId(layoutSet.getLogoId());
+			layoutSet.setLayoutSetPrototypeLinkEnabled(Boolean.FALSE);
+			layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
 
 			layoutSetPersistence.update(layoutSet);
+
+			updatePageCount(groupId, privateLayout);
 		}
 		else {
 			layoutSetPersistence.removeByG_P(groupId, privateLayout);

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutSetLocalServiceImpl.java
@@ -181,6 +181,11 @@ public class LayoutSetLocalServiceImpl extends LayoutSetLocalServiceBaseImpl {
 	}
 
 	@Override
+	public List<LayoutSet> getLayoutSetPrototypeUuids() {
+		return layoutSetFinder.findByLayoutSetPrototypeUuids();
+	}
+
+	@Override
 	public List<LayoutSet> getLayoutSetsByLayoutSetPrototypeUuid(
 		String layoutSetPrototypeUuid) {
 

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/LayoutSetFinderImpl.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.persistence.impl;
+
+import com.liferay.portal.kernel.dao.orm.QueryPos;
+import com.liferay.portal.kernel.dao.orm.SQLQuery;
+import com.liferay.portal.kernel.dao.orm.Session;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.model.Layout;
+import com.liferay.portal.model.LayoutSet;
+import com.liferay.portal.model.impl.LayoutSetImpl;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
+import com.liferay.util.dao.orm.CustomSQLUtil;
+
+import java.util.List;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class LayoutSetFinderImpl
+	extends BasePersistenceImpl<Layout> implements LayoutSetFinder {
+
+	public static final String FIND_BY_LAYOUTSET_PROTOTYPE_UUIDS =
+		LayoutSetFinder.class.getName() + ".findByLayoutSetPrototypeUuids";
+
+	@Override
+	public List<LayoutSet> findByLayoutSetPrototypeUuids() {
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			String sql = CustomSQLUtil.get(FIND_BY_LAYOUTSET_PROTOTYPE_UUIDS);
+
+			SQLQuery q = session.createSynchronizedSQLQuery(sql);
+
+			q.addEntity("LayoutSet", LayoutSetImpl.class);
+
+			QueryPos qPos = QueryPos.getInstance(q);
+
+			return q.list(true);
+		}
+		catch (Exception e) {
+			throw new SystemException(e);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyLayoutSet.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyLayoutSet.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.model.Group;
+import com.liferay.portal.model.LayoutSet;
+import com.liferay.portal.service.LayoutSetLocalServiceUtil;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @author Gergely Mathe
+ * @author Kenneth Chang
+ */
+public class VerifyLayoutSet extends VerifyProcess {
+
+	@Override
+	protected void doVerify() throws Exception {
+		verifyLayoutSet();
+	}
+
+	protected void verifyLayoutSet() throws Exception {
+		List<LayoutSet> layoutSetList =
+			LayoutSetLocalServiceUtil.getLayoutSetPrototypeUuids();
+
+		if (layoutSetList.size() > 0) {
+			for (LayoutSet layoutSet : layoutSetList) {
+				Group layoutSetGroup = layoutSet.getGroup();
+
+				if (!layoutSetGroup.isSite() &&
+					layoutSetGroup.isOrganization()) {
+
+					layoutSet.setLayoutSetPrototypeLinkEnabled(Boolean.FALSE);
+					layoutSet.setLayoutSetPrototypeUuid(StringPool.BLANK);
+					layoutSet.setModifiedDate(new Date());
+					layoutSet.setPageCount(0);
+
+					LayoutSetLocalServiceUtil.updateLayoutSet(layoutSet);
+				}
+			}
+		}
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -40,6 +40,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		verify(new VerifyCalendar());
 		verify(new VerifyGroupedModel());
 		verify(new VerifyLayout());
+		verify(new VerifyLayoutSet());
 		verify(new VerifyMessageBoards());
 		verify(new VerifyOrganization());
 		verify(new VerifyPortletPreferences());

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/base/StagingLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/base/StagingLocalServiceBaseImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.UserFinder;
 import com.liferay.portal.service.persistence.UserPersistence;
@@ -534,6 +535,24 @@ public abstract class StagingLocalServiceBaseImpl extends BaseLocalServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -783,6 +802,8 @@ public abstract class StagingLocalServiceBaseImpl extends BaseLocalServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/com/liferay/portlet/exportimport/service/base/StagingServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portlet/exportimport/service/base/StagingServiceBaseImpl.java
@@ -30,6 +30,7 @@ import com.liferay.portal.service.persistence.LayoutFinder;
 import com.liferay.portal.service.persistence.LayoutPersistence;
 import com.liferay.portal.service.persistence.LayoutRevisionPersistence;
 import com.liferay.portal.service.persistence.LayoutSetBranchPersistence;
+import com.liferay.portal.service.persistence.LayoutSetFinder;
 import com.liferay.portal.service.persistence.LayoutSetPersistence;
 import com.liferay.portal.service.persistence.UserFinder;
 import com.liferay.portal.service.persistence.UserPersistence;
@@ -531,6 +532,24 @@ public abstract class StagingServiceBaseImpl extends BaseServiceImpl
 	}
 
 	/**
+	 * Returns the layout set finder.
+	 *
+	 * @return the layout set finder
+	 */
+	public LayoutSetFinder getLayoutSetFinder() {
+		return layoutSetFinder;
+	}
+
+	/**
+	 * Sets the layout set finder.
+	 *
+	 * @param layoutSetFinder the layout set finder
+	 */
+	public void setLayoutSetFinder(LayoutSetFinder layoutSetFinder) {
+		this.layoutSetFinder = layoutSetFinder;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -780,6 +799,8 @@ public abstract class StagingServiceBaseImpl extends BaseServiceImpl
 	protected com.liferay.portal.service.LayoutSetService layoutSetService;
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;
+	@BeanReference(type = LayoutSetFinder.class)
+	protected LayoutSetFinder layoutSetFinder;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchLocalService.class)
 	protected com.liferay.portal.service.LayoutSetBranchLocalService layoutSetBranchLocalService;
 	@BeanReference(type = com.liferay.portal.service.LayoutSetBranchService.class)

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -547,6 +547,16 @@
 				(CAST_CLOB_TEXT(PortletPreferences.preferences) LIKE ?)
 		]]>
 	</sql>
+	<sql id="com.liferay.portal.service.persistence.LayoutSetFinder.findByLayoutSetPrototypeUuids">
+		<![CDATA[
+			SELECT
+				{LayoutSet.*}
+			FROM
+				LayoutSet
+			WHERE
+				layoutSetPrototypeUuid != ''
+		]]>
+	</sql>
 	<sql id="com.liferay.portal.service.persistence.OrganizationFinder.countByGroupId">
 		<![CDATA[
 			SELECT

--- a/portal-service/src/com/liferay/portal/service/LayoutSetLocalService.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutSetLocalService.java
@@ -200,6 +200,9 @@ public interface LayoutSetLocalService extends BaseLocalService,
 	public com.liferay.portal.model.LayoutSet getLayoutSet(
 		java.lang.String virtualHostname) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portal.model.LayoutSet> getLayoutSetPrototypeUuids();
+
 	/**
 	* Returns a range of all the layout sets.
 	*

--- a/portal-service/src/com/liferay/portal/service/LayoutSetLocalServiceUtil.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutSetLocalServiceUtil.java
@@ -233,6 +233,10 @@ public class LayoutSetLocalServiceUtil {
 		return getService().getLayoutSet(virtualHostname);
 	}
 
+	public static java.util.List<com.liferay.portal.model.LayoutSet> getLayoutSetPrototypeUuids() {
+		return getService().getLayoutSetPrototypeUuids();
+	}
+
 	/**
 	* Returns a range of all the layout sets.
 	*

--- a/portal-service/src/com/liferay/portal/service/LayoutSetLocalServiceWrapper.java
+++ b/portal-service/src/com/liferay/portal/service/LayoutSetLocalServiceWrapper.java
@@ -241,6 +241,11 @@ public class LayoutSetLocalServiceWrapper implements LayoutSetLocalService,
 		return _layoutSetLocalService.getLayoutSet(virtualHostname);
 	}
 
+	@Override
+	public java.util.List<com.liferay.portal.model.LayoutSet> getLayoutSetPrototypeUuids() {
+		return _layoutSetLocalService.getLayoutSetPrototypeUuids();
+	}
+
 	/**
 	* Returns a range of all the layout sets.
 	*

--- a/portal-service/src/com/liferay/portal/service/persistence/LayoutSetFinder.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/LayoutSetFinder.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.persistence;
+
+import aQute.bnd.annotation.ProviderType;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @generated
+ */
+@ProviderType
+public interface LayoutSetFinder {
+	public java.util.List<com.liferay.portal.model.LayoutSet> findByLayoutSetPrototypeUuids();
+}

--- a/portal-service/src/com/liferay/portal/service/persistence/LayoutSetFinderUtil.java
+++ b/portal-service/src/com/liferay/portal/service/persistence/LayoutSetFinderUtil.java
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.service.persistence;
+
+import aQute.bnd.annotation.ProviderType;
+
+import com.liferay.portal.kernel.bean.PortalBeanLocatorUtil;
+import com.liferay.portal.kernel.util.ReferenceRegistry;
+
+/**
+ * @author Brian Wing Shun Chan
+ * @generated
+ */
+@ProviderType
+public class LayoutSetFinderUtil {
+	public static java.util.List<com.liferay.portal.model.LayoutSet> findByLayoutSetPrototypeUuids() {
+		return getFinder().findByLayoutSetPrototypeUuids();
+	}
+
+	public static LayoutSetFinder getFinder() {
+		if (_finder == null) {
+			_finder = (LayoutSetFinder)PortalBeanLocatorUtil.locate(LayoutSetFinder.class.getName());
+
+			ReferenceRegistry.registerReference(LayoutSetFinderUtil.class,
+				"_finder");
+		}
+
+		return _finder;
+	}
+
+	public void setFinder(LayoutSetFinder finder) {
+		_finder = finder;
+
+		ReferenceRegistry.registerReference(LayoutSetFinderUtil.class, "_finder");
+	}
+
+	private static LayoutSetFinder _finder;
+}


### PR DESCRIPTION
With respect to your comment https://github.com/jonathanmccann/liferay-portal/pull/832#issuecomment-141479473, i have added a verifyProcess to to update the layoutset if Organization site is not referenced to Site Template anymore.
Also i think that pagecount says the number of page it has, but here , there is no pages available, so it should be 0.
