### PR TITLE
LPS-61446 Some versions of IE and Safari do not have String.startsWit…

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/recurrence_converter.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/recurrence_converter.js
@@ -3,6 +3,8 @@ AUI.add(
 	function(A) {
 		var Lang = A.Lang;
 
+		var LString = Lang.String;
+
 		var EXDATE = 'EXDATE';
 
 		var RRULE = 'RRULE';
@@ -19,7 +21,9 @@ AUI.add(
 
 		var WEEKLY = 'WEEKLY';
 
-		var padNumber = A.rbind('padNumber', A.Lang.String, 2);
+		var padNumber = A.rbind('padNumber', LString, 2);
+
+		var startsWith = A.rbind('startsWith', LString);
 
 		var RecurrenceConverter = function() {
 		};
@@ -144,7 +148,7 @@ AUI.add(
 
 					var exDate = null;
 
-					if (string && string.startsWith(EXDATE + STR_SEMICOLON)) {
+					if (string && startsWith(string, EXDATE + STR_SEMICOLON)) {
 						exDate = string.slice(7);
 					}
 
@@ -167,7 +171,7 @@ AUI.add(
 
 					var rrule = null;
 
-					if (string && string.startsWith(RRULE + STR_COLON)) {
+					if (string && startsWith(string, RRULE + STR_COLON)) {
 						string = string.slice(6);
 
 						var params = string.split(STR_SEMICOLON);


### PR DESCRIPTION
…h method, which is included in ES6; utilize A.Lang.String's startsWith method instead