### PR TITLE
LPS 61372

### DIFF
--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalService.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalService.java
@@ -292,8 +292,16 @@ public interface CalendarLocalService extends BaseLocalService,
 	public com.liferay.portal.model.PersistedModel getPersistedModel(
 		java.io.Serializable primaryKeyObj) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean hasStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar) throws PortalException;
+
 	public void importCalendar(long calendarId, java.lang.String data,
 		java.lang.String type) throws java.lang.Exception;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public boolean isStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.calendar.model.Calendar> search(

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceUtil.java
@@ -21,7 +21,7 @@ import com.liferay.osgi.util.ServiceTrackerFactory;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
- * Provides the local service utility for Calendar. This utility wraps
+ * Provides the local service utility for Calendar. This utility wrapsz
  * {@link com.liferay.calendar.service.impl.CalendarLocalServiceImpl} and is the
  * primary access point for service operations in application layer code running
  * on the local server. Methods of this service will not have security checks

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceUtil.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceUtil.java
@@ -21,7 +21,7 @@ import com.liferay.osgi.util.ServiceTrackerFactory;
 import org.osgi.util.tracker.ServiceTracker;
 
 /**
- * Provides the local service utility for Calendar. This utility wrapsz
+ * Provides the local service utility for Calendar. This utility wraps
  * {@link com.liferay.calendar.service.impl.CalendarLocalServiceImpl} and is the
  * primary access point for service operations in application layer code running
  * on the local server. Methods of this service will not have security checks
@@ -336,9 +336,20 @@ public class CalendarLocalServiceUtil {
 		return getService().getPersistedModel(primaryKeyObj);
 	}
 
+	public static boolean hasStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return getService().hasStagingCalendar(calendar);
+	}
+
 	public static void importCalendar(long calendarId, java.lang.String data,
 		java.lang.String type) throws java.lang.Exception {
 		getService().importCalendar(calendarId, data, type);
+	}
+
+	public static boolean isStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar) {
+		return getService().isStagingCalendar(calendar);
 	}
 
 	public static java.util.List<com.liferay.calendar.model.Calendar> search(

--- a/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceWrapper.java
+++ b/modules/apps/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarLocalServiceWrapper.java
@@ -350,9 +350,22 @@ public class CalendarLocalServiceWrapper implements CalendarLocalService,
 	}
 
 	@Override
+	public boolean hasStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		return _calendarLocalService.hasStagingCalendar(calendar);
+	}
+
+	@Override
 	public void importCalendar(long calendarId, java.lang.String data,
 		java.lang.String type) throws java.lang.Exception {
 		_calendarLocalService.importCalendar(calendarId, data, type);
+	}
+
+	@Override
+	public boolean isStagingCalendar(
+		com.liferay.calendar.model.Calendar calendar) {
+		return _calendarLocalService.isStagingCalendar(calendar);
 	}
 
 	@Override

--- a/modules/apps/calendar/calendar-service/src/main/resources/service.properties
+++ b/modules/apps/calendar/calendar-service/src/main/resources/service.properties
@@ -13,6 +13,6 @@
 ##
 
     build.namespace=Calendar
-    build.number=4
-    build.date=1424703239325
+    build.number=5
+    build.date=1452035698216
     build.auto.upgrade=true

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/edit_calendar_booking.jsp
@@ -171,6 +171,16 @@ if (guestCalendarResource != null) {
 
 long[] otherCalendarIds = StringUtil.split(SessionClicks.get(request, "com.liferay.calendar.web_otherCalendars", StringPool.BLANK), 0L);
 
+Iterator<Calendar> itr = manageableCalendars.iterator();
+
+while (itr.hasNext()) {
+	Calendar curCalendar = itr.next();
+
+	if (CalendarLocalServiceUtil.hasStagingCalendar(curCalendar) || (CalendarLocalServiceUtil.isStagingCalendar(curCalendar) && (curCalendar.getGroupId() != themeDisplay.getScopeGroupId()))) {
+		itr.remove();
+	}
+}
+
 for (long otherCalendarId : otherCalendarIds) {
 	Calendar otherCalendar = CalendarServiceUtil.fetchCalendar(otherCalendarId);
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/init.jsp
@@ -50,6 +50,7 @@ page import="com.liferay.calendar.recurrence.Recurrence" %><%@
 page import="com.liferay.calendar.recurrence.Weekday" %><%@
 page import="com.liferay.calendar.service.CalendarBookingLocalServiceUtil" %><%@
 page import="com.liferay.calendar.service.CalendarBookingServiceUtil" %><%@
+page import="com.liferay.calendar.service.CalendarLocalServiceUtil" %><%@
 page import="com.liferay.calendar.service.CalendarNotificationTemplateLocalServiceUtil" %><%@
 page import="com.liferay.calendar.service.CalendarResourceServiceUtil" %><%@
 page import="com.liferay.calendar.service.CalendarServiceUtil" %><%@


### PR DESCRIPTION
Hey Jonathan,

I tried to modify the fix to have it work the way you suggested on [my previous PR](https://github.com/jonathanmccann/liferay-portal/pull/901). However, I needed to make sure that the user selected calendars to be staged when they set the staging configuration. To do this, I had to use a method to see if a calendar existed with the staged GroupId, but the only method available to do this was fetchCalendarByUuidAndGroupId. I discussed it with Andrew, and he thinks that it is intentional that the staged version of a calendar has the same UUID as the live version, so I took advantage of that when calling the method.