### PR TITLE
LPS 61008

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -409,6 +409,7 @@ public abstract class BaseDB implements DB {
 				}
 				else {
 					sb.append(line);
+					sb.append(StringPool.NEW_LINE);
 
 					if (line.endsWith(";")) {
 						String sql = sb.toString();
@@ -760,7 +761,7 @@ public abstract class BaseDB implements DB {
 				}
 			}
 			else if (!tablesSQLLowerCase.contains(
-						"create table " + tableNameLowerCase + " (")) {
+						CREATE_TABLE + tableNameLowerCase + " (")) {
 
 				continue;
 			}
@@ -969,7 +970,7 @@ public abstract class BaseDB implements DB {
 
 					String[] columns = StringUtil.split(line.substring(x, y));
 
-					x = portalData.indexOf("create table " + table + " (");
+					x = portalData.indexOf(CREATE_TABLE + table + " (");
 					y = portalData.indexOf(");", x);
 
 					String portalTableData = portalData.substring(x, y);
@@ -1096,6 +1097,8 @@ public abstract class BaseDB implements DB {
 	protected static final String ALTER_COLUMN_TYPE = "alter_column_type ";
 
 	protected static final String ALTER_TABLE_NAME = "alter_table_name ";
+
+	protected static final String CREATE_TABLE = "create table ";
 
 	protected static final String DROP_INDEX = "drop index";
 

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
@@ -130,6 +131,59 @@ public class PostgreSQLDB extends BaseDB {
 		return sb.toString();
 	}
 
+	protected String getCreateRulesSql(String table, String column) {
+		StringBundler sb = new StringBundler(45);
+
+		sb.append("create or replace rule delete_");
+		sb.append(table);
+		sb.append(StringPool.UNDERLINE);
+		sb.append(column);
+		sb.append(" as on delete to ");
+		sb.append(table);
+		sb.append(" do also select case when exists( select 1 from ");
+		sb.append("pg_catalog.pg_largeobject where (loid = old.");
+		sb.append(column);
+		sb.append(")) then lo_unlink(old.");
+		sb.append(column);
+		sb.append(") end from ");
+		sb.append(table);
+		sb.append(" where ");
+		sb.append(table);
+		sb.append(StringPool.PERIOD);
+		sb.append(column);
+		sb.append(" = old.");
+		sb.append(column);
+
+		sb.append(";\ncreate or replace rule update_");
+		sb.append(table);
+		sb.append(StringPool.UNDERLINE);
+		sb.append(column);
+		sb.append(" as on update to ");
+		sb.append(table);
+		sb.append(" where old.");
+		sb.append(column);
+		sb.append(" is distinct from new.");
+		sb.append(column);
+		sb.append(" and old.");
+		sb.append(column);
+		sb.append(" is not null do also select case when exists( select 1 ");
+		sb.append("from pg_catalog.pg_largeobject where (loid = old.");
+		sb.append(column);
+		sb.append(")) then lo_unlink(old.");
+		sb.append(column);
+		sb.append(") end from ");
+		sb.append(table);
+		sb.append(" where ");
+		sb.append(table);
+		sb.append(StringPool.PERIOD);
+		sb.append(column);
+		sb.append(" = old.");
+		sb.append(column);
+		sb.append(StringPool.SEMICOLON);
+
+		return sb.toString();
+	}
+
 	@Override
 	protected String getServerName() {
 		return "postgresql";
@@ -140,6 +194,10 @@ public class PostgreSQLDB extends BaseDB {
 		return _POSTGRESQL;
 	}
 
+	protected String getTemplateBlob() {
+		return getTemplate()[5];
+	}
+
 	@Override
 	protected String reword(String data) throws IOException {
 		try (UnsyncBufferedReader unsyncBufferedReader =
@@ -148,6 +206,10 @@ public class PostgreSQLDB extends BaseDB {
 			StringBundler sb = new StringBundler();
 
 			String line = null;
+
+			String table = null;
+
+			StringBundler createRulesSqlSB = new StringBundler();
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				if (line.startsWith(ALTER_COLUMN_NAME)) {
@@ -173,6 +235,11 @@ public class PostgreSQLDB extends BaseDB {
 						"alter table @old-table@ rename to @new-table@;",
 						RENAME_TABLE_TEMPLATE, template);
 				}
+				else if (line.startsWith(CREATE_TABLE)) {
+					String[] tokens = StringUtil.split(line, ' ');
+
+					table = tokens[2];
+				}
 				else if (line.contains(DROP_INDEX)) {
 					String[] tokens = StringUtil.split(line, ' ');
 
@@ -186,6 +253,13 @@ public class PostgreSQLDB extends BaseDB {
 						"alter table @table@ drop constraint @table@_pkey;",
 						"@table@", tokens[2]);
 				}
+				else if (line.contains(getTemplateBlob())) {
+					String[] tokens = StringUtil.split(line, ' ');
+
+					createRulesSqlSB.append(StringPool.NEW_LINE);
+					createRulesSqlSB.append(
+						getCreateRulesSql(table, tokens[0]));
+				}
 				else if (line.contains("\\\'")) {
 					line = StringUtil.replace(line, "\\\'", "\'\'");
 				}
@@ -193,6 +267,8 @@ public class PostgreSQLDB extends BaseDB {
 				sb.append(line);
 				sb.append("\n");
 			}
+
+			sb.append(createRulesSqlSB.toString());
 
 			return sb.toString();
 		}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyPostgreSQL.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyPostgreSQL.java
@@ -1,0 +1,249 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.verify;
+
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Michael Bowerman
+ */
+public class VerifyPostgreSQL extends VerifyProcess {
+
+	protected void addRule(
+			Statement statement, String ruleName, String tableName,
+			String columnName)
+		throws SQLException {
+
+		String[] tokens = StringUtil.split(ruleName, StringPool.UNDERLINE);
+
+		String ruleType = tokens[0];
+
+		StringBundler sb = new StringBundler();
+
+		if (ruleType.equals(_RULE_TYPE_DELETE)) {
+			sb.append("create or replace rule ");
+			sb.append(ruleName);
+			sb.append(" as on delete to ");
+			sb.append(tableName);
+			sb.append(" do also select case when exists( select 1 from ");
+			sb.append("pg_catalog.pg_largeobject where (loid = old.");
+			sb.append(columnName);
+			sb.append(")) then lo_unlink(old.");
+			sb.append(columnName);
+			sb.append(") end from ");
+			sb.append(tableName);
+			sb.append(" where ");
+			sb.append(tableName);
+			sb.append(StringPool.PERIOD);
+			sb.append(columnName);
+			sb.append(" = old.");
+			sb.append(columnName);
+			sb.append(StringPool.SEMICOLON);
+		}
+		else if (ruleType.equals(_RULE_TYPE_UPDATE)) {
+			sb.append("create or replace rule ");
+			sb.append(ruleName);
+			sb.append(" as on update to ");
+			sb.append(tableName);
+			sb.append(" where old.");
+			sb.append(columnName);
+			sb.append(" is distinct from new.");
+			sb.append(columnName);
+			sb.append(" and old.");
+			sb.append(columnName);
+			sb.append(" is not null do also select case when exists( select ");
+			sb.append("1 from pg_catalog.pg_largeobject where (loid = old.");
+			sb.append(columnName);
+			sb.append(")) then lo_unlink(old.");
+			sb.append(columnName);
+			sb.append(") end from ");
+			sb.append(tableName);
+			sb.append(" where ");
+			sb.append(tableName);
+			sb.append(StringPool.PERIOD);
+			sb.append(columnName);
+			sb.append(" = old.");
+			sb.append(columnName);
+			sb.append(StringPool.SEMICOLON);
+		}
+		else {
+			if (_log.isErrorEnabled()) {
+				StringBundler errorSB = new StringBundler();
+
+				errorSB.append("Unknown rule type: ");
+				errorSB.append(ruleType);
+				errorSB.append(". The following rule will not be added: ");
+				errorSB.append(ruleName);
+
+				_log.error(errorSB.toString());
+
+				return;
+			}
+		}
+
+		statement.execute(sb.toString());
+	}
+
+	protected void deleteOrphanedLargeObjects(
+			Statement statement, HashMap<String, String> columnsWithOids)
+		throws SQLException {
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("select lo_unlink(l.loid) from pg_largeobject l group by ");
+		sb.append("loid having ");
+
+		int count = 1;
+		int size = columnsWithOids.size();
+
+		for (Map.Entry<String, String> column : columnsWithOids.entrySet()) {
+			String tableName = column.getKey();
+			String columnName = column.getValue();
+
+			sb.append("(not exists (select 1 from ");
+			sb.append(tableName);
+			sb.append(" t where t.");
+			sb.append(columnName);
+			sb.append(" = l.loid))");
+
+			if (count < size) {
+				sb.append(" and ");
+			}
+
+			count++;
+		}
+
+		if (_log.isInfoEnabled()) {
+			_log.info("Deleting orphaned large objects");
+		}
+
+		statement.execute(sb.toString());
+	}
+
+	@Override
+	protected void doVerify() throws Exception {
+		DB db = DBManagerUtil.getDB();
+
+		if (db.getDBType() != DBType.POSTGRESQL) {
+			return;
+		}
+
+		Statement statement = connection.createStatement();
+
+		HashMap<String, String> columnsWithOids = getColumnsWithOids(statement);
+
+		verifyRules(statement, columnsWithOids);
+		deleteOrphanedLargeObjects(statement, columnsWithOids);
+	}
+
+	protected HashMap<String, String> getColumnsWithOids(Statement statement)
+		throws SQLException {
+
+		HashMap<String, String> columnsWithOids = new HashMap<>();
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append("select table_name, column_name from ");
+		sb.append("information_schema.columns where table_schema='public' ");
+		sb.append("and data_type='oid';");
+
+		ResultSet rs = null;
+
+		rs = statement.executeQuery(sb.toString());
+
+		while (rs.next()) {
+			String table = (String)rs.getObject("table_name");
+			String column = (String)rs.getObject("column_name");
+
+			columnsWithOids.put(table, column);
+		}
+
+		return columnsWithOids;
+	}
+
+	protected void verifyRules(
+			Statement statement, HashMap<String, String> columnsWithOids)
+		throws SQLException {
+
+		ResultSet rs = null;
+
+		for (Map.Entry<String, String> column : columnsWithOids.entrySet()) {
+			String tableName = column.getKey();
+			String columnName = column.getValue();
+
+			StringBundler deleteRuleSB = new StringBundler(5);
+			deleteRuleSB.append(_RULE_TYPE_DELETE);
+			deleteRuleSB.append(StringPool.UNDERLINE);
+			deleteRuleSB.append(tableName);
+			deleteRuleSB.append(StringPool.UNDERLINE);
+			deleteRuleSB.append(columnName);
+
+			StringBundler updateRuleSB = new StringBundler(5);
+			updateRuleSB.append(_RULE_TYPE_UPDATE);
+			updateRuleSB.append(StringPool.UNDERLINE);
+			updateRuleSB.append(tableName);
+			updateRuleSB.append(StringPool.UNDERLINE);
+			updateRuleSB.append(columnName);
+
+			List<String> ruleList = new ArrayList<>();
+
+			ruleList.add(deleteRuleSB.toString());
+			ruleList.add(updateRuleSB.toString());
+
+			for (String ruleName : ruleList) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append("select * from pg_catalog.pg_rules where rulename ");
+				sb.append("= lower ('");
+				sb.append(ruleName);
+				sb.append("')");
+
+				rs = statement.executeQuery(sb.toString());
+
+				if (!rs.next()) {
+					if (_log.isInfoEnabled()) {
+						_log.info("Adding the following rule: " + ruleName);
+					}
+
+					addRule(statement, ruleName, tableName, columnName);
+				}
+			}
+		}
+	}
+
+	private static final String _RULE_TYPE_DELETE = "delete";
+
+	private static final String _RULE_TYPE_UPDATE = "update";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		VerifyPostgreSQL.class);
+
+}

--- a/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
+++ b/portal-impl/src/com/liferay/portal/verify/VerifyProcessSuite.java
@@ -26,6 +26,7 @@ public class VerifyProcessSuite extends VerifyProcess {
 		verify(new VerifyDB2());
 		verify(new VerifyMySQL());
 		verify(new VerifyOracle());
+		verify(new VerifyPostgreSQL());
 		verify(new VerifySQLServer());
 
 		verify(new VerifyUUID());


### PR DESCRIPTION
Hey Jonathan,

This is the same LPS from several weeks ago in which I tried to modify the Service Builder. Brian Chan reviewed my previous fix and wanted me to take a different approach in which I modify the Postgres reword method to add in the rules automatically when it detects a table with an oid, rather than generating a separate rules.sql file. This is my pull request for that approach.

The only table in Liferay that has an oid is DLContent, but I wrote my methods in such a way that they will work for any tables with oids, even if there are multiple. To test that they worked properly, I tried manually editing an oid column into a few tables and verified that everything worked as expected.