### PR TITLE
LPS-61008

### DIFF
--- a/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/BaseDB.java
@@ -185,6 +185,11 @@ public abstract class BaseDB implements DB {
 	}
 
 	@Override
+	public String getTemplateBlob() {
+		return getTemplate()[5];
+	}
+
+	@Override
 	public String getTemplateFalse() {
 		return getTemplate()[2];
 	}
@@ -409,6 +414,7 @@ public abstract class BaseDB implements DB {
 				}
 				else {
 					sb.append(line);
+					sb.append(StringPool.NEW_LINE);
 
 					if (line.endsWith(";")) {
 						String sql = sb.toString();
@@ -760,7 +766,7 @@ public abstract class BaseDB implements DB {
 				}
 			}
 			else if (!tablesSQLLowerCase.contains(
-						"create table " + tableNameLowerCase + " (")) {
+						CREATE_TABLE + tableNameLowerCase + " (")) {
 
 				continue;
 			}
@@ -969,7 +975,7 @@ public abstract class BaseDB implements DB {
 
 					String[] columns = StringUtil.split(line.substring(x, y));
 
-					x = portalData.indexOf("create table " + table + " (");
+					x = portalData.indexOf(CREATE_TABLE + table + " (");
 					y = portalData.indexOf(");", x);
 
 					String portalTableData = portalData.substring(x, y);
@@ -1096,6 +1102,8 @@ public abstract class BaseDB implements DB {
 	protected static final String ALTER_COLUMN_TYPE = "alter_column_type ";
 
 	protected static final String ALTER_TABLE_NAME = "alter_table_name ";
+
+	protected static final String CREATE_TABLE = "create table ";
 
 	protected static final String DROP_INDEX = "drop index";
 

--- a/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
+++ b/portal-impl/src/com/liferay/portal/dao/db/PostgreSQLDB.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.io.unsync.UnsyncBufferedReader;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringReader;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 
 import java.io.IOException;
@@ -130,6 +131,59 @@ public class PostgreSQLDB extends BaseDB {
 		return sb.toString();
 	}
 
+	protected String getCreateRulesSql(String table, String column) {
+		StringBundler sb = new StringBundler(45);
+
+		sb.append("create or replace rule delete_");
+		sb.append(table);
+		sb.append(StringPool.UNDERLINE);
+		sb.append(column);
+		sb.append(" as on delete to ");
+		sb.append(table);
+		sb.append(" do also select case when exists( select 1 from ");
+		sb.append("pg_catalog.pg_largeobject where (loid = old.");
+		sb.append(column);
+		sb.append(")) then lo_unlink(old.");
+		sb.append(column);
+		sb.append(") end from ");
+		sb.append(table);
+		sb.append(" where ");
+		sb.append(table);
+		sb.append(StringPool.PERIOD);
+		sb.append(column);
+		sb.append(" = old.");
+		sb.append(column);
+
+		sb.append(";\ncreate or replace rule update_");
+		sb.append(table);
+		sb.append(StringPool.UNDERLINE);
+		sb.append(column);
+		sb.append(" as on update to ");
+		sb.append(table);
+		sb.append(" where old.");
+		sb.append(column);
+		sb.append(" is distinct from new.");
+		sb.append(column);
+		sb.append(" and old.");
+		sb.append(column);
+		sb.append(" is not null do also select case when exists( select 1 ");
+		sb.append("from pg_catalog.pg_largeobject where (loid = old.");
+		sb.append(column);
+		sb.append(")) then lo_unlink(old.");
+		sb.append(column);
+		sb.append(") end from ");
+		sb.append(table);
+		sb.append(" where ");
+		sb.append(table);
+		sb.append(StringPool.PERIOD);
+		sb.append(column);
+		sb.append(" = old.");
+		sb.append(column);
+		sb.append(StringPool.SEMICOLON);
+
+		return sb.toString();
+	}
+
 	@Override
 	protected String getServerName() {
 		return "postgresql";
@@ -148,6 +202,10 @@ public class PostgreSQLDB extends BaseDB {
 			StringBundler sb = new StringBundler();
 
 			String line = null;
+
+			String table = null;
+
+			StringBundler createRulesSqlSB = new StringBundler();
 
 			while ((line = unsyncBufferedReader.readLine()) != null) {
 				if (line.startsWith(ALTER_COLUMN_NAME)) {
@@ -173,6 +231,11 @@ public class PostgreSQLDB extends BaseDB {
 						"alter table @old-table@ rename to @new-table@;",
 						RENAME_TABLE_TEMPLATE, template);
 				}
+				else if (line.startsWith(CREATE_TABLE)) {
+					String[] tokens = StringUtil.split(line, ' ');
+
+					table = tokens[2];
+				}
 				else if (line.contains(DROP_INDEX)) {
 					String[] tokens = StringUtil.split(line, ' ');
 
@@ -186,6 +249,13 @@ public class PostgreSQLDB extends BaseDB {
 						"alter table @table@ drop constraint @table@_pkey;",
 						"@table@", tokens[2]);
 				}
+				else if (line.contains(getTemplateBlob())) {
+					String[] tokens = StringUtil.split(line, ' ');
+
+					createRulesSqlSB.append(StringPool.NEW_LINE);
+					createRulesSqlSB.append(
+						getCreateRulesSql(table, tokens[0]));
+				}
 				else if (line.contains("\\\'")) {
 					line = StringUtil.replace(line, "\\\'", "\'\'");
 				}
@@ -193,6 +263,8 @@ public class PostgreSQLDB extends BaseDB {
 				sb.append(line);
 				sb.append("\n");
 			}
+
+			sb.append(createRulesSqlSB.toString());
 
 			return sb.toString();
 		}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeDocumentLibrary.java
@@ -14,6 +14,9 @@
 
 package com.liferay.portal.upgrade.v7_0_0;
 
+import com.liferay.portal.kernel.dao.db.DB;
+import com.liferay.portal.kernel.dao.db.DBManagerUtil;
+import com.liferay.portal.kernel.dao.db.DBType;
 import com.liferay.portal.kernel.dao.jdbc.DataAccess;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -111,6 +114,15 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		}
 
 		updateRepositoryClassNameIds();
+
+		DB db = DBManagerUtil.getDB();
+
+		if (db.getDBType() == DBType.POSTGRESQL) {
+			updatePostgreSQLDeleteRule();
+			updatePostgreSQLUpdateRule();
+
+			updatePostgreSQLLargeObjects();
+		}
 	}
 
 	protected boolean hasFileEntry(long groupId, long folderId, String fileName)
@@ -517,6 +529,101 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 		}
 		finally {
 			DataAccess.cleanUp(ps, rs);
+		}
+	}
+
+	protected void updatePostgreSQLDeleteRule() throws Exception {
+
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			ps = connection.prepareStatement(
+				"select * from pg_catalog.pg_rules where rulename = " +
+					"'update_dlcontent_data_'");
+
+			rs = ps.executeQuery();
+
+			if (!rs.next()) {
+				StringBundler sb = new StringBundler(6);
+
+				sb.append("create or replace rule delete_dlcontent_data_ as ");
+				sb.append("on delete to dlcontent do also select case when ");
+				sb.append("exists (select 1 from pg_catalog.");
+				sb.append("pg_largeobject_metadata where (oid = old.data_)) ");
+				sb.append("then lo_unlink (old.data_) end from dlcontent ");
+				sb.append("where dlcontent.data_ = old.data_;");
+
+				updatePostgreSQLRule(sb.toString());
+			}
+		}
+		finally {
+			DataAccess.cleanUp(ps);
+		}
+	}
+
+	protected void updatePostgreSQLLargeObjects() throws Exception {
+
+		PreparedStatement ps = null;
+
+		StringBundler sb = new StringBundler();
+
+		sb.append("select lo_unlink (l.oid) from pg_largeobject_metadata l ");
+		sb.append("where (not exists (select 1 from dlcontent t where ");
+		sb.append("t.data_ = l.oid))");
+
+		try {
+			ps = connection.prepareStatement(sb.toString());
+
+			ps.execute();
+		}
+		finally {
+			DataAccess.cleanUp(ps);
+		}
+	}
+
+	protected void updatePostgreSQLRule(String sql) throws Exception {
+
+		PreparedStatement ps = null;
+
+		try {
+			ps = connection.prepareStatement(sql);
+
+			ps.executeUpdate();
+		}
+		finally {
+			DataAccess.cleanUp(ps);
+		}
+	}
+
+	protected void updatePostgreSQLUpdateRule() throws Exception {
+
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			ps = connection.prepareStatement(
+				"select * from pg_catalog.pg_rules where rulename = " +
+					"'update_dlcontent_data_'");
+
+			rs = ps.executeQuery();
+
+			if (!rs.next()) {
+				StringBundler sb = new StringBundler(7);
+
+				sb.append("create or replace rule update_dlcontent_data_ as ");
+				sb.append("on update to dlcontent where old.data_ is ");
+				sb.append("distinct from new.data_ and old.data_ is not null ");
+				sb.append("do also select case when exists (select 1 from ");
+				sb.append("pg_catalog.pg_largeobject_metadata where (oid = ");
+				sb.append("old.data_)) then lo_unlink (old.data_) end from ");
+				sb.append("dlcontent where dlcontent.data_ = old.data_;");
+
+				updatePostgreSQLRule(sb.toString());
+			}
+		}
+		finally {
+			DataAccess.cleanUp(ps);
 		}
 	}
 

--- a/portal-service/src/com/liferay/portal/kernel/dao/db/DB.java
+++ b/portal-service/src/com/liferay/portal/kernel/dao/db/DB.java
@@ -59,6 +59,8 @@ public interface DB {
 
 	public int getMinorVersion();
 
+	public String getTemplateBlob();
+
 	public String getTemplateFalse();
 
 	public String getTemplateTrue();


### PR DESCRIPTION
I don't really like this. If the user has some custom oid columns in their database, this will delete largeobject data that is associated with them. I have another version that gets all the columns with oids and and uses that information when it calls the lo_unlink command, but I don't like that version either because UpdateDocumentLibrary no longer seems like an appropriate place to put it.

Also, our upgrade process seems to be broken, so I wasn't fully able to test this. By commenting a bunch of lines out so that it only ran my methods, I was able to determine that "updatePostgreSQLLargeObjects" worked as expected, and that the rules were added. However, the database wouldn't start, so I couldn't verify that the rules worked as intended. I did look at the rule definitions by going into the table, and compared them to the rule definitions of another one of my test database's rules that I knew worked, and they looked identical. So they should work.