### PR TITLE
[Technical Support] LPS-64945

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
+++ b/modules/apps/forms-and-workflow/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
@@ -1642,6 +1642,10 @@ AUI.add(
 									uri: Lang.sub(editCalendarBookingURL, data)
 								}
 							);
+
+							if (A.UA.ie) {
+								Liferay.Util.focusFormField('input:text');
+							}
 						}
 					},
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-64945

I put the function call inside the if-statement because other browsers already run the function. Without the if-statement, other browsers would run the function twice and with it all browsers will run it once.