### PR TITLE
[TECHNICAL-SUPPORT] LPS-66730

### DIFF
--- a/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/blogs/service/impl/BlogsEntryLocalServiceImpl.java
@@ -1101,14 +1101,6 @@ public class BlogsEntryLocalServiceImpl extends BlogsEntryLocalServiceBaseImpl {
 
 		blogsEntryPersistence.update(entry);
 
-		// Resources
-
-		if ((serviceContext.getGroupPermissions() != null) ||
-			(serviceContext.getGuestPermissions() != null)) {
-
-			updateEntryResources(entry, serviceContext.getModelPermissions());
-		}
-
 		// Asset
 
 		updateAsset(


### PR DESCRIPTION
/cc @mbowerman

From Michael:
>I think a more ideal fix would be to make it so that the serviceContext gets the modelPermissions from the previous version of the blog entry. However, the fix that I have submitted is consistent with the behavior in other parts of the portal (e.g. Document Library, Wiki). For instance, If you update a wiki article, the serviceContext will be generated with default group and guest permissions (as opposed to the group and guest permissions for that specific Wiki Article), but these permissions never actually get read by the update method. I tried to replicate that here.