### PR TITLE
LPS-66693 Fix XSS bug with IE

### DIFF
--- a/modules/apps/foundation/portal/portal-monitoring/src/main/java/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringBottomDynamicInclude.java
+++ b/modules/apps/foundation/portal/portal-monitoring/src/main/java/com/liferay/portal/monitoring/internal/servlet/taglib/MonitoringBottomDynamicInclude.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.monitoring.configuration.MonitoringConfiguration;
 import com.liferay.portal.monitoring.constants.MonitoringWebKeys;
 import com.liferay.portal.monitoring.internal.statistics.portal.PortalRequestDataSample;
+import com.liferay.portal.kernel.util.HtmlUtil;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -83,7 +84,7 @@ public class MonitoringBottomDynamicInclude extends BaseDynamicInclude {
 		sb.append("<!--\n");
 
 		for (DataSample curDataSample : dataSamples) {
-			sb.append(curDataSample.toString());
+			sb.append(HtmlUtil.escape(curDataSample.toString()));
 			sb.append("\n");
 		}
 


### PR DESCRIPTION
Hello Jonathan,

I would like to backport this fix that deals with an XSS bug in Internet Explorer that is causing an alert to show up whenever a string is appended to the end of the URL. The reason why it was happening was because IE doesn't properly escape the URL then leaving the URL to be rendered as HTML. 

By escaping it here, this then handles the referer attribute that was getting rendered as HTML. 

Also, quick question, if this PR gets approved, do I then request to backport this to ee-6.2.x in another ticket or do I just send this pull to Sam Ziemer?

Here is the related ticket: https://issues.liferay.com/browse/LPS-66693

Thanks for your help!

Daniel