### PR TITLE
[TECHNICAL-SUPPORT] LPS-66811

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -1493,7 +1493,7 @@
 	<sql id="com.liferay.portal.kernel.service.persistence.UserFinder.findByC_FN_MN_LN_SN_EA_S">
 		<![CDATA[
 			SELECT
-				DISTINCT User_.userId AS userId, User_.screenName AS screenName, User_.firstName AS firstName, User_.middleName AS middleName, User_.lastName AS lastName, User_.loginDate as loginDate
+				User_.userId AS userId, User_.screenName AS screenName, User_.firstName AS firstName, User_.middleName AS middleName, User_.lastName AS lastName, User_.loginDate as loginDate
 			FROM
 				User_
 			[$JOIN$]


### PR DESCRIPTION
/cc @jgok

From Josh:

> Hi Sam,
> 
> I worked with Preston on this, and he said that the DISTINCT keyword is unnecessary because we have a unique index as part of the result. He said there possibly could be issues with left joins or outer joins, but the left join that I found did not have any issues after removing DISTINCT.
> 
> I was not able to test in master, as DB2 is not supported in master. I was able to test this fix in ee-7.0.x, and I did not see any issues with my change.
> 
> Thanks,
> Josh