### PR TITLE
[TECHNICAL-SUPPORT] LPS-66384

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/util/impl/DDMImpl.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/util/impl/DDMImpl.java
@@ -523,6 +523,10 @@ public class DDMImpl implements DDM {
 		String[] existingFieldsDisplayValues = splitFieldsDisplayValue(
 			existingFields.get(DDMImpl.FIELDS_DISPLAY_NAME));
 
+		if (newFieldsDisplayValues.length == 0) {
+			newFieldsDisplayValues = existingFieldsDisplayValues;
+		}
+
 		Iterator<Field> itr = newFields.iterator(true);
 
 		while (itr.hasNext()) {
@@ -1261,6 +1265,10 @@ public class DDMImpl implements DDM {
 	}
 
 	protected String[] splitFieldsDisplayValue(Field fieldsDisplayField) {
+		if (fieldsDisplayField == null) {
+			return new String[0];
+		}
+
 		String value = (String)fieldsDisplayField.getValue();
 
 		return StringUtil.split(value);


### PR DESCRIPTION
/cc @jgok

Notes from Josh:

>This change is needed to fix a NPE when using the JSONWS to update a DDL record. The NPE is caused because there is no field caused "_fieldsDisplay" when using the web service.

>My changes check for null, and (if null) set the display value as the same as the existing display value, since display values do not need to be changed from the web service call.