### PR TITLE
Lps 65847

### DIFF
--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/init.jsp
@@ -16,4 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
+<%@ page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>
+
 <portlet:defineObjects />

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/image_selector/page.jsp
@@ -55,7 +55,14 @@ if (fileEntryId != 0) {
 		<div class="drag-drop-label">
 			<c:choose>
 				<c:when test="<%= Validator.isNotNull(itemSelectorEventName) && Validator.isNotNull(itemSelectorURL) %>">
-					<liferay-ui:message arguments="<%= selectFileLink %>" key="drag-and-drop-to-upload-or-x" />
+					<c:choose>
+						<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
+							<%= selectFileLink %>
+						</c:when>
+						<c:otherwise>
+							<liferay-ui:message arguments="<%= selectFileLink %>" key="drag-and-drop-to-upload-or-x" />
+						</c:otherwise>
+					</c:choose>
 				</c:when>
 				<c:otherwise>
 					<%= LanguageUtil.get(resourceBundle, "drag-and-drop-to-upload") %>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/init.jsp
@@ -19,4 +19,5 @@
 <%@ page import="com.liferay.portal.kernel.model.Image" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
-page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %>
+page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %>

--- a/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/repository_entry_browser/page.jsp
@@ -177,7 +177,14 @@ if (Validator.isNotNull(keywords)) {
 		</liferay-util:buffer>
 
 		<div class="drop-enabled drop-zone no-border">
-			<strong><liferay-ui:message arguments="<%= selectFileHTML %>" key="drag-and-drop-to-upload-or-x" /></strong>
+			<c:choose>
+				<c:when test="<%= BrowserSnifferUtil.isMobile(request) %>">
+					<%= selectFileHTML %>
+				</c:when>
+				<c:otherwise>
+					<strong><liferay-ui:message arguments="<%= selectFileHTML %>" key="drag-and-drop-to-upload-or-x" /></strong>
+				</c:otherwise>
+			</c:choose>
 		</div>
 	</c:if>
 

--- a/modules/apps/collaboration/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,8 @@
  */
 --%>
 
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
@@ -24,6 +26,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.item.selector.criteria.UploadableFileReturnType" %><%@
 page import="com.liferay.item.selector.upload.web.internal.ItemSelectorUploadView" %><%@
 page import="com.liferay.item.selector.upload.web.internal.display.context.ItemSelectorUploadViewDisplayContext" %><%@
+page import="com.liferay.portal.kernel.servlet.BrowserSnifferUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/collaboration/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
+++ b/modules/apps/collaboration/item-selector/item-selector-upload-web/src/main/resources/META-INF/resources/upload.jsp
@@ -23,9 +23,13 @@ ItemSelectorUploadViewDisplayContext itemSelectorUploadViewDisplayContext = (Ite
 <div class="container-fluid-1280 lfr-item-viewer" id="itemSelectorUploadContainer">
 	<div class="drop-enabled drop-zone upload-view">
 		<div id="uploadDescription">
-			<p>
-				<strong><liferay-ui:message arguments="<%= itemSelectorUploadViewDisplayContext.getRepositoryName() %>" key="drag-and-drop-to-upload-to-x-or" /></strong>
-			</p>
+			<c:choose>
+				<c:when test="<%= !BrowserSnifferUtil.isMobile(request) %>">
+					<p>
+						<strong><liferay-ui:message arguments="<%= itemSelectorUploadViewDisplayContext.getRepositoryName() %>" key="drag-and-drop-to-upload-to-x-or" /></strong>
+					</p>
+				</c:when>
+			</c:choose>
 
 			<p>
 				<label class="btn btn-default" for="<portlet:namespace />inputFile"><liferay-ui:message key="select-file" /></label>

--- a/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_image_selector.scss
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/taglib/_image_selector.scss
@@ -57,3 +57,13 @@
 		}
 	}
 }
+
+.mobile .taglib-image-selector {
+	.glyphicon-ok {
+		display: none;
+	}
+
+	&.check-active .glyphicon-ok {
+		display: block;
+	}
+}


### PR DESCRIPTION
**Retry PR:**
jonathanmccann/liferay-portal#1013

**Old Notes:**

This fix is for master. The drag and drop text is removed from three different locations according to:
https://issues.liferay.com/browse/LPS-65847

Also note the front-end change too. Upon removing the text, a glyphicon blocked the way of the Select File button. Using display: none; hides it from view.