### PR TITLE
[TECHNICAL-SUPPORT] LPS-67176

### DIFF
--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -48,11 +48,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.StreamUtil;
-import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.*;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
@@ -432,6 +428,16 @@ public class S3Store extends BaseStore {
 		AWSCredentialsProvider awsCredentialsProvider) {
 
 		ClientConfiguration clientConfiguration = getClientConfiguration();
+
+		String proxyHost = GetterUtil.getString(
+			SystemProperties.get("http.proxyHost"));
+		int proxyPort = GetterUtil.getInteger(
+			SystemProperties.get("http.proxyPort"));
+
+		if (Validator.isNotNull(proxyHost) && Validator.isNotNull(proxyPort)) {
+			clientConfiguration.setProxyHost(proxyHost);
+			clientConfiguration.setProxyPort(proxyPort);
+		}
 
 		AmazonS3 amazonS3 = new AmazonS3Client(
 			awsCredentialsProvider, clientConfiguration);


### PR DESCRIPTION
/cc @Alec-Shay

Notes from Alec:

> https://issues.liferay.com/browse/LPS-67176
> https://issues.liferay.com/browse/LPP-21931
> 
> Although we allow configuring Liferay with a forward proxy, we have not implemented using it with S3, although clients should be able to expect this. Some clients must connect using a proxy.
> 
> I implemented it with just the basic configurations (copied the logic of using different proxy authorization types from HttpImpl), but it's possible there are more configuration options we could add as well that I just wasn't sure whether we already have options for, as I noted on the LPS (the web.server.protocol property?). I tested using Apache web server for a proxy, and enabling it as a proxy and for using HTTPS (which seems to be the default S3 will use).