### PR TITLE
LPS-67176

### DIFF
--- a/modules/apps/foundation/portal-store/portal-store-s3/build.gradle
+++ b/modules/apps/foundation/portal-store/portal-store-s3/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	provided group: "com.fasterxml.jackson.core", name: "jackson-core", version: "2.5.3"
 	provided group: "com.fasterxml.jackson.core", name: "jackson-databind", version: "2.5.3"
 	provided group: "com.liferay", name: "com.liferay.portal.configuration.metatype", version: "2.0.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.0.0"
 	provided group: "commons-codec", name: "commons-codec", version: "1.6"
 	provided group: "commons-logging", name: "commons-logging", version: "1.2"

--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -48,11 +48,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.CharPool;
-import com.liferay.portal.kernel.util.StreamUtil;
-import com.liferay.portal.kernel.util.StringBundler;
-import com.liferay.portal.kernel.util.StringPool;
-import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.*;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
@@ -432,6 +428,16 @@ public class S3Store extends BaseStore {
 		AWSCredentialsProvider awsCredentialsProvider) {
 
 		ClientConfiguration clientConfiguration = getClientConfiguration();
+
+		String proxyHost = GetterUtil.getString(
+			SystemProperties.get("http.proxyHost"));
+		int proxyPort = GetterUtil.getInteger(
+			SystemProperties.get("http.proxyPort"));
+
+		if (Validator.isNotNull(proxyHost) && Validator.isNotNull(proxyPort)) {
+			clientConfiguration.setProxyHost(proxyHost);
+			clientConfiguration.setProxyPort(proxyPort);
+		}
 
 		AmazonS3 amazonS3 = new AmazonS3Client(
 			awsCredentialsProvider, clientConfiguration);

--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -50,13 +50,13 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.CharPool;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.SystemProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.File;
 import java.io.IOException;
@@ -655,19 +655,13 @@ public class S3Store extends BaseStore {
 		clientConfiguration.setProxyHost(proxyHost);
 		clientConfiguration.setProxyPort(proxyPort);
 
-		String proxyAuthType = GetterUtil.getString(
-			PropsUtil.get("com.liferay.portal.util.HttpImpl.proxy.auth.type"));
+		String proxyAuthType = PropsValues.HTTP_IMPL_PROXY_AUTH_TYPE;
 
-		String proxyPassword = GetterUtil.getString(
-			PropsUtil.get("com.liferay.portal.util.HttpImpl.proxy.password"));
-		String proxyUsername = GetterUtil.getString(
-			PropsUtil.get("com.liferay.portal.util.HttpImpl.proxy.username"));
+		String proxyPassword = PropsValues.HTTP_IMPL_PROXY_PASSWORD;
+		String proxyUsername = PropsValues.HTTP_IMPL_PROXY_USERNAME;
 
-		String ntlmProxyDomain = GetterUtil.getString(
-			PropsUtil.get(
-				"com.liferay.portal.util.HttpImpl.proxy.ntlm.domain"));
-		String ntlmProxyHost = GetterUtil.getString(
-			PropsUtil.get("com.liferay.portal.util.HttpImpl.proxy.ntlm.host"));
+		String ntlmProxyDomain = PropsValues.HTTP_IMPL_PROXY_NTLM_DOMAIN;
+		String ntlmProxyHost = PropsValues.HTTP_IMPL_PROXY_NTLM_HOST;
 
 		if ((proxyAuthType != null) &&
 			proxyAuthType.equals("username-password") &&

--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -436,6 +436,10 @@ public class S3Store extends BaseStore {
 
 		ClientConfiguration clientConfiguration = getClientConfiguration();
 
+		int connectionTimeout = PropsValues.HTTP_IMPL_TIMEOUT;
+
+		clientConfiguration.setConnectionTimeout(connectionTimeout);
+
 		setProxyConfiguration(clientConfiguration);
 
 		AmazonS3 amazonS3 = new AmazonS3Client(

--- a/portal-impl/src/com/liferay/portal/util/HttpImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HttpImpl.java
@@ -1762,41 +1762,39 @@ public class HttpImpl implements Http {
 
 	private static final int _MAX_BYTE_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
 
-	private static final int _MAX_CONNECTIONS_PER_HOST = GetterUtil.getInteger(
-		PropsUtil.get(HttpImpl.class.getName() + ".max.connections.per.host"),
-		2);
+	private static final int _MAX_CONNECTIONS_PER_HOST =
+		PropsValues.HTTP_IMPL_MAX_CONNECTIONS_PER_HOST;
 
-	private static final int _MAX_TOTAL_CONNECTIONS = GetterUtil.getInteger(
-		PropsUtil.get(HttpImpl.class.getName() + ".max.total.connections"), 20);
+	private static final int _MAX_TOTAL_CONNECTIONS =
+		PropsValues.HTTP_IMPL_MAX_TOTAL_CONNECTIONS;
 
 	private static final String _NON_PROXY_HOSTS = SystemProperties.get(
 		"http.nonProxyHosts");
 
-	private static final String _PROXY_AUTH_TYPE = GetterUtil.getString(
-		PropsUtil.get(HttpImpl.class.getName() + ".proxy.auth.type"));
+	private static final String _PROXY_AUTH_TYPE =
+		PropsValues.HTTP_IMPL_PROXY_AUTH_TYPE;
 
 	private static final String _PROXY_HOST = GetterUtil.getString(
 		SystemProperties.get("http.proxyHost"));
 
-	private static final String _PROXY_NTLM_DOMAIN = GetterUtil.getString(
-		PropsUtil.get(HttpImpl.class.getName() + ".proxy.ntlm.domain"));
+	private static final String _PROXY_NTLM_DOMAIN =
+		PropsValues.HTTP_IMPL_PROXY_NTLM_DOMAIN;
 
-	private static final String _PROXY_NTLM_HOST = GetterUtil.getString(
-		PropsUtil.get(HttpImpl.class.getName() + ".proxy.ntlm.host"));
+	private static final String _PROXY_NTLM_HOST =
+		PropsValues.HTTP_IMPL_PROXY_NTLM_HOST;
 
-	private static final String _PROXY_PASSWORD = GetterUtil.getString(
-		PropsUtil.get(HttpImpl.class.getName() + ".proxy.password"));
+	private static final String _PROXY_PASSWORD =
+		PropsValues.HTTP_IMPL_PROXY_PASSWORD;
 
 	private static final int _PROXY_PORT = GetterUtil.getInteger(
 		SystemProperties.get("http.proxyPort"));
 
-	private static final String _PROXY_USERNAME = GetterUtil.getString(
-		PropsUtil.get(HttpImpl.class.getName() + ".proxy.username"));
+	private static final String _PROXY_USERNAME =
+		PropsValues.HTTP_IMPL_PROXY_USERNAME;
 
 	private static final String _TEMP_SLASH = "_LIFERAY_TEMP_SLASH_";
 
-	private static final int _TIMEOUT = GetterUtil.getInteger(
-		PropsUtil.get(HttpImpl.class.getName() + ".timeout"), 5000);
+	private static final int _TIMEOUT = PropsValues.HTTP_IMPL_TIMEOUT;
 
 	private static final Log _log = LogFactoryUtil.getLog(HttpImpl.class);
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -622,11 +622,11 @@ public class PropsValues {
 
 	public static final int HTTP_IMPL_MAX_TOTAL_CONNECTIONS = GetterUtil.getInteger(PropsUtil.get(PropsKeys.HTTP_IMPL_MAX_TOTAL_CONNECTIONS), 20);
 
+	public static final String HTTP_IMPL_PROXY_AUTH_TYPE = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_AUTH_TYPE);
+
 	public static final String HTTP_IMPL_PROXY_NTLM_DOMAIN = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_NTLM_DOMAIN);
 
 	public static final String HTTP_IMPL_PROXY_NTLM_HOST = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_NTLM_HOST);
-
-	public static final String HTTP_IMPL_PROXY_AUTH_TYPE = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_AUTH_TYPE);
 
 	public static final String HTTP_IMPL_PROXY_PASSWORD = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_PASSWORD);
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -618,6 +618,22 @@ public class PropsValues {
 
 	public static final String HTTP_HEADER_VERSION_VERBOSITY = PropsUtil.get(PropsKeys.HTTP_HEADER_VERSION_VERBOSITY);
 
+	public static final int HTTP_IMPL_MAX_CONNECTIONS_PER_HOST = GetterUtil.getInteger(PropsUtil.get(PropsKeys.HTTP_IMPL_MAX_CONNECTIONS_PER_HOST), 2);
+
+	public static final int HTTP_IMPL_MAX_TOTAL_CONNECTIONS = GetterUtil.getInteger(PropsUtil.get(PropsKeys.HTTP_IMPL_MAX_TOTAL_CONNECTIONS), 20);
+
+	public static final String HTTP_IMPL_PROXY_NTLM_DOMAIN = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_NTLM_DOMAIN);
+
+	public static final String HTTP_IMPL_PROXY_NTLM_HOST = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_NTLM_HOST);
+
+	public static final String HTTP_IMPL_PROXY_AUTH_TYPE = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_AUTH_TYPE);
+
+	public static final String HTTP_IMPL_PROXY_PASSWORD = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_PASSWORD);
+
+	public static final String HTTP_IMPL_PROXY_USERNAME = PropsUtil.get(PropsKeys.HTTP_IMPL_PROXY_USERNAME);
+
+	public static final int HTTP_IMPL_TIMEOUT = GetterUtil.getInteger(PropsUtil.get(PropsKeys.HTTP_IMPL_TIMEOUT), 5000);
+
 	public static final String IFRAME_PASSWORD_PASSWORD_TOKEN_ROLE = PropsUtil.get(PropsKeys.IFRAME_PASSWORD_PASSWORD_TOKEN_ROLE);
 
 	public static final boolean IMAGE_AUTO_SCALE = GetterUtil.getBoolean(PropsUtil.get(PropsKeys.IMAGE_AUTO_SCALE));

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -825,6 +825,22 @@ public interface PropsKeys {
 
 	public static final String HTTP_HEADER_VERSION_VERBOSITY = "http.header.version.verbosity";
 
+	public static final String HTTP_IMPL_MAX_CONNECTIONS_PER_HOST = "com.liferay.portal.util.HttpImpl.max.connections.per.host";
+
+	public static final String HTTP_IMPL_MAX_TOTAL_CONNECTIONS = "com.liferay.portal.util.HttpImpl.max.total.connections";
+
+	public static final String HTTP_IMPL_PROXY_AUTH_TYPE = "com.liferay.portal.util.HttpImpl.proxy.auth.type";
+
+	public static final String HTTP_IMPL_PROXY_NTLM_DOMAIN = "com.liferay.portal.util.HttpImpl.proxy.ntlm.domain";
+
+	public static final String HTTP_IMPL_PROXY_NTLM_HOST = "com.liferay.portal.util.HttpImpl.proxy.ntlm.host";
+
+	public static final String HTTP_IMPL_PROXY_PASSWORD = "com.liferay.portal.util.HttpImpl.proxy.password";
+
+	public static final String HTTP_IMPL_PROXY_USERNAME = "com.liferay.portal.util.HttpImpl.proxy.username";
+
+	public static final String HTTP_IMPL_TIMEOUT = "com.liferay.portal.util.HttpImpl.timeout";
+
 	public static final String IFRAME_PASSWORD_PASSWORD_TOKEN_ROLE = "iframe.password.token.role";
 
 	public static final String IMAGE_AUTO_SCALE = "image.auto.scale";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-67176
https://issues.liferay.com/browse/LPP-21931

Refactored to use PropsValues for the properties, and added a configuration for the connection timeout.

There is another setting we can add to the ClientConfiguration, which is for the max connections. However, I didn't know whether it would be better to use the http.impl.max.connections.per.host property or the http.impl.max.total.connections property, since I don't know how we would want to handle this, so I left it out.

Copying from #1019 :

> Although we allow configuring Liferay with a forward proxy, we have not implemented using it with S3, although clients should be able to expect this. Some clients must connect using a proxy.

> I implemented it with just the basic configurations (copied the logic of using different proxy authorization types from HttpImpl), but it's possible there are more configuration options we could add as well that I just wasn't sure whether we already have options for, as I noted on the LPS (the web.server.protocol property?). I tested using Apache web server for a proxy, and enabling it as a proxy and for using HTTPS (which seems to be the default S3 will use).