### PR TITLE
LPS-67904 Fix ResourcePermission.name to check against class name

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -431,7 +431,7 @@
 			LEFT JOIN
 				ResourcePermission ON
 					(ResourcePermission.companyId = Layout.companyId) AND
-					(ResourcePermission.name = Layout.name) AND
+					(ResourcePermission.name = 'com.liferay.portal.kernel.model.Layout') AND
 					(ResourcePermission.scope = ?) AND
 					(ResourcePermission.primKey = CAST_TEXT(Layout.plid)) AND
 					(ResourcePermission.roleId = ?)


### PR DESCRIPTION
Please see [LPS-67904](https://issues.liferay.com/browse/LPS-67904)