### PR TITLE
[TECHNICAL-SUPPORT] LPS-68083

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/util/BlogsEntryUtil.java
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/util/BlogsEntryUtil.java
@@ -29,12 +29,23 @@ public class BlogsEntryUtil {
 	public static String getDisplayTitle(
 		ResourceBundle resourceBundle, BlogsEntry entry) {
 
+		return getDisplayTitle(resourceBundle, entry, true);
+	}
+
+	public static String getDisplayTitle(
+		ResourceBundle resourceBundle, BlogsEntry entry, Boolean escape) {
+
 		if (Validator.isNull(entry.getTitle())) {
 			return HtmlUtil.escape(
 				LanguageUtil.get(resourceBundle, "untitled-entry"));
 		}
 
-		return HtmlUtil.escape(entry.getTitle());
+		if (escape) {
+			return HtmlUtil.escape(entry.getTitle());
+		}
+		else {
+			return entry.getTitle();
+		}
 	}
 
 }

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -155,7 +155,7 @@ if (portletTitleBasedNavigation) {
 
 					<div class="col-md-8 col-md-offset-2">
 						<div class="entry-title">
-							<h1><liferay-ui:input-editor contents="<%= HtmlUtil.escape(title) %>" editorName="alloyeditor" name="titleEditor" placeholder="title" showSource="<%= false %>" /></h1>
+							<h1><liferay-ui:input-editor contents="<%= title %>" editorName="alloyeditor" name="titleEditor" placeholder="title" showSource="<%= false %>" /></h1>
 						</div>
 
 						<aui:input name="title" type="hidden" />
@@ -450,7 +450,7 @@ if (entry != null) {
 	portletURL.setParameter("mvcRenderCommandName", "/blogs/view_entry");
 	portletURL.setParameter("entryId", String.valueOf(entry.getEntryId()));
 
-	PortalUtil.addPortletBreadcrumbEntry(request, BlogsEntryUtil.getDisplayTitle(resourceBundle, entry), portletURL.toString());
+	PortalUtil.addPortletBreadcrumbEntry(request, BlogsEntryUtil.getDisplayTitle(resourceBundle, entry, false), portletURL.toString());
 	PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "edit"), currentURL);
 }
 else {

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entry.jsp
@@ -43,7 +43,7 @@ portletDisplay.setURLBack(redirect);
 boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getInitParameter("portlet-title-based-navigation"));
 
 if (portletTitleBasedNavigation) {
-	renderResponse.setTitle(BlogsEntryUtil.getDisplayTitle(resourceBundle, entry));
+	renderResponse.setTitle(BlogsEntryUtil.getDisplayTitle(resourceBundle, entry, false));
 }
 %>
 

--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs_admin/entry_search_columns.jspf
@@ -36,7 +36,7 @@
 
 			<h4>
 				<aui:a href="<%= rowURL.toString() %>">
-					<%= BlogsEntryUtil.getDisplayTitle(resourceBundle, entry) %>
+					<%= BlogsEntryUtil.getDisplayTitle(resourceBundle, entry, false) %>
 				</aui:a>
 			</h4>
 


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:

> Due to the creation of the BlogsEntryUtil.getDisplayTitle method, various titles are being escaped twice in the JPS's
> 
> Re-included the Null check that was in edit_entry, and took out the Null Check in BlogsEntryUtil