### PR TITLE
[TECHNICAL-SUPPORT]

### DIFF
--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
@@ -150,7 +150,11 @@ public class AssetEntryQuery {
 
 		if (Validator.isNotNull(tagName)) {
 			_allTagIds = AssetTagLocalServiceUtil.getTagIds(
-				themeDisplay.getSiteGroupId(), new String[] {tagName});
+				themeDisplay.getScopeGroupId(), new String[] {tagName});
+
+			if (_allTagIds.length == 0) {
+				_allTagIds = new long[] {0};
+			}
 
 			_allTagIdsArray = new long[][] {_allTagIds};
 		}

--- a/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
@@ -65,7 +65,7 @@ private String _buildTagsNavigation(long scopeGroupId, long siteGroupId, String 
 		tags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 	else {
-		tags = AssetTagServiceUtil.getGroupTags(siteGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+		tags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 
 	if (tags.isEmpty()) {


### PR DESCRIPTION
/cc @NolanChan 

Notes from Nolan:
> Tag navigation now shows global tags; Asset searches using tags in portlets now respects portlet's scope
> 
> Assumptions:
> 1. Tags only show up if they're part of the specific scope. Ex: Global tags don't show up in site scope, and vice versa.
> 2. When doing an asset search with tag, NO assets will show up unless they have that specific tag.