### PR TITLE
LPS-68552 Show only the amount of activites set in configuration and …

### DIFF
--- a/modules/apps/collaboration/social/social-activities-web/src/main/java/com/liferay/social/activities/web/internal/portlet/display/context/DefaultSocialActivitiesDisplayContext.java
+++ b/modules/apps/collaboration/social/social-activities-web/src/main/java/com/liferay/social/activities/web/internal/portlet/display/context/DefaultSocialActivitiesDisplayContext.java
@@ -122,12 +122,13 @@ public class DefaultSocialActivitiesDisplayContext
 		SocialActivitiesQueryHelper.Scope scope =
 			SocialActivitiesQueryHelper.Scope.fromValue(getSelectedTabName());
 
-		int start = _socialActivitiesRequestHelper.getEnd();
+		int max = _socialActivitiesRequestHelper.getMax();
+
+		int start = _socialActivitiesRequestHelper.getEnd() - max;
 
 		_socialActivitySets =
 			_socialActivitiesQueryHelper.getSocialActivitySets(
-				group, layout, scope, 0,
-				start + _socialActivitiesRequestHelper.getMax());
+				group, layout, scope, start, start + max);
 
 		return _socialActivitySets;
 	}


### PR DESCRIPTION
…allow pagination through activities

Currently, when we have more activities to list than whatever the display max is set to in the configurations of the social activities portlet, we do not see the "see more" button and the number of activities displayed is double whatever is set in the configuration.

This commit fixes that issue, however it leaves one potential issue. The see more button is shown when the number of activities in a set equal the max to be shown.

For example, if you have 6 activities and configure the portlet to show only 2 at a time, you can click on the see more button until you have paged through all activities. However, the button is still shown. Clicking one more time leads to a page that displays "no more activities to load at this time"

I am not sure if the current pagination was intended or not. We don't have any way to track the total number of activities that can be shown so checking the total number available is not possible at this time.