### PR TITLE
LPS-68514

### DIFF
--- a/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -23,7 +23,7 @@ if (showAssetCount && (classNameId > 0)) {
 	assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 }
 else {
-	assetTags = AssetTagServiceUtil.getGroupTags(themeDisplay.getSiteGroupId(), 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
 }
 
 assetTags = ListUtil.sort(assetTags);

--- a/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/persistence/AssetEntryQuery.java
@@ -150,7 +150,11 @@ public class AssetEntryQuery {
 
 		if (Validator.isNotNull(tagName)) {
 			_allTagIds = AssetTagLocalServiceUtil.getTagIds(
-				themeDisplay.getSiteGroupId(), new String[] {tagName});
+				themeDisplay.getScopeGroupId(), new String[] {tagName});
+
+			if (_allTagIds.length == 0) {
+				_allTagIds = new long[] {0};
+			}
 
 			_allTagIdsArray = new long[][] {_allTagIds};
 		}

--- a/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/asset_tags_navigation/page.jsp
@@ -28,7 +28,7 @@ String tag = ParamUtil.getString(request, "tag");
 
 PortletURL portletURL = renderResponse.createRenderURL();
 
-String tagsNavigation = _buildTagsNavigation(scopeGroupId, themeDisplay.getSiteGroupId(), tag, portletURL, classNameId, displayStyle, maxAssetTags, showAssetCount, showZeroAssetCount);
+String tagsNavigation = _buildTagsNavigation(scopeGroupId, tag, portletURL, classNameId, displayStyle, maxAssetTags, showAssetCount, showZeroAssetCount);
 
 if (Validator.isNotNull(tagsNavigation)) {
 %>
@@ -58,14 +58,14 @@ if (Validator.isNotNull(tag)) {
 %>
 
 <%!
-private String _buildTagsNavigation(long scopeGroupId, long siteGroupId, String selectedTagName, PortletURL portletURL, long classNameId, String displayStyle, int maxAssetTags, boolean showAssetCount, boolean showZeroAssetCount) throws Exception {
+private String _buildTagsNavigation(long scopeGroupId, String selectedTagName, PortletURL portletURL, long classNameId, String displayStyle, int maxAssetTags, boolean showAssetCount, boolean showZeroAssetCount) throws Exception {
 	List<AssetTag> tags = null;
 
 	if (showAssetCount && (classNameId > 0)) {
 		tags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 	else {
-		tags = AssetTagServiceUtil.getGroupTags(siteGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+		tags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
 	}
 
 	if (tags.isEmpty()) {


### PR DESCRIPTION
continuing https://github.com/jonathanmccann/liferay-portal/pull/1082

Tag navigation now shows global tags; Asset searches using tags in portlets now respects portlet's scope

Assumptions:
1. Tags will only appear in Tag Navigator if they're part of the portlet's specific scope. Ex: Global tags don't show up in site scope, and vice versa.
2. When doing an asset search with tag, NO assets will show up unless they have that specific tag.