### PR TITLE
[TECHNICAL-SUPPORT] LPS-69127

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/edit_message.jsp
@@ -351,17 +351,20 @@ if (portletTitleBasedNavigation) {
 					<%
 					boolean disabled = false;
 					boolean question = threadAsQuestionByDefault;
+					MBCategory category = MBCategoryLocalServiceUtil.getCategory(categoryId);
 
 					if (message != null) {
 						thread = MBThreadLocalServiceUtil.getThread(threadId);
 
 						if (thread.isQuestion() || message.isAnswer()) {
 							question = true;
+
+							if ((category != null) && category.getDisplayStyle().equals("question")) {
+								disabled = true;
+							}
 						}
 					}
 					else {
-						MBCategory category = MBCategoryLocalServiceUtil.getCategory(categoryId);
-
 						if ((category != null) && category.getDisplayStyle().equals("question")) {
 							disabled = true;
 							question = true;


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:

>The 'Mark as a Question' checkbox is disabled for threads with category 'Question'
> 
> LPS-68460 introduced a fix that set threads created in a Message Board Question Category to be marked as questions (they originally were not set as questions). However, this introduced a bug that caused the 'Mark as Question' checkbox to appear alterable, although on save it would always remain checked. 
> 
> This fix disables the 'Mark as Question' checkbox so that this choice is not available to the user. 
> 
> See Bryan's comment about the problem: 
> https://github.com/brianchandotcom/liferay-portal/pull/44183#issuecomment-255819780
> 
> And Adolfo's follow-up (and proposed solution):
> https://github.com/brianchandotcom/liferay-portal/pull/44183#issuecomment-256027910