### PR TITLE
[TECHNICAL-SUPPORT] LPS-69212

### DIFF
--- a/modules/core/portal-bootstrap/system.packages.extra.mf
+++ b/modules/core/portal-bootstrap/system.packages.extra.mf
@@ -3416,7 +3416,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  nel.dao.jdbc,com.liferay.portal.kernel.upgrade";version="1.0.0",com.l
  iferay.portal.upgrade.dao.orm;uses:="com.liferay.portal.kernel.dao.db
  ,com.liferay.portal.kernel.upgrade.dao.orm";version="1.0.0",com.lifer
- ay.portal.upgrade.util;version="1.2.0";uses:="com.liferay.portal.kern
+ ay.portal.upgrade.util;version="1.3.0";uses:="com.liferay.portal.kern
  el.security.pacl,com.liferay.portal.kernel.upgrade,com.liferay.portal
  .kernel.upgrade.util,com.liferay.portal.kernel.xml",com.liferay.porta
  l.upgrade.v6_0_12_to_6_1_0;uses:="com.liferay.portal.kernel.upgrade,c
@@ -3431,7 +3431,7 @@ Export-Package: com.liferay.ibm.icu;version="4.0.1",com.liferay.ibm.ic
  ortal.kernel.model,com.liferay.portal.kernel.upgrade,com.liferay.port
  al.kernel.upgrade.v6_2_0,com.liferay.portal.kernel.xml,com.liferay.po
  rtlet,javax.portlet";version="1.0.0",com.liferay.portal.upgrade.v6_2_
- 0.util;version="1.0.0",com.liferay.portal.upgrade.v7_0_0;version="1.4
+ 0.util;version="1.0.0",com.liferay.portal.upgrade.v7_0_0;version="1.5
  .0";uses:="com.liferay.portal.kernel.dao.orm,com.liferay.portal.kerne
  l.settings,com.liferay.portal.kernel.upgrade,com.liferay.portal.upgra
  de.util,com.liferay.portal.upgrade.v7_0_0.util,javax.portlet",com.lif

--- a/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_2_0.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/UpgradeProcess_6_2_0.java
@@ -35,6 +35,7 @@ import com.liferay.portal.upgrade.v6_2_0.UpgradeLayoutSet;
 import com.liferay.portal.upgrade.v6_2_0.UpgradeLayoutSetBranch;
 import com.liferay.portal.upgrade.v6_2_0.UpgradeMessageBoards;
 import com.liferay.portal.upgrade.v6_2_0.UpgradeMessageBoardsAttachments;
+import com.liferay.portal.upgrade.v6_2_0.UpgradePolls;
 import com.liferay.portal.upgrade.v6_2_0.UpgradePortletItem;
 import com.liferay.portal.upgrade.v6_2_0.UpgradePortletPreferences;
 import com.liferay.portal.upgrade.v6_2_0.UpgradeRepository;
@@ -80,6 +81,7 @@ public class UpgradeProcess_6_2_0 extends Pre7UpgradeProcess {
 		upgrade(UpgradeLayoutSetBranch.class);
 		upgrade(UpgradeMessageBoards.class);
 		upgrade(UpgradeMessageBoardsAttachments.class);
+		upgrade(UpgradePolls.class);
 		upgrade(UpgradePortletItem.class);
 		upgrade(UpgradePortletPreferences.class);
 		upgrade(UpgradeRepository.class);

--- a/portal-impl/src/com/liferay/portal/upgrade/util/UpgradeUUIDUtil.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/UpgradeUUIDUtil.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.util;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Michael Bowerman
+ */
+public class UpgradeUUIDUtil {
+
+	public static void upgradeUUID(
+			Connection con, String tableName, String pkColumnName)
+		throws SQLException {
+
+		String selectSQL = getSelectSQL(tableName, pkColumnName);
+		String updateSQL = getUpdateSQL(tableName, pkColumnName);
+
+		try (PreparedStatement ps1 = con.prepareStatement(selectSQL);
+			ResultSet rs = ps1.executeQuery();
+			PreparedStatement ps2 = AutoBatchPreparedStatementUtil.autoBatch(
+				con.prepareStatement(updateSQL))) {
+
+			while (rs.next()) {
+				long voteId = rs.getLong(1);
+
+				ps2.setString(1, PortalUUIDUtil.generate());
+				ps2.setLong(2, voteId);
+
+				ps2.addBatch();
+			}
+
+			ps2.executeBatch();
+		}
+	}
+
+	protected static String getSelectSQL(
+		String tableName, String pkColumnName) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("select ");
+		sb.append(pkColumnName);
+		sb.append(" from ");
+		sb.append(tableName);
+		sb.append(" where uuid_ is null or uuid_ = ''");
+
+		return sb.toString();
+	}
+
+	protected static String getUpdateSQL(
+		String tableName, String pkColumnName) {
+
+		StringBundler sb = new StringBundler(5);
+
+		sb.append("update ");
+		sb.append(tableName);
+		sb.append(" set uuid_ = ? where ");
+		sb.append(pkColumnName);
+		sb.append(" = ?");
+
+		return sb.toString();
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeDocumentLibrary.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_1_1/UpgradeDocumentLibrary.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.StringPool;
+import com.liferay.portal.upgrade.util.UpgradeUUIDUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -32,6 +33,9 @@ public class UpgradeDocumentLibrary extends UpgradeProcess {
 	@Override
 	protected void doUpgrade() throws Exception {
 		updateFileEntries();
+
+		UpgradeUUIDUtil.upgradeUUID(
+			connection, "DLFileVersion", "fileVersionId");
 	}
 
 	protected boolean hasFileEntry(long groupId, long folderId, String title)

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeMessageBoards.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradeMessageBoards.java
@@ -20,6 +20,9 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.RSSUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.upgrade.util.UpgradeUUIDUtil;
+
+import java.sql.SQLException;
 
 import javax.portlet.PortletPreferences;
 
@@ -32,11 +35,20 @@ public class UpgradeMessageBoards extends BaseUpgradePortletPreferences {
 	@Override
 	protected void doUpgrade() throws Exception {
 		super.doUpgrade();
+
+		updateUUID();
 	}
 
 	@Override
 	protected String[] getPortletIds() {
 		return new String[] {"19"};
+	}
+
+	protected void updateUUID() throws SQLException {
+		UpgradeUUIDUtil.upgradeUUID(connection, "MBBan", "banId");
+		UpgradeUUIDUtil.upgradeUUID(connection, "MBDiscussion", "discussionId");
+		UpgradeUUIDUtil.upgradeUUID(connection, "MBThread", "threadId");
+		UpgradeUUIDUtil.upgradeUUID(connection, "MBThreadFlag", "threadFlagId");
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePolls.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v6_2_0/UpgradePolls.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v6_2_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.util.UpgradeUUIDUtil;
+
+/**
+ * @author Michael Bowerman
+ */
+public class UpgradePolls extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		UpgradeUUIDUtil.upgradeUUID(connection, "PollsVote", "voteId");
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeAsset.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.upgrade.util.UpgradeUUIDUtil;
 import com.liferay.portal.upgrade.v7_0_0.util.AssetEntryTable;
 import com.liferay.portlet.asset.util.AssetVocabularySettingsHelper;
 
@@ -48,6 +49,8 @@ public class UpgradeAsset extends UpgradeProcess {
 
 		updateAssetEntries();
 		updateAssetVocabularies();
+
+		UpgradeUUIDUtil.upgradeUUID(connection, "AssetTag", "tagId");
 	}
 
 	protected long getDDMStructureId(String structureKey) throws Exception {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeTeam.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeTeam.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.upgrade.v7_0_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.upgrade.util.UpgradeUUIDUtil;
+
+/**
+ * @author Michael Bowerman
+ */
+public class UpgradeTeam extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		UpgradeUUIDUtil.upgradeUUID(connection, "Team", "teamId");
+	}
+
+}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0


### PR DESCRIPTION
/cc @mbowerman

Notes from Michael:
> This fix could not be tested in master since it requires an Oracle database to reproduce. I also had trouble testing it properly in ee-7.0.x because I ran into errors when trying to run the upgrade process with an Oracle database, which caused the upgrade process to end prematurely. I ultimately cherry-picked my fix into ee-7.0.x and tested it using the following steps:
> 
> 1. Start up an Oracle database in 6.1 GA1.
> 2. Verify that there are multiple entries in the MBThread table.
> 3. Shut down the portal
> 4. Run the upgrader tool for ee-7.0.x.
> 5. Wait for the upgrade to fail (it fails before we try to add indexes).
> 6. Observe the uuid_ column in the MBThread table.
> 
> Without my fix, the uuid_ column consisted only of null entries after the upgrade failed. With my fix, the uuid_ column was populated with unique uuid values.
> 
> 
> The way I decided which tableNames to call UpgradeUUIDUtil.upgradeUUID for was the following:
> 
> 1. Check if a uuid_ column gets added to the table in any of the update-(old version #)-(new version #).sql files
> 2. Check the indexes.sql file to see if this table has a unique index involving the uuid_ column.
> 
> If both these conditions were true, then I would call UpgradeUUIDUtil.upgradeUUID for that table in the same part of the upgrade process indicated by the version #s in the update.sql file. For instance, in update-6.1.1-6.2.0.sql, we add the uuid_ column to the MBBan table. Moreover, MBBan has a unique index on (uuid_, groupId). Therefore, in the 6.2.0 Upgrade process, I made sure to populate the uuid_ column by calling UpgradeUUIDUtil.upgradeUUID on the MBBan table.
> 
> There were several tables that only consisted of a non-unique index involving uuid_. I did not think it was necessary to add these tables to my fix since the bug would not prevent the index from being created.
> 
> There is one table that fulfilled both the conditions I mentioned above, yet I still did not include it in my fix. That table is the Group_ table. The Group_ table has a unique index on (uuid_, groupId). However, groupId is the primary key of the Group_ table, so I thought it would be impossible for that index to ever be violated, even if all the uuid_s were null. I don't even understand why we would have a unique index involving a primary key - it seems completely unnecessary to me, since the primary key already acts as a unique index by itself anyway, unless I'm missing something? 