### PR TITLE
[TECHNICAL-SUPPORT] LPS-69159

### DIFF
--- a/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entries.jspf
+++ b/modules/apps/collaboration/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entries.jspf
@@ -31,7 +31,7 @@
 			delta="<%= GetterUtil.getInteger(blogsGroupServiceOverriddenConfiguration.rssDelta()) %>"
 			displayStyle="<%= blogsGroupServiceOverriddenConfiguration.rssDisplayStyle() %>"
 			feedType="<%= blogsGroupServiceOverriddenConfiguration.rssFeedType() %>"
-			url='<%= themeDisplay.getPathMain() + "/blogs/rss" %>'
+			url='<%= themeDisplay.getPathMain() + "/blogs/rss?p_l_id=" + plid + "&groupId=" + themeDisplay.getScopeGroupId() %>'
 		/>
 	</c:if>
 


### PR DESCRIPTION
/cc @gregory-bretall

Notes from Nolan:

> From Sergio Gonzalez on whether or not the fix here presents a security risk: 
> 
> "That shouldn't have any security risk because the user should only see the blog entries if he has permission in that particular group.
> 
> See the code in https://github.com/liferay/liferay-portal/blob/master/modules/apps/collaboration/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/RSSAction.java#L95 As you can see, we are using BlogsEntryService (which does permission checking) and we are passing the groupId in the URL.
> 
> That means that if we don't have permission to view blog entries in that groupId, the method _blogsEntryService.getGroupEntriesRSS( will only return the blog entries that the user can see)."