### PR TITLE
[TECHNICAL-SUPPORT] LPS-69663

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
@@ -235,9 +235,9 @@ if (portletTitleBasedNavigation) {
 						</div>
 					</aui:fieldset>
 
-					<c:if test="<%= (wikiPage != null) && (wikiPage.getPageId() > 0) %>">
+					<c:if test="<%= ((wikiPage != null) && (wikiPage.getPageId() > 0)) || (templateNodeId != 0) %>">
 						<aui:fieldset collapsed="<%= true %>" collapsible="<%= true %>" label="attachments">
-							<c:if test="<%= WikiNodePermissionChecker.contains(permissionChecker, node.getNodeId(), ActionKeys.ADD_ATTACHMENT) %>">
+							<c:if test="<%= !wikiPage.isNew() && WikiNodePermissionChecker.contains(permissionChecker, node.getNodeId(), ActionKeys.ADD_ATTACHMENT) %>">
 								<liferay-util:include page="/wiki/edit_page_attachment.jsp" servletContext="<%= application %>" />
 							</c:if>
 

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
@@ -89,7 +89,7 @@ if (wikiPage != null) {
 	int attachmentsFileEntriesCount = attachmentsFileEntries.size();
 	String emptyResultsMessage = "this-page-does-not-have-file-attachments";
 	boolean paginate = false;
-	boolean showPageAttachmentAction = true;
+	boolean showPageAttachmentAction = (templateNodeId == 0);
 	int status = WorkflowConstants.STATUS_APPROVED;
 	%>
 

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
@@ -42,7 +42,11 @@ if ((templateNodeId > 0) && Validator.isNotNull(templateTitle)) {
 	}
 }
 
-int deletedAttachmentsCount = wikiPage.getDeletedAttachmentsFileEntriesCount();
+int deletedAttachmentsCount = 0;
+
+if (wikiPage != null) {
+	deletedAttachmentsCount = wikiPage.getDeletedAttachmentsFileEntriesCount();
+}
 %>
 
 <c:if test="<%= TrashUtil.isTrashEnabled(scopeGroupId) && (deletedAttachmentsCount > 0) %>">
@@ -82,7 +86,7 @@ int deletedAttachmentsCount = wikiPage.getDeletedAttachmentsFileEntriesCount();
 	</c:if>
 
 	<%
-	int attachmentsFileEntriesCount = wikiPage.getAttachmentsFileEntriesCount();
+	int attachmentsFileEntriesCount = attachmentsFileEntries.size();
 	String emptyResultsMessage = "this-page-does-not-have-file-attachments";
 	boolean paginate = false;
 	boolean showPageAttachmentAction = true;

--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_page_details.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_page_details.jsp
@@ -302,7 +302,6 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "details
 						PortletURL copyPageURL = PortletURLUtil.clone(viewPageURL, renderResponse);
 
 						copyPageURL.setParameter("mvcRenderCommandName", "/wiki/edit_page");
-						copyPageURL.setParameter("redirect", viewPageURL.toString());
 						copyPageURL.setParameter("nodeId", String.valueOf(wikiPage.getNodeId()));
 						copyPageURL.setParameter("title", StringPool.BLANK);
 						copyPageURL.setParameter("editTitle", "1");


### PR DESCRIPTION
/cc @Alec-Shay 

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-23561
> https://issues.liferay.com/browse/LPS-69663
> 
> The option to copy page attachments when copying a Wiki page (from the page's "Details") is missing. This is largely due to our logic checking against whether the Wiki page already exists.
> 
> Wiki attachments normally are only allowed to be added for an existing Wiki page, because an existing page is required to upload or delete attachments to/from. However, to restore the option to copy page attachments (which was clearly intended originally, since we had implemented a checkbox specifically for it), all that is needed is to be able to view the attachments.
> 
> Editing the attachments does not make sense in the UI for copying anyway, since the attachments are not yet copied; to edit the attachments at this point would change the attachments for the original page, which is confusing. So the second commit here is aimed at restricting the ability to do so.
> 
> I also included one last commit to change the redirect URL for when the new page is published. Normally, when a new page is published, it redirects back to a list of all pages, but without this change, when a page is successfully copied, it redirects back to the original page. I think this is very confusing and counter-intuitive, and may even mislead users to think they are looking at the copied page, when they are looking at the original page.
> 
> Removing the explicitly set redirect URL will leverage the default value in edit_page.jsp, which is the same behavior for when a new page is made normally. I think this is the more correct way to do it, but please feel free to drop this commit if it is decided that the current implementation is better.