### PR TITLE
[TECHNICAL-SUPPORT] LPS-69664

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jsp
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards_admin/view_entries.jsp
@@ -131,7 +131,7 @@ boolean portletTitleBasedNavigation = GetterUtil.getBoolean(portletConfig.getIni
 							</h5>
 
 							<%
-							int subcategoriesCount = MBCategoryServiceUtil.getCategoriesCount(scopeGroupId, curCategory.getCategoryId());
+							int subcategoriesCount = MBCategoryServiceUtil.getCategoriesCount(scopeGroupId, curCategory.getCategoryId(), WorkflowConstants.STATUS_APPROVED);
 							int threadsCount = MBThreadServiceUtil.getThreadsCount(scopeGroupId, curCategory.getCategoryId(), WorkflowConstants.STATUS_APPROVED);
 							%>
 


### PR DESCRIPTION
/cc @NolanChan 

Notes from Nolan:

> Commit msg: Message Board Parent Category Count no longer includes categories in the recycle bin
> 
> Categories seem to only be able to have the status "approved" or "in trash," so I'm forcing a check for only "approved" categories