### PR TITLE
[TECHNICAL-SUPPORT]

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -38,7 +38,6 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.util.AssetUtil;
 
 import java.util.ArrayList;
@@ -81,7 +80,6 @@ public class AssetPublisherPortletToolbarContributor
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		Group scopeGroup = themeDisplay.getScopeGroup();
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		String portletName = portletDisplay.getPortletName();
@@ -96,8 +94,6 @@ public class AssetPublisherPortletToolbarContributor
 				portletRequest.getPreferences());
 
 		if (!assetPublisherDisplayContext.isShowAddContentButton() ||
-			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup() &&
-			 PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) ||
 			portletName.equals(
 				AssetPublisherPortletKeys.HIGHEST_RATED_ASSETS) ||
 			portletName.equals(AssetPublisherPortletKeys.MOST_VIEWED_ASSETS) ||

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -26,15 +26,14 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
+import com.liferay.portal.kernel.portlet.toolbar.contributor.BasePortletToolbarContributor;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.PortletToolbarContributor;
 import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.servlet.taglib.ui.URLMenuItem;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -43,7 +42,6 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.portlet.asset.util.AssetUtil;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -73,25 +71,7 @@ import org.osgi.service.component.annotations.Reference;
 	}
 )
 public class AssetPublisherPortletToolbarContributor
-	implements PortletToolbarContributor {
-
-	@Override
-	public List<Menu> getPortletTitleMenus(
-		PortletRequest portletRequest, PortletResponse portletResponse) {
-
-		Menu addEntryPortletTitleMenu = getAddEntryPortletTitleMenu(
-			portletRequest, portletResponse);
-
-		if (addEntryPortletTitleMenu == null) {
-			return Collections.emptyList();
-		}
-
-		List<Menu> menus = new ArrayList<>();
-
-		menus.add(addEntryPortletTitleMenu);
-
-		return menus;
-	}
+	extends BasePortletToolbarContributor {
 
 	protected void addPortletTitleAddAssetEntryMenuItems(
 			List<MenuItem> menuItems, PortletRequest portletRequest,
@@ -197,36 +177,7 @@ public class AssetPublisherPortletToolbarContributor
 		menuItems.add(urlMenuItem);
 	}
 
-	protected Menu getAddEntryPortletTitleMenu(
-		PortletRequest portletRequest, PortletResponse portletResponse) {
-
-		List<MenuItem> portletTitleMenuItems = getPortletTitleMenuItems(
-			portletRequest, portletResponse);
-
-		if (ListUtil.isEmpty(portletTitleMenuItems)) {
-			return null;
-		}
-
-		Menu menu = new Menu();
-
-		Map<String, Object> data = new HashMap<>();
-
-		data.put("qa-id", "addButton");
-
-		menu.setData(data);
-
-		menu.setDirection("right");
-		menu.setExtended(false);
-		menu.setIcon("plus");
-		menu.setMarkupView("lexicon");
-		menu.setMenuItems(portletTitleMenuItems);
-		menu.setScroll(false);
-		menu.setShowArrow(false);
-		menu.setShowWhenSingleIcon(true);
-
-		return menu;
-	}
-
+	@Override
 	protected List<MenuItem> getPortletTitleMenuItems(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
 

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -96,7 +96,6 @@ public class AssetPublisherPortletToolbarContributor
 				portletRequest.getPreferences());
 
 		if (!assetPublisherDisplayContext.isShowAddContentButton() ||
-			(scopeGroup == null) || scopeGroup.isLayoutPrototype() ||
 			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup() &&
 			 PropsValues.STAGING_LIVE_GROUP_LOCKING_ENABLED) ||
 			portletName.equals(

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/toolbar/contributor/AssetPublisherPortletToolbarContributor.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.toolbar.contributor.BasePortletToolbarContributor;
@@ -80,6 +81,7 @@ public class AssetPublisherPortletToolbarContributor
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		Layout layout = themeDisplay.getLayout();
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
 		String portletName = portletDisplay.getPortletName();
@@ -94,6 +96,7 @@ public class AssetPublisherPortletToolbarContributor
 				portletRequest.getPreferences());
 
 		if (!assetPublisherDisplayContext.isShowAddContentButton() ||
+			layout.isLayoutPrototypeLinkActive() ||
 			portletName.equals(
 				AssetPublisherPortletKeys.HIGHEST_RATED_ASSETS) ||
 			portletName.equals(AssetPublisherPortletKeys.MOST_VIEWED_ASSETS) ||

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/toolbar/contributor/BasePortletToolbarContributor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/toolbar/contributor/BasePortletToolbarContributor.java
@@ -14,9 +14,12 @@
 
 package com.liferay.portal.kernel.portlet.toolbar.contributor;
 
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,6 +39,15 @@ public abstract class BasePortletToolbarContributor
 	@Override
 	public List<Menu> getPortletTitleMenus(
 		PortletRequest portletRequest, PortletResponse portletResponse) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		Group scopeGroup = themeDisplay.getScopeGroup();
+
+		if ((scopeGroup == null) || scopeGroup.isLayoutPrototype()) {
+			return Collections.emptyList();
+		}
 
 		List<MenuItem> portletTitleMenuItems = getPortletTitleMenuItems(
 			portletRequest, portletResponse);

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/toolbar/contributor/BasePortletToolbarContributor.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/toolbar/contributor/BasePortletToolbarContributor.java
@@ -18,7 +18,10 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.servlet.taglib.ui.Menu;
 import com.liferay.portal.kernel.servlet.taglib.ui.MenuItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -45,7 +48,10 @@ public abstract class BasePortletToolbarContributor
 
 		Group scopeGroup = themeDisplay.getScopeGroup();
 
-		if ((scopeGroup == null) || scopeGroup.isLayoutPrototype()) {
+		if ((scopeGroup == null) || scopeGroup.isLayoutPrototype() ||
+			(scopeGroup.hasStagingGroup() && !scopeGroup.isStagingGroup() &&
+			 _STAGING_LIVE_GROUP_LOCKING_ENABLED)) {
+
 			return Collections.emptyList();
 		}
 
@@ -82,5 +88,9 @@ public abstract class BasePortletToolbarContributor
 
 	protected abstract List<MenuItem> getPortletTitleMenuItems(
 		PortletRequest portletRequest, PortletResponse portletResponse);
+
+	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =
+		GetterUtil.getBoolean(
+			PropsUtil.get(PropsKeys.STAGING_LIVE_GROUP_LOCKING_ENABLED));
 
 }


### PR DESCRIPTION
/cc @ericyanLr 

com-liferay-journal Pull Request: https://github.com/jonathanmccann/com-liferay-journal/pull/9 

Notes from Eric:
> Original Ticket: [LPP-23690](https://issues.liferay.com/browse/LPP-23690)
> Pull Request to **com-liferay-journal**: https://github.com/SamZiemer/com-liferay-journal/pull/3
> 
> ### Overview
> The changes for this pull request were made based on the guidelines from a forum post.
> The guidelines can be summarized in two points:
> 
> - Do not show the "Add menu" button for the portlet when configuring a page template.
> - Do not show the "Add menu" button for the portlet when viewing a page that inherits changes from a page template IF the actions from the "Add menu" button can affect the portlet configuration.
> 
> Reference: https://in.liferay.com/web/support/forums/-/message_boards/message/27995186#_19_message_28155139
> 
> ### Portlets that can affect the portlet configuration: when viewed on a page that inherits changes from a page template
> 
> I found that these portlets can affect the portlet configuration when using one of the menu items from the "Add menu":
> - Asset Publisher
> - Web Content Display
> 
> That is why this commit only involves those 2 specific portlets:
> [LPS-70013 prevent menu items to be added to the Add menu when viewing a page using a page template, for portlets where using the provided menu items can affect the portlet configuration](https://github.com/SamZiemer/liferay-portal/commit/0f54e0b1e6fbc931997fb7fbcba419b3e7aa9415)
> 
> Please let me know if you have any questions.
> Thanks!
> 
> ----
> 
> ### Additional Notes - Portlets that utilize the "Add menu" on the portlet toolbar
> From my testing, I found that these portlets have an "Add menu":
> - Asset Publisher
> - Web Content Display
> - Bookmarks
> - Documents and Media
> - Media Gallery
> - Wiki