### PR TITLE
[TECHNICAL-SUPPORT] LPS-70230

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/resources/META-INF/resource-actions/default.xml
@@ -37,6 +37,7 @@
 			</supports>
 			<site-member-defaults>
 				<action-key>VIEW</action-key>
+				<action-key>VIEW_BOOKING_DETAILS</action-key>
 			</site-member-defaults>
 			<guest-defaults>
 				<action-key>VIEW</action-key>


### PR DESCRIPTION
/cc @SpencerWoo 

Notes from Spencer:

> Ticket : https://issues.liferay.com/browse/LPS-70230
> 
> This changes the default permissions of the calendar, enabling the View Event Details option for site members, which is relevant for site calendars.  Below is the difference for site members (having View and View Event Details coupled by default) to highlight whether this option is a better default for site members.
> 
> This change does not affect existing calendars, and the calendar permissions are still configurable.  
> 
> Current default with the View option enabled : 
> ![image](https://cloud.githubusercontent.com/assets/24235208/22120318/2571a7bc-de34-11e6-9b62-09e979c60897.png)
> 
> Changed default with the View and View Event Details options enabled : 
> ![image](https://cloud.githubusercontent.com/assets/24235208/22120334/36ed379a-de34-11e6-9d92-8be645954a29.png)
> ![image](https://cloud.githubusercontent.com/assets/24235208/22120363/4a8cc298-de34-11e6-986f-1c2ac94f8214.png)