### PR TITLE
[TECHNICAL-SUPPORT] LPS-70314

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_redirect.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_redirect.jsp
@@ -19,6 +19,12 @@
 <%
 String redirect = request.getParameter("redirect");
 
+String workflowEnabledRedirect = ParamUtil.getString(request, "workflowEnabledRedirect");
+
+if (workflowEnabledRedirect != null) {
+	redirect = workflowEnabledRedirect;
+}
+
 redirect = PortalUtil.escapeRedirect(redirect);
 
 Portlet selPortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId(), portletDisplay.getId());

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/asset_actions.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/asset_actions.jsp
@@ -30,6 +30,12 @@ if (showEditURL && assetRenderer.hasEditPermission(permissionChecker)) {
 
 	redirectURL.setParameter("mvcPath", "/add_asset_redirect.jsp");
 
+	if (request.getAttribute("view.jsp-workflowEnabledRedirect") != null) {
+		String workflowEnabledRedirect = (String)request.getAttribute("view.jsp-workflowEnabledRedirect");
+
+		redirectURL.setParameter("workflowEnabledRedirect", workflowEnabledRedirect);
+	}
+
 	String fullContentRedirect = (String)request.getAttribute("view.jsp-fullContentRedirect");
 
 	if (fullContentRedirect != null) {

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/display/full_content.jsp
@@ -47,12 +47,18 @@ String title = assetRenderer.getTitle(LocaleUtil.fromLanguageId(languageId));
 
 boolean print = ((Boolean)request.getAttribute("view.jsp-print")).booleanValue();
 
+boolean workflowEnabled = WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName());
+
 assetPublisherDisplayContext.setLayoutAssetEntry(assetEntry);
 
 assetEntry = assetPublisherDisplayContext.incrementViewCounter(assetEntry);
 
 request.setAttribute("view.jsp-fullContentRedirect", currentURL);
 request.setAttribute("view.jsp-showIconLabel", true);
+
+if (workflowEnabled) {
+	request.setAttribute("view.jsp-workflowEnabledRedirect", redirect);
+}
 %>
 
 <div class="h2">

--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/resources/META-INF/resources/init.jsp
@@ -79,6 +79,7 @@ page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" 
 page import="com.liferay.portal.kernel.service.ClassNameLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.PortletLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.permission.PortletPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@


### PR DESCRIPTION
/cc @Alec-Shay 

Notes from Alec:

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-24041
> https://issues.liferay.com/browse/LPS-70314
> 
> When workflow is enabled for Blogs entries, editing a Blogs entry in an asset publisher where it would normally redirect to a view of the entry will throw an error because the entry is no longer unavailable.
> 
> The Blogs entry itself must be unavailable to the asset publisher because Blogs entries are not versioned; only one entry in the database is created, so when that entry is changed with a status of "pending," the entry is not available until the change is approved. This was explained as a limitation of Blogs here: https://in.liferay.com/web/support/forums/-/message_boards/message/29097470#_19_message_29167882
> 
> So, the solution being worked on for this ticket is simply to avoid throwing an error despite the entry no longer being available, by redirecting back to the main view of the asset publisher instead of trying to view the asset again.
> 
> At first I wanted to implement a way to detect whether the type of asset entry had versions or not when workflow was enabled, but I could not find a good way to tell in the code whether a new version would be created just from the AssetEntry itself (at least not without hard-coding for the specific BlogsEntry class, which I think isn't a good idea). So I ended up just doing this in any case where workflow is enabled. Even in the case of other types of asset entries, the changes still wouldn't show up until they were approved anyway, so I think this still is fine and may even reduce confusion. But I still think there's a chance it's not the correct solution, so I'd be interested in any further feedback.
> 
> Also, please note that while I've tested this in master and ee-7.0.x, there is another bug (just in master) that causes the interface when editing the Blogs entry in an asset publisher to be skewed out of the window so far that only the bottom of the "Submit for Publication" button can be seen. I was still able to test this by just clicking that button when editing, but if that causes any issues testing this, please let me know.
> 
> Thank you.