### PR TITLE
LPS-70361

### DIFF
--- a/modules/apps/collaboration/blogs/.gitrepo
+++ b/modules/apps/collaboration/blogs/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = aed304e560549e239c233dfe1ef21fe67255448f
+	commit = 7194b3c7eead4a58ba2b186eb85ee625ebf569ac
 	mode = push
-	parent = 9e83686f51f334ef57a2ad0768ce1455a48120b8
+	parent = b3c807c880bdb8946d3a1a8e9ac6aeab5a9242df
 	remote = git@github.com:liferay/com-liferay-blogs.git

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0a3e9c00c27a2439a1a21b81ca9249ded53fae33
+	commit = 4afa08ba1643ab3760d155921e357784366adf4d
 	mode = push
-	parent = 162a8ff63c7a745f883ed0c7851e628525e50181
+	parent = bc867136ad06eb6fc380cec812953580eb9177fe
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/message-boards/.gitrepo
+++ b/modules/apps/collaboration/message-boards/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 081a61e21baca8243cb35976e341d80752194488
+	commit = 8e2492e8873a1ecb47637e207a4c1838be224a0d
 	mode = push
-	parent = 285661bf7564cdb83544d3ab0d1074c84a46e217
+	parent = caac22ab1cdf21643cbc7858cf8aca8647152ac2
 	remote = git@github.com:liferay/com-liferay-message-boards.git

--- a/modules/apps/collaboration/wiki/.gitrepo
+++ b/modules/apps/collaboration/wiki/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = 0840ddbbd3c5a22c5191b8384d01f24106e5362e
+	commit = e4072efca2dcc16544e8d002f28cc3a14c51fe0a
 	mode = push
-	parent = 72421809fa92a1d6a8252dd67e5e80217783e775
+	parent = 03348a9cddfd5eac14e6417924033129b1fbe66f
 	remote = git@github.com:liferay/com-liferay-wiki.git

--- a/modules/apps/forms-and-workflow/calendar/.gitrepo
+++ b/modules/apps/forms-and-workflow/calendar/.gitrepo
@@ -3,7 +3,7 @@
 ;
 [subrepo]
 	cmdver = liferay
-	commit = d27b1e5b16c558b47111d0b683d429a720d3123b
+	commit = d4978c36dc504486762d934d72d6b51df302e3f8
 	mode = push
-	parent = 5606c66594d03ae1c2e5ae2e7fff24e765622c8a
+	parent = 07e2094482c6e3b752059fd4ce27bdca35fc8806
 	remote = git@github.com:liferay/com-liferay-calendar.git

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
@@ -1262,18 +1262,39 @@ public class BaseTextExportImportContentProcessor
 				privateLayout = layoutSet.isPrivateLayout();
 			}
 
-			String groupFriendlyURL = group.getFriendlyURL();
+			long companyId = group.getCompanyId();
 
-			if (url.equals(groupFriendlyURL)) {
+			if (GroupLocalServiceUtil.fetchFriendlyURLGroup(companyId, url) !=
+					null) {
+
 				continue;
 			}
 
-			if (url.startsWith(groupFriendlyURL + StringPool.SLASH)) {
-				url = url.substring(groupFriendlyURL.length());
+			if (LayoutLocalServiceUtil.fetchLayoutByFriendlyURL(
+					groupId, privateLayout, url) != null) {
+
+				continue;
 			}
 
+			int indexOfSecondSlash = url.indexOf(StringPool.SLASH, 1);
+
+			if (indexOfSecondSlash == -1) {
+				throw new NoSuchLayoutException();
+			}
+
+			Group urlGroup = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+				companyId, url.substring(0, indexOfSecondSlash));
+
+			if (urlGroup == null) {
+				throw new NoSuchLayoutException();
+			}
+
+			long urlGroupId = urlGroup.getGroupId();
+
+			url = url.substring(indexOfSecondSlash);
+
 			Layout layout = LayoutLocalServiceUtil.fetchLayoutByFriendlyURL(
-				groupId, privateLayout, url);
+				urlGroupId, privateLayout, url);
 
 			if (layout == null) {
 				throw new NoSuchLayoutException();


### PR DESCRIPTION
Hi @jonathanmccann,

This is a very high priority issue for a client, so Chris asked me to send the pull request directly to you. Also, we were wondering if we could do an SDH for this.

You may be concerned that we pass companyId in when we call GroupLocalServiceUtil.fetchFriendlyURLGroup. However, we can safely assume that the group (if it exists) will be in the same company because of the way replaceExportHostname works. replaceExportHostname will prevent the URL from being validated if it doesn't begin with the current company's virtualHost.