### PR TITLE
LPS-70431 Avoid rendering when ddmFormFieldValue has null values

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/internal/notification/DDLFormEmailNotificationSender.java
+++ b/modules/apps/forms-and-workflow/dynamic-data-lists/dynamic-data-lists-form-web/src/main/java/com/liferay/dynamic/data/lists/form/web/internal/notification/DDLFormEmailNotificationSender.java
@@ -257,7 +257,9 @@ public class DDLFormEmailNotificationSender {
 				}
 			}
 
-			sb.append(renderDDMFormFieldValue(ddmFormFieldValue, locale));
+			if (ddmFormFieldValue.getValue() != null) {
+				sb.append(renderDDMFormFieldValue(ddmFormFieldValue, locale));
+			}
 
 			if (i < (ddmFormFieldValues.size() - 1)) {
 				sb.append(StringPool.COMMA_AND_SPACE);


### PR DESCRIPTION
LPS : https://issues.liferay.com/browse/LPS-70431
LPP : https://issues.liferay.com/browse/LPP-24204

The problem is that a NPE is thrown ("Form Text" has a null "values" section for ddmFormFieldValue). There are various places where a fix would work to avoid the NPE and give the proper functionality for this LPS.

I chose this file to have the fix because it is directly related to FormEmailNotification. The fix itself is checking whether ddmFormFieldValue.getValue() is null. If it exists we sb.append(render) naturally.

From what I can tell we don't use the fact that NPEs are thrown based on a null "values" section for functionality, but if it is then I should do the fix in another way or in another location.