### PR TITLE
[TECHNICAL-SUPPORT] LPS-71052

### DIFF
--- a/portal-impl/src/com/liferay/portal/security/sso/SSOUtil.java
+++ b/portal-impl/src/com/liferay/portal/security/sso/SSOUtil.java
@@ -36,11 +36,16 @@ public class SSOUtil {
 	public static String getSessionExpirationRedirectURL(
 		long companyId, String sessionExpirationRedirectURL) {
 
-		if (_instance._ssoMap.isEmpty()) {
+		String ssoSessionExpirationRedirectURL =
+			_instance._getSessionExpirationRedirectUrl(companyId);
+
+		if (_instance._ssoMap.isEmpty() ||
+			(ssoSessionExpirationRedirectURL == null)) {
+
 			return sessionExpirationRedirectURL;
 		}
 
-		return _instance._getSessionExpirationRedirectUrl(companyId);
+		return ssoSessionExpirationRedirectURL;
 	}
 
 	public static String getSignInURL(long companyId, String signInURL) {


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:

> In LPS-71039, `isSessionRedirectOnExpire` was corrected to return true if the user has portal property _session.timeout.redirect.on.expire_=`true`
> 
> However, we also need to fix `getSessionExpirationRedirectURL` to make sure that the correct session expiration redirect url is returned. At this moment, `ssoMap` is default injected with three SSO services that return `null` for their session expiration redirect url. I'm writing code to return the url set in _company.default.home.url_ if every sso does not have a url set.