### PR TITLE
[TECHNICAL-SUPPORT] LPS-71134

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,16 +132,16 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
-		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
-			portletDataContext.getGroupId(), node.getName());
-
 		String nodeName = node.getName();
+
+		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
+			portletDataContext.getGroupId(), nodeName);
 
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {
 				if (nodeWithSameName != null) {
 					nodeName = getNodeName(
-						portletDataContext, node, node.getName(), 2);
+						portletDataContext, node, nodeName, 2);
 				}
 
 				serviceContext.setUuid(node.getUuid());

--- a/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
+++ b/modules/apps/collaboration/wiki/wiki-service/src/main/java/com/liferay/wiki/internal/exportimport/data/handler/WikiNodeStagedModelDataHandler.java
@@ -132,18 +132,37 @@ public class WikiNodeStagedModelDataHandler
 		WikiNode existingNode = fetchStagedModelByUuidAndGroupId(
 			node.getUuid(), portletDataContext.getScopeGroupId());
 
+		WikiNode nodeWithSameName = _wikiNodeLocalService.fetchNode(
+			portletDataContext.getGroupId(), node.getName());
+
+		String nodeName = node.getName();
+
 		if (portletDataContext.isDataStrategyMirror()) {
 			if (existingNode == null) {
+				if (nodeWithSameName != null) {
+					nodeName = getNodeName(
+						portletDataContext, node, node.getName(), 2);
+				}
+
 				serviceContext.setUuid(node.getUuid());
 
 				importedNode = _wikiNodeLocalService.addNode(
-					userId, node.getName(), node.getDescription(),
-					serviceContext);
+					userId, nodeName, node.getDescription(), serviceContext);
 			}
 			else {
+				String uuid = existingNode.getUuid();
+
+				if ((nodeWithSameName != null) &&
+					!uuid.equals(nodeWithSameName.getUuid()) &&
+					!nodeName.equals(existingNode.getName())) {
+
+					nodeName = getNodeName(
+						portletDataContext, node, nodeName, 2);
+				}
+
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
-					node.getDescription(), serviceContext);
+					existingNode.getNodeId(), nodeName, node.getDescription(),
+					serviceContext);
 			}
 		}
 		else {
@@ -154,12 +173,11 @@ public class WikiNodeStagedModelDataHandler
 				initialNodeName.equals(existingNode.getName())) {
 
 				importedNode = _wikiNodeLocalService.updateNode(
-					existingNode.getNodeId(), node.getName(),
-					node.getDescription(), serviceContext);
+					existingNode.getNodeId(), nodeName, node.getDescription(),
+					serviceContext);
 			}
 			else {
-				String nodeName = getNodeName(
-					portletDataContext, node, node.getName(), 2);
+				nodeName = getNodeName(portletDataContext, node, nodeName, 2);
 
 				importedNode = _wikiNodeLocalService.addNode(
 					userId, nodeName, node.getDescription(), serviceContext);


### PR DESCRIPTION
/cc @Alec-Shay 

Notes from Alec:
> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-24513
> https://issues.liferay.com/browse/LPS-71134
> 
> As a result of LPS-57516, a bug was exposed where importing Wiki nodes using the default "Mirror" import strategy would not work because it cannot handle name conflicts the same way other components can, despite code for it already being in place. This fix is leveraging the existing getNodeName() method to create a new name to avoid name conflicts when importing with the default "Mirror" strategy.