### PR TITLE
[TECHNICAL-SUPPORT] LPS-70366

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -4683,7 +4683,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 		user.setLastLoginDate(lastLoginDate);
 		user.setLastLoginIP(lastLoginIP);
 
-		resetFailedLoginAttempts(user, true);
+		user = resetFailedLoginAttempts(user, true);
 
 		return user;
 	}


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:

> The primary issue was found after testing LPS-70366/https://github.com/brianchandotcom/liferay-portal/pull/47500 locally with a fresh Test user. Because Test user does not have a `passwordModifiedDate` on creation, [isPasswordExpiringSoon](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/events/LoginPostAction.java#L110) was trying to update the Test user. Yet the [user retrieved from the request](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/events/LoginPostAction.java#L108) was stale. This fix establishes why the user was stale, and fixes it.
> 
> In `updateLastLogin`, the user is updated with a new object in the back end but not returned (pass by value error). This fix should then [pass back the right value to user](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/servlet/MainServlet.java#L1061), which will [correctly update the user in the request](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/servlet/MainServlet.java#L1066-L1069), ultimately allowing [`PortalUtil.getUser(request)` to return a not stale user](https://github.com/liferay/liferay-portal-ee/blob/master/portal-impl/src/com/liferay/portal/events/LoginPostAction.java#L108 ).
> 
> Keeping `getUser` is in response to https://github.com/jonathanmccann/liferay-portal/pull/1257