### PR TITLE
[TECHNICAL-SUPPORT] LPS-71727

### DIFF
--- a/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/foundation/portal-security/portal-security-ldap/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -21,6 +21,7 @@ import com.liferay.expando.kernel.util.ExpandoConverterUtil;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.SingleVMPool;
+import com.liferay.portal.kernel.exception.GroupFriendlyURLException;
 import com.liferay.portal.kernel.exception.NoSuchRoleException;
 import com.liferay.portal.kernel.exception.NoSuchUserGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -833,6 +834,22 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 					importGroups(ldapImportContext, userAttributes, user);
 				}
+				catch (GroupFriendlyURLException gfurle) {
+					int type = gfurle.getType();
+
+					if (type == GroupFriendlyURLException.DUPLICATE) {
+						_log.error(
+							"importing user " + searchResult +
+								" duplicates a group friendly url",
+							gfurle);
+					}
+					else {
+						_log.error(
+							"Unable to import user " +
+								searchResult,
+							gfurle);
+					}
+				}
 				catch (Exception e) {
 					_log.error("Unable to import user " + searchResult, e);
 				}
@@ -1236,6 +1253,20 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 						}
 
 						newUserIds.add(user.getUserId());
+					}
+				}
+				catch (GroupFriendlyURLException gfurle) {
+					int type = gfurle.getType();
+
+					if (type == GroupFriendlyURLException.DUPLICATE) {
+						_log.error(
+							"importing user " + userAttributes +
+								" duplicates a group friendly url",
+							gfurle);
+					}
+					else {
+						_log.error(
+							"Unable to import user " + userAttributes, gfurle);
 					}
 				}
 				catch (Exception e) {


### PR DESCRIPTION
/cc @NolanChan

Notes from Nolan:
> Follow up on https://github.com/jonathanmccann/liferay-portal/pull/1285
> 
> In my new fix, I've implemented the logging message in the code block responsible for Group LDAP Imports. I believe the same code manages the imports for 'import on start up' vs. 'import on logins.' However my LDAP configuration often kept erroring out on logins so this might need another confirmation. At the very least, the correct logging error pops up when Liferay pings back the LDAP server after log in.
> 
> >Improved Logging For LDAP Imports that Duplicate GroupFriendlyUrl's
> >
> >https://issues.liferay.com/browse/LPS-71727
> >https://issues.liferay.com/browse/LPP-24995
> >
> >Error message now reads:
> >`importing user CN=justin b: null:null:{samaccountname=sAMAccountName: justin} duplicates a group friendly url >com.liferay.portal.kernel.exception.GroupFriendlyURLException`