### PR TITLE
[TECHNICAL-SUPPORT] LPS-71983

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeMVCCVersion.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/upgrade/UpgradeMVCCVersion.java
@@ -46,8 +46,11 @@ public class UpgradeMVCCVersion extends UpgradeProcess {
 
 		tableName = normalizeName(tableName, databaseMetaData);
 
+		String catalog = connection.getCatalog();
+		String schema = connection.getSchema();
+
 		try (ResultSet tableResultSet = databaseMetaData.getTables(
-				null, null, tableName, null)) {
+				catalog, schema, tableName, null)) {
 
 			if (!tableResultSet.next()) {
 				_log.error("Table " + tableName + " does not exist");
@@ -56,7 +59,7 @@ public class UpgradeMVCCVersion extends UpgradeProcess {
 			}
 
 			try (ResultSet columnResultSet = databaseMetaData.getColumns(
-					null, null, tableName,
+					catalog, schema, tableName,
 					normalizeName("mvccVersion", databaseMetaData))) {
 
 				if (columnResultSet.next()) {


### PR DESCRIPTION
Hi Jonathan,

This change ensures we use the correct database metadata when upgrading to prevent columns appearing to exist when they do not.