### PR TITLE
[TECHNICAL-SUPPORT] LPS-69913

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/bnd.bnd
+++ b/modules/apps/web-experience/export-import/export-import-service/bnd.bnd
@@ -14,6 +14,9 @@ Export-Package:\
 	com.liferay.exportimport.staged.model.repository.base,\
 	com.liferay.exportimport.staging,\
 	com.liferay.exportimport.xstream
+Import-Package:\
+	com.liferay.portal.kernel.security.auth,\
+	*
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Data Management
 Liferay-Require-SchemaVersion: 1.0.0

--- a/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
@@ -179,6 +180,9 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 			try {
 				_liveGroupURL = StagingUtil.getRemoteSiteURL(
 					group, layout.isPrivateLayout());
+			}
+			catch (PrincipalException pe) {
+				_log.error(pe.getMessage());
 			}
 			catch (PortalException pe) {
 				_log.error(pe);

--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -46,6 +46,7 @@ page import="com.liferay.portal.kernel.model.LayoutSetBranch" %><%@
 page import="com.liferay.portal.kernel.model.LayoutSetBranchConstants" %><%@
 page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.security.auth.PrincipalException" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.service.LayoutBranchLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@

--- a/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -184,6 +184,18 @@ if (layout != null) {
 
 						<%
 						}
+						catch (PrincipalException pe) {
+							_log.error("User " + user.getScreenName() + " must be authenticated");
+						%>
+
+							<a class="control-menu-icon" value="go-to-remote-live">
+								<aui:icon image="home" label="go-to-remote-live" markupView="lexicon" />
+							</a>
+
+							<liferay-ui:icon icon="exclamation-full" markupView="lexicon" message="an-unexpected-error-occurred" toolTip="<%= true %>" />
+
+						<%
+						}
 						catch (SystemException se) {
 							_log.error(se, se);
 						%>

--- a/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
+++ b/portal-impl/src/com/liferay/portal/security/auth/tunnel/TunnelAuthenticationManagerImpl.java
@@ -130,7 +130,9 @@ public class TunnelAuthenticationManagerImpl
 
 			authException.setType(AuthException.INTERNAL_SERVER_ERROR);
 
-			throw authException;
+			if (_log.isWarnEnabled()) {
+				_log.warn(authException.getMessage());
+			}
 		}
 
 		return user.getUserId();

--- a/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/http/TunnelUtil.java
@@ -66,6 +66,13 @@ public class TunnelUtil {
 
 		Thread thread = Thread.currentThread();
 
+		int responseCode = httpURLConnection.getResponseCode();
+
+		if ((responseCode == 401) || (responseCode == 403)) {
+			throw new PrincipalException.MustBeAuthenticated(
+				httpPrincipal.getLogin());
+		}
+
 		try (ObjectInputStream objectInputStream =
 				new ProtectedClassLoaderObjectInputStream(
 					httpURLConnection.getInputStream(),
@@ -76,19 +83,6 @@ public class TunnelUtil {
 		catch (EOFException eofe) {
 			if (_log.isDebugEnabled()) {
 				_log.debug("Unable to read object", eofe);
-			}
-		}
-		catch (IOException ioe) {
-			String ioeMessage = ioe.getMessage();
-
-			if ((ioeMessage != null) &&
-				ioeMessage.contains("HTTP response code: 401")) {
-
-				throw new PrincipalException.MustBeAuthenticated(
-					httpPrincipal.getLogin());
-			}
-			else {
-				throw ioe;
 			}
 		}
 


### PR DESCRIPTION
/cc @JoshuaStClair

Notes from Josh:

> When doing remote staging, the user needs to exist and have staging permissions on both servers, otherwise a RemoteAuthException will occur. Although throwing this exception is the expected behavior, the client has requested for a way to suppress these errors and reduce the stack traces to avoid blowing up their logs. As it currently stands, the stack traces make the error look like a bug rather than the expected behavior. So a couple of steps were taken to reduce the output to the console and make the error messages cleaner.
> First, the RemoteAuthException was reduced to a WARN so it could be toggled off and only the error message is displayed instead of the full stack trace.
> A ClassNotFoundException is also thrown since the staging module cannot find com.liferay.portal.kernel.security.auth at run time. The bnd was modified to add this import.
> After implementing these changes, the calling server started to report a 403 error and stack trace when trying to access the remote server. So before getting the input stream, a check was added to make sure the response code is good, otherwise, throw a PrincipalException for authentication. To catch the PrincipalException we are throwing, a catch was added in the view.jsp which logs a message explaining the error. 
> After catching that error, SiteAdministrationPanelCategoryDisplayContext was logging another stack trace, PrincipalException$MustBeAuthenticatedException, so I added another catch block for that to reduce the error message to a single line.
> 
> [LPS-69913](https://issues.liferay.com/browse/LPS-69913) deals specifically with the staging bar not displaying but it is caused by the RemoteAuthException this fix addresses.