### PR TITLE
[TECHNICAL-SUPPORT] LPS-72155

### DIFF
--- a/modules/apps/foundation/password-policies-admin/.gitrepo
+++ b/modules/apps/foundation/password-policies-admin/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 4441f2b4d8d84613ab439e8a2d5b2b429e9cd660
+	commit = 448617aa14ae2baa06293c14636672091818c52f
 	mergebuttonmergecommits = false
 	mode = push
-	parent = cdcc8bc122e5974b7dc4561ec1af05548b79bf17
+	parent = ff6bd56618e42e8289a84547840c291a2d4f343c
 	remote = git@github.com:liferay/com-liferay-password-policies-admin.git

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/build.gradle
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/build.gradle
@@ -5,7 +5,7 @@ dependencies {
 	provided group: "com.liferay", name: "com.liferay.password.policies.admin.api", version: "2.0.0"
 	provided group: "com.liferay", name: "com.liferay.portal.upgrade", version: "2.0.0"
 	provided group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "2.0.0"
-	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "2.7.0"
+	provided group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	provided group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "2.0.0"
 	provided group: "javax.portlet", name: "portlet-api", version: "2.0"
 	provided group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -55,6 +55,7 @@ page import="com.liferay.portal.kernel.security.ldap.LDAPSettingsUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.service.PasswordPolicyLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.PasswordPolicyRelLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.service.PasswordPolicyServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.service.permission.PortalPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/foundation/password-policies-admin/password-policies-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -122,11 +122,11 @@ PortalUtil.addPortletBreadcrumbEntry(request, LanguageUtil.get(request, "passwor
 			<%
 			PasswordPolicyDisplayTerms searchTerms = (PasswordPolicyDisplayTerms)passwordPolicySearchContainer.getSearchTerms();
 
-			total = PasswordPolicyLocalServiceUtil.searchCount(company.getCompanyId(), searchTerms.getKeywords());
+			total = PasswordPolicyServiceUtil.searchCount(company.getCompanyId(), searchTerms.getKeywords());
 
 			passwordPolicySearchContainer.setTotal(total);
 
-			List results = PasswordPolicyLocalServiceUtil.search(company.getCompanyId(), searchTerms.getKeywords(), passwordPolicySearchContainer.getStart(), passwordPolicySearchContainer.getEnd(), passwordPolicySearchContainer.getOrderByComparator());
+			List results = PasswordPolicyServiceUtil.search(company.getCompanyId(), searchTerms.getKeywords(), passwordPolicySearchContainer.getStart(), passwordPolicySearchContainer.getEnd(), passwordPolicySearchContainer.getOrderByComparator());
 
 			passwordPolicySearchContainer.setResults(results);
 

--- a/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/web-experience/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -353,9 +353,13 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 	}
 
 	public boolean isShowSiteSelector() throws PortalException {
-		List<Group> mySites = getMySites();
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			_portletRequest);
 
-		if (mySites.isEmpty()) {
+		List<Group> mySites = getMySites();
+		List<Group> recentSites = _recentGroupManager.getRecentGroups(request);
+
+		if (mySites.isEmpty() && recentSites.isEmpty()) {
 			return false;
 		}
 

--- a/portal-impl/src/com/liferay/portal/service/http/PasswordPolicyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/PasswordPolicyServiceHttp.java
@@ -161,6 +161,62 @@ public class PasswordPolicyServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> search(
+		HttpPrincipal httpPrincipal, long companyId, java.lang.String name,
+		int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc) {
+		try {
+			MethodKey methodKey = new MethodKey(PasswordPolicyServiceUtil.class,
+					"search", _searchParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					companyId, name, start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portal.kernel.model.PasswordPolicy>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static int searchCount(HttpPrincipal httpPrincipal, long companyId,
+		java.lang.String name) {
+		try {
+			MethodKey methodKey = new MethodKey(PasswordPolicyServiceUtil.class,
+					"searchCount", _searchCountParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					companyId, name);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return ((Integer)returnObj).intValue();
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static com.liferay.portal.kernel.model.PasswordPolicy updatePasswordPolicy(
 		HttpPrincipal httpPrincipal, long passwordPolicyId,
 		java.lang.String name, java.lang.String description,
@@ -175,7 +231,7 @@ public class PasswordPolicyServiceHttp {
 		throws com.liferay.portal.kernel.exception.PortalException {
 		try {
 			MethodKey methodKey = new MethodKey(PasswordPolicyServiceUtil.class,
-					"updatePasswordPolicy", _updatePasswordPolicyParameterTypes3);
+					"updatePasswordPolicy", _updatePasswordPolicyParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					passwordPolicyId, name, description, changeable,
@@ -224,7 +280,14 @@ public class PasswordPolicyServiceHttp {
 	private static final Class<?>[] _fetchPasswordPolicyParameterTypes2 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updatePasswordPolicyParameterTypes3 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes3 = new Class[] {
+			long.class, java.lang.String.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _searchCountParameterTypes4 = new Class[] {
+			long.class, java.lang.String.class
+		};
+	private static final Class<?>[] _updatePasswordPolicyParameterTypes5 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String.class,
 			boolean.class, boolean.class, long.class, boolean.class,
 			boolean.class, int.class, int.class, int.class, int.class, int.class,

--- a/portal-impl/src/com/liferay/portal/service/http/PasswordPolicyServiceSoap.java
+++ b/portal-impl/src/com/liferay/portal/service/http/PasswordPolicyServiceSoap.java
@@ -120,6 +120,39 @@ public class PasswordPolicyServiceSoap {
 		}
 	}
 
+	public static com.liferay.portal.kernel.model.PasswordPolicySoap[] search(
+		long companyId, java.lang.String name, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> returnValue =
+				PasswordPolicyServiceUtil.search(companyId, name, start, end,
+					obc);
+
+			return com.liferay.portal.kernel.model.PasswordPolicySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static int searchCount(long companyId, java.lang.String name)
+		throws RemoteException {
+		try {
+			int returnValue = PasswordPolicyServiceUtil.searchCount(companyId,
+					name);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.portal.kernel.model.PasswordPolicySoap updatePasswordPolicy(
 		long passwordPolicyId, java.lang.String name,
 		java.lang.String description, boolean changeable,

--- a/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PasswordPolicyServiceImpl.java
@@ -20,7 +20,10 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.PasswordPolicyPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.service.base.PasswordPolicyServiceBaseImpl;
+
+import java.util.List;
 
 /**
  * @author Scott Lee
@@ -74,6 +77,20 @@ public class PasswordPolicyServiceImpl extends PasswordPolicyServiceBaseImpl {
 		}
 
 		return passwordPolicy;
+	}
+
+	@Override
+	public List<PasswordPolicy> search(
+		long companyId, String name, int start, int end,
+		OrderByComparator<PasswordPolicy> obc) {
+
+		return passwordPolicyFinder.filterFindByC_N(
+			companyId, name, start, end, obc);
+	}
+
+	@Override
+	public int searchCount(long companyId, String name) {
+		return passwordPolicyFinder.filterCountByC_N(companyId, name);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyFinderImpl.java
@@ -44,6 +44,33 @@ public class PasswordPolicyFinderImpl
 
 	@Override
 	public int countByC_N(long companyId, String name) {
+		return doCountByC_N(companyId, name, false);
+	}
+
+	@Override
+	public int filterCountByC_N(long companyId, String name) {
+		return doCountByC_N(companyId, name, true);
+	}
+
+	@Override
+	public List<PasswordPolicy> filterFindByC_N(
+		long companyId, String name, int start, int end,
+		OrderByComparator<PasswordPolicy> obc) {
+
+		return doFindByC_N(companyId, name, start, end, obc, true);
+	}
+
+	@Override
+	public List<PasswordPolicy> findByC_N(
+		long companyId, String name, int start, int end,
+		OrderByComparator<PasswordPolicy> obc) {
+
+		return doFindByC_N(companyId, name, start, end, obc, false);
+	}
+
+	protected int doCountByC_N(
+		long companyId, String name, boolean inlineSQLHelper) {
+
 		name = CustomSQLUtil.keywords(name)[0];
 
 		Session session = null;
@@ -52,6 +79,15 @@ public class PasswordPolicyFinderImpl
 			session = openSession();
 
 			String sql = CustomSQLUtil.get(COUNT_BY_C_N);
+
+			if (inlineSQLHelper &&
+				InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+
+				sql = InlineSQLHelperUtil.replacePermissionCheck(
+					sql, PasswordPolicy.class.getName(),
+					"PasswordPolicy.passwordPolicyId", null, null,
+					new long[] {0}, null);
+			}
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 
@@ -81,22 +117,6 @@ public class PasswordPolicyFinderImpl
 		finally {
 			closeSession(session);
 		}
-	}
-
-	@Override
-	public List<PasswordPolicy> filterFindByC_N(
-		long companyId, String name, int start, int end,
-		OrderByComparator<PasswordPolicy> obc) {
-
-		return doFindByC_N(companyId, name, start, end, obc, true);
-	}
-
-	@Override
-	public List<PasswordPolicy> findByC_N(
-		long companyId, String name, int start, int end,
-		OrderByComparator<PasswordPolicy> obc) {
-
-		return doFindByC_N(companyId, name, start, end, obc, false);
 	}
 
 	protected List<PasswordPolicy> doFindByC_N(

--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/PasswordPolicyFinderImpl.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.Type;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.model.PasswordPolicy;
+import com.liferay.portal.kernel.security.permission.InlineSQLHelperUtil;
 import com.liferay.portal.kernel.service.persistence.PasswordPolicyFinder;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.model.impl.PasswordPolicyImpl;
@@ -83,9 +84,24 @@ public class PasswordPolicyFinderImpl
 	}
 
 	@Override
+	public List<PasswordPolicy> filterFindByC_N(
+		long companyId, String name, int start, int end,
+		OrderByComparator<PasswordPolicy> obc) {
+
+		return doFindByC_N(companyId, name, start, end, obc, true);
+	}
+
+	@Override
 	public List<PasswordPolicy> findByC_N(
 		long companyId, String name, int start, int end,
 		OrderByComparator<PasswordPolicy> obc) {
+
+		return doFindByC_N(companyId, name, start, end, obc, false);
+	}
+
+	protected List<PasswordPolicy> doFindByC_N(
+		long companyId, String name, int start, int end,
+		OrderByComparator<PasswordPolicy> obc, boolean inlineSQLHelper) {
 
 		name = CustomSQLUtil.keywords(name)[0];
 
@@ -97,6 +113,15 @@ public class PasswordPolicyFinderImpl
 			String sql = CustomSQLUtil.get(FIND_BY_C_N);
 
 			sql = CustomSQLUtil.replaceOrderBy(sql, obc);
+
+			if (inlineSQLHelper &&
+				InlineSQLHelperUtil.isEnabled(companyId, 0)) {
+
+				sql = InlineSQLHelperUtil.replacePermissionCheck(
+					sql, PasswordPolicy.class.getName(),
+					"PasswordPolicy.passwordPolicyId", null, null,
+					new long[] {0}, null);
+			}
 
 			SQLQuery q = session.createSynchronizedSQLQuery(sql);
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -81,6 +81,8 @@ public class AssetVocabularyLocalServiceImpl
 
 		ServiceContext serviceContext = new ServiceContext();
 
+		serviceContext.setAddGuestPermissions(true);
+
 		serviceContext.setScopeGroupId(groupId);
 
 		return assetVocabularyLocalService.addVocabulary(

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -82,7 +82,6 @@ public class AssetVocabularyLocalServiceImpl
 		ServiceContext serviceContext = new ServiceContext();
 
 		serviceContext.setAddGuestPermissions(true);
-
 		serviceContext.setScopeGroupId(groupId);
 
 		return assetVocabularyLocalService.addVocabulary(

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyService.java
@@ -24,6 +24,9 @@ import com.liferay.portal.kernel.security.access.control.AccessControlled;
 import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+import java.util.List;
 
 /**
  * Provides the remote service interface for PasswordPolicy. Methods of this
@@ -73,12 +76,19 @@ public interface PasswordPolicyService extends BaseService {
 		long resetFailureCount, long resetTicketMaxAge,
 		ServiceContext serviceContext) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int searchCount(long companyId, java.lang.String name);
+
 	/**
 	* Returns the OSGi service identifier.
 	*
 	* @return the OSGi service identifier
 	*/
 	public java.lang.String getOSGiServiceIdentifier();
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<PasswordPolicy> search(long companyId, java.lang.String name,
+		int start, int end, OrderByComparator<PasswordPolicy> obc);
 
 	public void deletePasswordPolicy(long passwordPolicyId)
 		throws PortalException;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyServiceUtil.java
@@ -88,6 +88,10 @@ public class PasswordPolicyServiceUtil {
 			serviceContext);
 	}
 
+	public static int searchCount(long companyId, java.lang.String name) {
+		return getService().searchCount(companyId, name);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*
@@ -95,6 +99,12 @@ public class PasswordPolicyServiceUtil {
 	*/
 	public static java.lang.String getOSGiServiceIdentifier() {
 		return getService().getOSGiServiceIdentifier();
+	}
+
+	public static java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> search(
+		long companyId, java.lang.String name, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc) {
+		return getService().search(companyId, name, start, end, obc);
 	}
 
 	public static void deletePasswordPolicy(long passwordPolicyId)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PasswordPolicyServiceWrapper.java
@@ -81,6 +81,11 @@ public class PasswordPolicyServiceWrapper implements PasswordPolicyService,
 			serviceContext);
 	}
 
+	@Override
+	public int searchCount(long companyId, java.lang.String name) {
+		return _passwordPolicyService.searchCount(companyId, name);
+	}
+
 	/**
 	* Returns the OSGi service identifier.
 	*
@@ -89,6 +94,13 @@ public class PasswordPolicyServiceWrapper implements PasswordPolicyService,
 	@Override
 	public java.lang.String getOSGiServiceIdentifier() {
 		return _passwordPolicyService.getOSGiServiceIdentifier();
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> search(
+		long companyId, java.lang.String name, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc) {
+		return _passwordPolicyService.search(companyId, name, start, end, obc);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/PasswordPolicyFinder.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/PasswordPolicyFinder.java
@@ -24,6 +24,12 @@ import aQute.bnd.annotation.ProviderType;
 public interface PasswordPolicyFinder {
 	public int countByC_N(long companyId, java.lang.String name);
 
+	public int filterCountByC_N(long companyId, java.lang.String name);
+
+	public java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> filterFindByC_N(
+		long companyId, java.lang.String name, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc);
+
 	public java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> findByC_N(
 		long companyId, java.lang.String name, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc);

--- a/portal-kernel/src/com/liferay/portal/kernel/service/persistence/PasswordPolicyFinderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/persistence/PasswordPolicyFinderUtil.java
@@ -29,6 +29,16 @@ public class PasswordPolicyFinderUtil {
 		return getFinder().countByC_N(companyId, name);
 	}
 
+	public static int filterCountByC_N(long companyId, java.lang.String name) {
+		return getFinder().filterCountByC_N(companyId, name);
+	}
+
+	public static java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> filterFindByC_N(
+		long companyId, java.lang.String name, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc) {
+		return getFinder().filterFindByC_N(companyId, name, start, end, obc);
+	}
+
 	public static java.util.List<com.liferay.portal.kernel.model.PasswordPolicy> findByC_N(
 		long companyId, java.lang.String name, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator<com.liferay.portal.kernel.model.PasswordPolicy> obc) {


### PR DESCRIPTION
Relevant tickets:
[LPS-72155](https://issues.liferay.com/browse/LPS-72155)
[LPS-62282](https://issues.liferay.com/browse/LPS-62282)

If the user is not a member of any sites, the site selector button does not display. This was caused by LPS-62282 because the pop up would be blank if the button was clicked.

This change adds an additional check to see if there are recently visited sites that are able to be displayed and selected. If that is the case, we want users to be able to navigate to recent sites even if they are not members of any sites.

Please let me know if there are any problems, thanks.