### PR TITLE
LPS-72290 Validate poll empty selection before submission

### DIFF
--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls/view_question.jsp
@@ -65,19 +65,24 @@ portletDisplay.setURLBack(redirect);
 
 			<c:choose>
 				<c:when test="<%= !viewResults && !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+					<div class="form-group">
 
-					<%
-					for (PollsChoice choice : choices) {
-						choice = choice.toEscapedModel();
-					%>
+						<%
+						for (PollsChoice choice : choices) {
+							choice = choice.toEscapedModel();
+						%>
 
-						<aui:field-wrapper cssClass="radio">
-							<aui:input label='<%= choice.getName() + ". " + choice.getDescription(locale) %>' name="choiceId" type="radio" value="<%= choice.getChoiceId() %>" />
-						</aui:field-wrapper>
+							<aui:field-wrapper cssClass="radio">
+								<aui:input label='<%= choice.getName() + ". " + choice.getDescription(locale) %>' name="choiceId" type="radio" value="<%= choice.getChoiceId() %>">
+									<aui:validator name="required" />
+								</aui:input>
+							</aui:field-wrapper>
 
-					<%
-					}
-					%>
+						<%
+						}
+						%>
+
+					</div>
 
 					<c:if test="<%= PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.UPDATE) %>">
 						<portlet:renderURL var="viewResultsURL">
@@ -133,3 +138,16 @@ portletDisplay.setURLBack(redirect);
 		</aui:fieldset>
 	</aui:fieldset-group>
 </aui:form>
+
+<aui:script use="aui-base,selector-css3">
+	var form = A.one('#<portlet:namespace />fm');
+
+	if (form) {
+		form.on(
+			'submit',
+			function(event) {
+				submitForm(form);
+			}
+		);
+	}
+</aui:script>

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -83,19 +83,24 @@ catch (NoSuchQuestionException nsqe) {
 
 					<c:choose>
 						<c:when test="<%= !question.isExpired() && !hasVoted && PollsQuestionPermissionChecker.contains(permissionChecker, question, ActionKeys.ADD_VOTE) %>">
+							<div class="form-group">
 
-							<%
-							for (PollsChoice choice : choices) {
-								choice = choice.toEscapedModel();
-							%>
+								<%
+								for (PollsChoice choice : choices) {
+									choice = choice.toEscapedModel();
+								%>
 
-								<aui:field-wrapper cssClass="radio">
-									<aui:input label='<%= choice.getName() + ". " + choice.getDescription(locale) %>' name="choiceId" type="radio" value="<%= choice.getChoiceId() %>" />
-								</aui:field-wrapper>
+									<aui:field-wrapper cssClass="radio">
+										<aui:input label='<%= choice.getName() + ". " + choice.getDescription(locale) %>' name="choiceId" type="radio" value="<%= choice.getChoiceId() %>">
+											<aui:validator name="required" />
+										</aui:input>
+									</aui:field-wrapper>
 
-							<%
-							}
-							%>
+								<%
+								}
+								%>
+
+							</div>
 
 							<aui:button-row>
 								<aui:button type="submit" value="vote[action]" />
@@ -114,5 +119,18 @@ catch (NoSuchQuestionException nsqe) {
 				</aui:fieldset>
 			</aui:fieldset-group>
 		</aui:form>
+
+		<aui:script use="aui-base,selector-css3">
+			var form = A.one('#<portlet:namespace />fm');
+
+			if (form) {
+				form.on(
+					'submit',
+					function(event) {
+						submitForm(form);
+					}
+				);
+			}
+		</aui:script>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
+++ b/modules/apps/forms-and-workflow/polls/polls-web/src/main/resources/META-INF/resources/polls_display/view.jsp
@@ -103,7 +103,7 @@ catch (NoSuchQuestionException nsqe) {
 							</div>
 
 							<aui:button-row>
-								<aui:button type="submit" value="vote[action]" />
+								<aui:button cssClass="btn-lg" type="submit" value="vote[action]" />
 							</aui:button-row>
 						</c:when>
 						<c:otherwise>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-72290

**Changes**
The first commit we use `<aui:validator>` to reject empty polls before submission.  

The second commit we increase the button size for consistency across other submit buttons (login, DDLs, Web Content -> Polls, etc) as well as to mitigate the issue of LPS-72383.

**Additional Notes**
The behavior of polls matches the behavior of DDL -> Data Definition -> required radio buttons.  
This frontend validation should prevent backend NoSuchChoiceExceptions.