### PR TITLE
LPS-73582 Revert changes to getLocalizedFriendlyURL made by LPS-59252

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -3567,26 +3567,12 @@ public class PortalImpl implements Portal {
 		else {
 			layoutFriendlyURL = layout.getFriendlyURL(originalLocale);
 		}
-
-		String friendlyURL = StringPool.SLASH;
-
+		
 		if (requestURI.contains(layoutFriendlyURL)) {
 			friendlyURL = layout.getFriendlyURL(locale);
 
 			requestURI = StringUtil.replaceFirst(
 				requestURI, layoutFriendlyURL, friendlyURL);
-		}
-
-		LayoutSet layoutSet = layout.getLayoutSet();
-
-		String virtualHostname = layoutSet.getVirtualHostname();
-
-		String portalURL = getPortalURL(request);
-
-		if (Validator.isNull(virtualHostname) ||
-			!portalURL.contains(virtualHostname)) {
-
-			friendlyURL = requestURI;
 		}
 
 		String i18nPath =
@@ -3608,7 +3594,7 @@ public class PortalImpl implements Portal {
 			localizedFriendlyURL += i18nPath;
 		}
 
-		localizedFriendlyURL += friendlyURL;
+		localizedFriendlyURL += requestURI;
 
 		String queryString = request.getQueryString();
 


### PR DESCRIPTION
Original commit that is being reverted is d1eaeee as it causes a regression in the behavior of the method when using a virtual host, causing the redirect to not go to the right URL (as requestURI is not appended).