### PR TITLE
[TECHNICAL-SUPPORT]

### DIFF
--- a/build-common.xml
+++ b/build-common.xml
@@ -645,7 +645,7 @@ information.
 								<then>
 									<local name="outputproperty" />
 
-									<propertycopy name="outputproperty" from="@{outputproperty}" />
+									<propertycopy from="@{outputproperty}" name="outputproperty" />
 
 									<echo message="${outputproperty}" />
 								</then>

--- a/build-common.xml
+++ b/build-common.xml
@@ -624,18 +624,34 @@ information.
 			<if>
 				<equals arg1="${task.available}" arg2="true" />
 				<then>
-					<exec dir="@{dir}" executable="${project.dir}/gradlew${gradlew.suffix}" failonerror="@{failonerror}">
-						<args />
-						<arg value="--no-daemon" />
-						<arg value="--project-cache-dir=${project.dir}/.gradle" />
-						<arg value="--stacktrace" />
-						<arg value="-Dapp.server.parent.dir=${app.server.parent.dir}" />
-						<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
-						<arg value="-Dliferay.home=${liferay.home}" />
-						<arg value="@{task}" />
-						<env key="GRADLE_OPTS" value="${env.ANT_OPTS}" />
-						<redirector errorproperty="@{outputproperty}.error" outputproperty="@{outputproperty}" unless:blank="@{outputproperty}" />
-					</exec>
+					<trycatch>
+						<try>
+							<exec dir="@{dir}" executable="${project.dir}/gradlew${gradlew.suffix}" failonerror="@{failonerror}">
+								<args />
+								<arg value="--no-daemon" />
+								<arg value="--project-cache-dir=${project.dir}/.gradle" />
+								<arg value="--stacktrace" />
+								<arg value="-Dapp.server.parent.dir=${app.server.parent.dir}" />
+								<arg value="-Dforced.cache.enabled=@{forcedcacheenabled}" />
+								<arg value="-Dliferay.home=${liferay.home}" />
+								<arg value="@{task}" />
+								<env key="GRADLE_OPTS" value="${env.ANT_OPTS}" />
+								<redirector errorproperty="@{outputproperty}.error" outputproperty="@{outputproperty}" unless:blank="@{outputproperty}" />
+							</exec>
+						</try>
+						<finally>
+							<if>
+								<isset property="@{outputproperty}" />
+								<then>
+									<local name="outputproperty" />
+
+									<propertycopy name="outputproperty" from="@{outputproperty}" />
+
+									<echo message="${outputproperty}" />
+								</then>
+							</if>
+						</finally>
+					</trycatch>
 				</then>
 				<else>
 					<echo>Skipped unavailable task: @{task}.</echo>

--- a/modules/apps/collaboration/document-library/.gitrepo
+++ b/modules/apps/collaboration/document-library/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = fe0f0daebfe50d23ad6a8af1b2ccacf05074f071
+	commit = b5354d3af6f7354437b30e4dcc8109f95e329390
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5cfff29d6bdb9f80d9100fca29713c8f0260733a
+	parent = a5f54629915af5fa5ea46fb8ef593079ee3cd8cf
 	remote = git@github.com:liferay/com-liferay-document-library.git

--- a/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
+++ b/modules/apps/collaboration/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/trash/test/DLFileEntryTrashHandlerTest.java
@@ -445,35 +445,40 @@ public class DLFileEntryTrashHandlerTest
 		BaseModel<?> parentBaseModel = getParentBaseModel(
 			group, serviceContext);
 
-		BaseModel<?> baseModel = addBaseModel(parentBaseModel, serviceContext);
-
-		DLAppLocalServiceUtil.addFileRank(
-			group.getGroupId(), TestPropsValues.getCompanyId(),
-			TestPropsValues.getUserId(), (Long)baseModel.getPrimaryKeyObj(),
-			serviceContext);
-
-		Assert.assertEquals(
-			1,
-			getActiveDLFileRanksCount(
-				group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
-
-		moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
-
-		Assert.assertEquals(
-			0,
-			getActiveDLFileRanksCount(
-				group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
-
 		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
 			getBaseModelClassName());
 
-		trashHandler.restoreTrashEntry(
-			TestPropsValues.getUserId(), getTrashEntryClassPK(baseModel));
+		try {
+			baseModel = addBaseModel(parentBaseModel, serviceContext);
 
-		Assert.assertEquals(
-			1,
-			getActiveDLFileRanksCount(
-				group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
+			DLAppLocalServiceUtil.addFileRank(
+				group.getGroupId(), TestPropsValues.getCompanyId(),
+				TestPropsValues.getUserId(), (Long)baseModel.getPrimaryKeyObj(),
+				serviceContext);
+
+			Assert.assertEquals(
+				1,
+				getActiveDLFileRanksCount(
+					group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
+
+			moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
+
+			Assert.assertEquals(
+				0,
+				getActiveDLFileRanksCount(
+					group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
+
+			trashHandler.restoreTrashEntry(
+				TestPropsValues.getUserId(), getTrashEntryClassPK(baseModel));
+
+			Assert.assertEquals(
+				1,
+				getActiveDLFileRanksCount(
+					group.getGroupId(), (Long)baseModel.getPrimaryKeyObj()));
+		}
+		finally {
+			trashHandler.deleteTrashEntry(getTrashEntryClassPK(baseModel));
+		}
 	}
 
 	private static final String _FILE_ENTRY_TITLE = RandomTestUtil.randomString(

--- a/modules/apps/foundation/frontend-theme/frontend-theme-contributor-extender/src/main/java/com/liferay/frontend/theme/contributor/extender/internal/ThemeContributorDynamicInclude.java
+++ b/modules/apps/foundation/frontend-theme/frontend-theme-contributor-extender/src/main/java/com/liferay/frontend/theme/contributor/extender/internal/ThemeContributorDynamicInclude.java
@@ -201,7 +201,7 @@ public class ThemeContributorDynamicInclude implements DynamicInclude {
 		long themeLastModified, HttpServletRequest request,
 		PrintWriter printWriter) {
 
-		printWriter.write("<link data-senna-track=\"temporary\" href=\"");
+		printWriter.write("<link data-senna-track=\"permanent\" href=\"");
 
 		printWriter.write(
 			_portal.getStaticResourceURL(
@@ -215,7 +215,7 @@ public class ThemeContributorDynamicInclude implements DynamicInclude {
 		long themeLastModified, HttpServletRequest request,
 		PrintWriter printWriter) {
 
-		printWriter.write("<script data-senna-track=\"temporary\" src=\"");
+		printWriter.write("<script data-senna-track=\"permanent\" src=\"");
 
 		printWriter.write(
 			_portal.getStaticResourceURL(
@@ -235,7 +235,7 @@ public class ThemeContributorDynamicInclude implements DynamicInclude {
 				portalURL.concat(_portal.getPathProxy()).concat(resourceURL),
 				themeLastModified);
 
-			printWriter.write("<link data-senna-track=\"temporary\" href=\"");
+			printWriter.write("<link data-senna-track=\"permanent\" href=\"");
 			printWriter.write(staticResourceURL);
 			printWriter.write("\" rel=\"stylesheet\" type = \"text/css\" />\n");
 		}
@@ -251,7 +251,7 @@ public class ThemeContributorDynamicInclude implements DynamicInclude {
 				portalURL.concat(_portal.getPathProxy()).concat(resourceURL),
 				themeLastModified);
 
-			printWriter.write("<script data-senna-track=\"temporary\" src=\"");
+			printWriter.write("<script data-senna-track=\"permanent\" src=\"");
 			printWriter.write(staticResourceURL);
 			printWriter.write("\" \" type = \"text/javascript\"></script>\n");
 		}

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/override/test/LPKGOverrideVerifyTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/override/test/LPKGOverrideVerifyTest.java
@@ -95,12 +95,12 @@ public class LPKGOverrideVerifyTest {
 					"Static JAR not sucessfully overridden: " + symbolicName,
 					location.contains("Static-Jar::"));
 			}
-			else if (wars.remove(symbolicName)) {
+			else {
 				String location = bundle.getLocation();
 
-				Assert.assertTrue(
-					"WAR not sucessfully overridden: " + symbolicName,
-					location.contains("protocol=file"));
+				if (location.contains("protocol=file")) {
+					wars.remove(symbolicName);
+				}
 			}
 		}
 

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/override/test/LPKGRevertOverrideVerifyTest.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-test/src/testIntegration/java/com/liferay/portal/lpkg/deployer/override/test/LPKGRevertOverrideVerifyTest.java
@@ -103,12 +103,12 @@ public class LPKGRevertOverrideVerifyTest {
 					"Static JAR not sucessfully reverted: " + symbolicName,
 					!location.contains("Static-Jar::"));
 			}
-			else if (wars.remove(symbolicName)) {
+			else {
 				String location = bundle.getLocation();
 
-				Assert.assertTrue(
-					"WAR not sucessfully reverted: " + symbolicName,
-					location.contains("protocol=lpkg"));
+				if (location.contains("protocol=lpkg")) {
+					wars.remove(symbolicName);
+				}
 			}
 		}
 

--- a/modules/apps/web-experience/staging/.gitrepo
+++ b/modules/apps/web-experience/staging/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 0f13e49d4a17cced1081c82df9c6f0ad253e5e06
+	commit = 11a20d776fa648345464f2fad74953c142313a47
 	mergebuttonmergecommits = false
 	mode = push
-	parent = dafaa9e76d54204182bac1e597d09819f7a87214
+	parent = 72568d5b8a15f83916d052e0682a80fb3084724d
 	remote = git@github.com:liferay/com-liferay-staging.git

--- a/modules/apps/web-experience/staging/staging-processes-web/bnd.bnd
+++ b/modules/apps/web-experience/staging/staging-processes-web/bnd.bnd
@@ -1,6 +1,7 @@
 Bundle-Name: Liferay Staging Processes Web
 Bundle-SymbolicName: com.liferay.staging.processes.web
 Bundle-Version: 1.0.19
+Liferay-JS-Config: /META-INF/resources/js/config.js
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Data Management
 Web-ContextPath: /staging-processes-web

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesPortlet.java
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/StagingProcessesPortlet.java
@@ -37,7 +37,6 @@ import org.osgi.service.component.annotations.Reference;
 	property = {
 		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-staging-processes",
-		"com.liferay.portlet.footer-portlet-javascript=/js/main.js",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",
 		"com.liferay.portlet.private-request-attributes=false",
 		"com.liferay.portlet.private-session-attributes=false",

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/config.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/config.js
@@ -1,0 +1,32 @@
+;(function() {
+	AUI().applyConfig(
+		{
+			groups: {
+				stagingprocessesweb: {
+					base: MODULE_PATH + '/',
+					combine: Liferay.AUI.getCombine(),
+					modules: {
+						'liferay-staging-processes-export-import': {
+							path: 'js/main.js',
+							requires: [
+								'aui-datatype',
+								'aui-dialog-iframe-deprecated',
+								'aui-io-request',
+								'aui-modal',
+								'aui-parse-content',
+								'aui-toggler',
+								'aui-tree-view',
+								'liferay-notice',
+								'liferay-portlet-base',
+								'liferay-portlet-url',
+								'liferay-store',
+								'liferay-util-window'
+							]
+						},
+					},
+					root: MODULE_PATH + '/'
+				}
+			}
+		}
+	);
+})();

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/js/main.js
@@ -1,5 +1,5 @@
 AUI.add(
-	'liferay-export-import',
+	'liferay-staging-processes-export-import',
 	function(A) {
 		var $ = AUI.$;
 

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
@@ -82,7 +82,7 @@ PortletURL portletURL = renderResponse.createRenderURL();
 	</c:when>
 </c:choose>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="publishLayouts" var="publishProcessesURL">
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_DELTA_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_DELTA_PARAM) %>" />

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/publish_layouts.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/new_publication/publish_layouts.jsp
@@ -341,7 +341,7 @@ renderResponse.setTitle(!configuredPublish ? LanguageUtil.get(request, "new-publ
 	Liferay.Util.toggleRadio('<portlet:namespace />rangeLast', '<portlet:namespace />rangeLastInputs', ['<portlet:namespace />startEndDate']);
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	var exportImport = new Liferay.ExportImport(
 		{
 			commentsNode: '#<%= PortletDataHandlerKeys.COMMENTS %>',

--- a/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
+++ b/modules/apps/web-experience/staging/staging-processes-web/src/main/resources/META-INF/resources/publish_templates/edit_template.jsp
@@ -197,7 +197,7 @@ renderResponse.setTitle((exportImportConfiguration == null) ? LanguageUtil.get(r
 	Liferay.Util.toggleRadio('<portlet:namespace />rangeLast', '<portlet:namespace />rangeLastInputs', ['<portlet:namespace />startEndDate']);
 </aui:script>
 
-<aui:script use="liferay-export-import">
+<aui:script use="liferay-staging-processes-export-import">
 	<liferay-portlet:resourceURL copyCurrentRenderParameters="<%= false %>" id="publishLayouts" var="publishProcessesURL">
 		<portlet:param name="<%= Constants.CMD %>" value="<%= cmd %>" />
 		<portlet:param name="<%= SearchContainer.DEFAULT_CUR_PARAM %>" value="<%= ParamUtil.getString(request, SearchContainer.DEFAULT_CUR_PARAM) %>" />

--- a/modules/apps/web-experience/trash/.gitrepo
+++ b/modules/apps/web-experience/trash/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = befeee7d23fc5d5693d4f1aae3a9d9413ffaae18
+	commit = 813fe14f55dcbfe5a663f973a63b1c869498d067
 	mergebuttonmergecommits = false
 	mode = push
-	parent = 5ca19a2fdc5b59773c999edf7a71fd354e5598b2
+	parent = 4f548275bc92bcce9180afbb2aa28b0eb0e6fed7
 	remote = git@github.com:liferay/com-liferay-trash.git

--- a/modules/apps/web-experience/trash/trash-test-util/src/main/java/com/liferay/trash/test/util/BaseTrashHandlerTestCase.java
+++ b/modules/apps/web-experience/trash/trash-test-util/src/main/java/com/liferay/trash/test/util/BaseTrashHandlerTestCase.java
@@ -1018,19 +1018,24 @@ public abstract class BaseTrashHandlerTestCase {
 		BaseModel<?> parentBaseModel = getParentBaseModel(
 			group, serviceContext);
 
-		baseModel = addBaseModel(parentBaseModel, serviceContext);
-
-		moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
-
-		deleteParentBaseModel(parentBaseModel, false);
-
 		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
 			getBaseModelClassName());
 
-		boolean restorable = trashHandler.isRestorable(
-			getAssetClassPK(baseModel));
+		try {
+			baseModel = addBaseModel(parentBaseModel, serviceContext);
 
-		Assert.assertFalse(restorable);
+			moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
+
+			deleteParentBaseModel(parentBaseModel, false);
+
+			boolean restorable = trashHandler.isRestorable(
+				getAssetClassPK(baseModel));
+
+			Assert.assertFalse(restorable);
+		}
+		finally {
+			trashHandler.deleteTrashEntry(getTrashEntryClassPK(baseModel));
+		}
 	}
 
 	@Test
@@ -1364,27 +1369,32 @@ public abstract class BaseTrashHandlerTestCase {
 		BaseModel<?> parentBaseModel = getParentBaseModel(
 			group, serviceContext);
 
-		baseModel = addBaseModel(parentBaseModel, serviceContext);
-
-		moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
-
-		whenHasParent.moveParentBaseModelToTrash(
-			(Long)parentBaseModel.getPrimaryKeyObj());
-
-		TrashHandler parentTrashHandler =
-			TrashHandlerRegistryUtil.getTrashHandler(
-				whenHasParent.getParentBaseModelClassName());
-
-		parentTrashHandler.deleteTrashEntry(
-			(Long)parentBaseModel.getPrimaryKeyObj());
-
 		TrashHandler trashHandler = TrashHandlerRegistryUtil.getTrashHandler(
 			getBaseModelClassName());
 
-		boolean restorable = trashHandler.isRestorable(
-			getAssetClassPK(baseModel));
+		try {
+			baseModel = addBaseModel(parentBaseModel, serviceContext);
 
-		Assert.assertFalse(restorable);
+			moveBaseModelToTrash((Long)baseModel.getPrimaryKeyObj());
+
+			whenHasParent.moveParentBaseModelToTrash(
+				(Long)parentBaseModel.getPrimaryKeyObj());
+
+			TrashHandler parentTrashHandler =
+				TrashHandlerRegistryUtil.getTrashHandler(
+					whenHasParent.getParentBaseModelClassName());
+
+			parentTrashHandler.deleteTrashEntry(
+				(Long)parentBaseModel.getPrimaryKeyObj());
+
+			boolean restorable = trashHandler.isRestorable(
+				getAssetClassPK(baseModel));
+
+			Assert.assertFalse(restorable);
+		}
+		finally {
+			trashHandler.deleteTrashEntry(getTrashEntryClassPK(baseModel));
+		}
 	}
 
 	@Test

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -160,7 +160,7 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 			function(key) {
 				var field = A.one('[name="<portlet:namespace />' + key + '"]');
 
-				if ((field.attr('type') === 'checkbox') || (field.attr('type') === 'radio')) {
+				if (field && ((field.attr('type') === 'checkbox') || (field.attr('type') === 'radio'))) {
 					field = A.one('[name="<portlet:namespace />' + key + '"]:checked');
 
 					fieldsMap[key] = '';
@@ -199,7 +199,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				optionalFieldError.replace(optionalFieldError);
 			}
 
-			field.attr('aria-invalid', true);
+			if (field) {
+				field.attr('aria-invalid', true);
+			}
 		}
 		else if (!fieldValidationFunctions[key](currentFieldValue, fieldsMap)) {
 			A.all('.alert-success').hide();
@@ -213,7 +215,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				validationError.replace(validationError);
 			}
 
-			field.attr('aria-invalid', true);
+			if (field) {
+				field.attr('aria-invalid', true);
+			}
 		}
 		else {
 			if (optionalFieldError) {
@@ -224,7 +228,9 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 				validationError.hide();
 			}
 
-			field.attr('aria-invalid', false);
+			if (field) {
+				field.attr('aria-invalid', false);
+			}
 
 			return true;
 		}

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -182,6 +182,18 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 		var field = A.one('[name="<portlet:namespace />' + key + '"]');
 
+		if (field && (field.attr('type') === 'radio')) {
+			var uncheckedOptions = A.all('[name="<portlet:namespace />' + key + '"]:not(:checked)');
+
+			uncheckedOptions.each(
+				function(option) {
+					option.removeAttribute('aria-invalid');
+				}
+			);
+
+			field = A.one('[name="<portlet:namespace />' + key + '"]:checked');
+		}
+
 		var currentFieldValue = fieldsMap[key];
 
 		var optionalFieldError = A.one('#<portlet:namespace />fieldOptionalError' + key);

--- a/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-form/web-form-web/src/main/resources/META-INF/resources/view.jsp
@@ -275,17 +275,23 @@ String successURL = portletPreferences.getValue("successURL", StringPool.BLANK);
 
 	keys.forEach(
 		function(key) {
-			var field = A.one('[name="<portlet:namespace />' + key + '"]');
+			var fields = A.all('[name="<portlet:namespace />' + key + '"]');
 
-			field.on(
-				'blur',
-				function(event) {
-					if (!validateField(key)) {
-						event.halt();
-						event.stopImmediatePropagation();
+			var addOnBlurFieldValidation = function(field) {
+				field.on(
+					'blur',
+					function(event) {
+						if (!validateField(key)) {
+							event.halt();
+							event.stopImmediatePropagation();
+						}
 					}
-				});
-		});
+				);
+			};
+
+			fields.each(addOnBlurFieldValidation);
+		}
+	);
 
 	var form = A.one('#<portlet:namespace />fm');
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AlloyEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AlloyEditor.macro
@@ -3,6 +3,14 @@
 		<execute function="Type#typeEditor" locator1="AlloyEditor#CONTENT_FIELD" value1="${content}" />
 	</command>
 
+	<command name="addSourceContent">
+		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
+
+		<execute function="Click" locator1="Button#EDITOR_SWITCH" />
+
+		<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="${content}" />
+	</command>
+
 	<command name="addTitle">
 		<execute function="Type#typeEditor" locator1="AlloyEditor#TITLE_FIELD" value1="${title}" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AssetCategorization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AssetCategorization.macro
@@ -126,8 +126,8 @@
 			</then>
 		</if>
 
-		<execute function="Click" locator1="AssetCategorization#TAG_CHECKBOX">
-			<var name="key_tagName" value="${tagName}" />
+		<execute function="Click" locator1="ContentRow#ENTRY_CONTENT_ENTRY_CHECKBOX">
+			<var name="key_rowEntry" value="${tagName}" />
 		</execute>
 
 		<execute function="SelectFrameTop" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AssetCategorization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AssetCategorization.macro
@@ -126,7 +126,7 @@
 			</then>
 		</if>
 
-		<execute function="Click" locator1="ContentRow#ENTRY_CONTENT_ENTRY_CHECKBOX">
+		<execute function="Check" locator1="ContentRow#ENTRY_CONTENT_ENTRY_CHECKBOX">
 			<var name="key_rowEntry" value="${tagName}" />
 		</execute>
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/AssetPublisherPortlet.macro
@@ -142,6 +142,10 @@
 			<var name="navTab" value="Display Settings" />
 		</execute>
 
+		<execute macro="Panel#expandPanel">
+			<var name="panelHeading" value="Set and Enable" />
+		</execute>
+
 		<if>
 			<isset var="disableConfiguration" />
 			<then>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Blogs.macro
@@ -93,11 +93,9 @@
 			<var name="entrySubtitle" value="${entrySubtitle}" />
 		</execute>
 
-		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
-
-		<execute function="Click" locator1="Button#EDITOR_SWITCH" />
-
-		<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="${entryContent}" />
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content" value="${entryContent}" />
+		</execute>
 
 		<execute macro="PortletEntry#publish" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/FormFields.macro
@@ -119,7 +119,7 @@
 	<command name="editTextWithBackspace">
 		<var name="key_fieldName" value="${fieldName}" />
 
-		<execute function="Click" locator1="FormFields#TEXT_FIELD" />
+		<execute function="DoubleClick" locator1="FormFields#TEXT_FIELD" />
 
 		<execute function="KeyPress" locator1="FormFields#TEXT_FIELD" value1="\BACK_SPACE" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/KBArticle.macro
@@ -152,11 +152,9 @@
 		<if>
 			<equals arg1="${kbArticleAddViaSource}" arg2="true" />
 			<then>
-				<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
-
-				<execute function="Click" locator1="Button#EDITOR_SWITCH" />
-
-				<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="${kbArticleContentSource}" />
+				<execute macro="AlloyEditor#addSourceContent">
+					<var name="content" value="${kbArticleContentSource}" />
+				</execute>
 			</then>
 			<else>
 				<execute macro="AlloyEditor#addContent">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -228,8 +228,6 @@
 		</execute>
 
 		<execute function="Type" locator1="Portlet#BORDER_WIDTH_TOP_INPUT" value1="20" />
-
-		<execute macro="PortletEntry#save" />
 	</command>
 
 	<command name="configureCustomTitleViaLookandfeelPG">
@@ -301,8 +299,6 @@
 
 	<command name="selectApplicationDecorator">
 		<execute function="Select" locator1="Select#APPLICATION_DECORATORS" value1="${decorator}" />
-
-		<execute macro="PortletEntry#save" />
 	</command>
 
 	<command name="selectTreeNode">

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -207,8 +207,6 @@
 	</command>
 
 	<command name="configureApplicationDecoratorViaLookandfeelPG">
-		<execute macro="IFrame#selectConfigurationFrame" />
-
 		<execute macro="Navigator#gotoNavTab">
 			<var name="navTab" value="General" />
 		</execute>
@@ -217,8 +215,6 @@
 	</command>
 
 	<command name="configureCustomStylesViaLookandfeelPG">
-		<execute macro="IFrame#selectConfigurationFrame" />
-
 		<execute macro="Navigator#gotoNavTab">
 			<var name="navTab" value="Text Styles" />
 		</execute>
@@ -304,8 +300,6 @@
 	</command>
 
 	<command name="selectApplicationDecorator">
-		<execute macro="IFrame#selectConfigurationFrame" />
-
 		<execute function="Select" locator1="Select#APPLICATION_DECORATORS" value1="${decorator}" />
 
 		<execute macro="PortletEntry#save" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/SiteTemplatesNavigator.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/SiteTemplatesNavigator.macro
@@ -14,7 +14,7 @@
 
 		<execute function="AssertClick#assertPartialTextClickAt" locator1="SiteTemplates#SITE_TEMPLATE_TABLE_NAME" value1="${siteTemplateName}" />
 
-		<execute function="SelectWindow" locator1="home - ${siteTemplateName} - ${siteName}" />
+		<execute function="SelectWindow" locator1="Home - ${siteTemplateName} - ${siteName}" />
 
 		<execute macro="Navigator#_gotoPage">
 			<var name="pageName" value="${pageName}" />

--- a/portal-web/test/functional/com/liferay/portalweb/macros/WikiEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/WikiEntry.macro
@@ -9,14 +9,6 @@
 		</execute>
 	</command>
 
-	<command name="addPageContentViaSource">
-		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
-
-		<execute function="Click" locator1="AlloyEditor#CONTENT_EDITOR_SWITCH_ACE_EDITOR" />
-
-		<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="${wikiPageContent}" />
-	</command>
-
 	<command name="addPageTitle">
 		<execute function="Type#typeEditor" locator1="AlloyEditor#TITLE_FIELD" value1="${wikiPageTitle}" />
 	</command>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/IFrame.path
@@ -120,7 +120,7 @@
 </tr>
 <tr>
 	<td>SELECT_TAG</td>
-	<td>//iframe[contains(@id,'AssetTagsSelectorPortlet')]</td>
+	<td>//iframe[contains(@id,'selectTag_iframe')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetCategorization.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AssetCategorization.path
@@ -110,7 +110,7 @@
 </tr>
 <tr>
 	<td>TAG_CHECKBOX</td>
-	<td>//div[contains(.,'${key_tagName}')]//input[@type='checkbox']</td>
+	<td>//tr[contains(.,'${key_tagName}')]//input[@type='checkbox']</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/bookmarks/cpbookmarks/CPBookmarks.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/bookmarks/cpbookmarks/CPBookmarks.testcase
@@ -603,7 +603,7 @@
 		<execute macro="Bookmark#addCP">
 			<var name="bookmarkDescription" value="This is another test bookmark!" />
 			<var name="bookmarkName" value="Test Bookmark 2" />
-			<var name="bookmarkURL" value="http://digg.com" />
+			<var name="bookmarkURL" value="http://www.msn.com" />
 		</execute>
 
 		<execute macro="Navigator#openURL" />
@@ -625,7 +625,7 @@
 
 		<execute macro="Bookmark#viewBookmark">
 			<var name="bookmarkName" value="Test Bookmark 2" />
-			<var name="bookmarkURL" value="http://digg.com" />
+			<var name="bookmarkURL" value="http://www.msn.com" />
 		</execute>
 
 		<execute macro="Navigator#openURL" />
@@ -679,7 +679,7 @@
 		<execute macro="Bookmark#addCP">
 			<var name="bookmarkDescription" value="This is another test bookmark!" />
 			<var name="bookmarkName" value="Test Bookmark 2" />
-			<var name="bookmarkURL" value="http://digg.com" />
+			<var name="bookmarkURL" value="http://www.msn.com" />
 		</execute>
 
 		<execute macro="Navigator#openURL" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/pgwiki/PGWiki.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/pgwiki/PGWiki.testcase
@@ -323,11 +323,9 @@
 			<var name="wikiPageTitle" value="Wiki FrontPage Child Page Title" />
 		</execute>
 
-		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
-
-		<execute function="Click" locator1="AlloyEditor#CONTENT_EDITOR_SWITCH_ACE_EDITOR" />
-
-		<execute function="Type#typeAceEditor" locator1="TextArea#ACE_EDITOR" value1="${welcomeToLiferay}" />
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content" value="${welcomeToLiferay}" />
+		</execute>
 
 		<execute macro="PortletEntry#publish" />
 
@@ -548,8 +546,8 @@
 
 		<execute macro="WikiEntry#confirmHTML" />
 
-		<execute macro="WikiEntry#addPageContentViaSource">
-			<var name="wikiPageContent">
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content">
 			<![CDATA[
 				<p id="demo">PASS</p><script type="text/javascript">document.getElementById('demo').innerHTML="this code should not be read by the client";</script>
 			]]>
@@ -731,13 +729,9 @@
 			<var name="wikiPageTitle" value="Wiki Page Title" />
 		</execute>
 
-		<execute function="Click#clickAt" locator1="AlloyEditor#CONTENT_FIELD" />
-
-		<execute function="Click" locator1="AlloyEditor#CONTENT_EDITOR_SWITCH_ACE_EDITOR" />
-
-		<execute function="Pause" locator1="1000" />
-
-		<execute function="Type#typeAceEditor" locator1="TextArea#ACE_EDITOR" value1="${welcomeToLiferay}" />
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content" value="${welcomeToLiferay}" />
+		</execute>
 
 		<execute macro="PortletEntry#publish" />
 
@@ -801,15 +795,12 @@
 			<var name="wikiPageTitle" value="Wiki Page With JSPWiki Content" />
 		</execute>
 
-		<execute function="Click" locator1="AlloyEditor#CONTENT_FIELD" />
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content"><![CDATA[
+!JSPWiki Header"
 
-		<execute function="Click" locator1="AlloyEditor#CONTENT_EDITOR_SWITCH_ACE_EDITOR" />
-
-		<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="!JSPWiki Header" />
-
-		<execute function="KeyPress" locator1="TextArea#ACE_EDITOR" value1="\RETURN" />
-
-		<execute function="Type#sendKeysAceEditor" locator1="TextArea#ACE_EDITOR" value1="__JSPWiki Bold Text__" />
+__JSPWiki Bold Text__]]></var>
+		</execute>
 
 		<execute macro="PortletEntry#publish" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/pgwikidisplay/PGWikidisplay.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/wiki/pgwikidisplay/PGWikidisplay.testcase
@@ -153,11 +153,9 @@
 			<var name="wikiPageTitle" value="Wiki FrontPage Child Page Title" />
 		</execute>
 
-		<execute function="Click#clickAt" locator1="AlloyEditor#CONTENT_FIELD" />
-
-		<execute function="Click" locator1="AlloyEditor#CONTENT_EDITOR_SWITCH_ACE_EDITOR" />
-
-		<execute function="Type#typeAceEditor" locator1="TextArea#ACE_EDITOR" value1="${welcomeToLiferay}" />
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content" value="${welcomeToLiferay}" />
+		</execute>
 
 		<execute macro="PortletEntry#publish" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/cpsites/CPSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/sitesadministration/cpsites/CPSites.testcase
@@ -25,6 +25,8 @@
 	</tear-down>
 
 	<command name="ActivateSite" priority="4">
+		<property name="test.name.skip.portal.instance" value="CPSites#ActivateSite" />
+
 		<execute macro="ProductMenu#gotoControlPanelConfiguration">
 			<var name="portlet" value="System Settings" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecaseWithVersioning.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/staging/usecase/StagingUsecaseWithVersioning.testcase
@@ -148,6 +148,8 @@
 			<var name="portletName" value="Sites Directory" />
 		</execute>
 
+		<execute macro="PortletEntry#save" />
+
 		<execute macro="Portlet#configureApplicationDecoratorViaLookandfeelPG">
 			<var name="applicationDecorator" value="Decorate" />
 		</execute>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/util/lookandfeel/LookAndFeel.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/util/lookandfeel/LookAndFeel.testcase
@@ -34,6 +34,8 @@
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
 
+		<execute macro="IFrame#selectConfigurationFrame" />
+
 		<execute macro="Portlet#configureCustomStylesViaLookandfeelPG" />
 
 		<execute macro="Navigator#openURL" />
@@ -48,6 +50,8 @@
 			<var name="portletName" value="Web Content Display" />
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
+
+		<execute macro="IFrame#selectConfigurationFrame" />
 
 		<execute macro="Portlet#configureApplicationDecoratorViaLookandfeelPG">
 			<var name="applicationDecorator" value="Borderless" />
@@ -65,6 +69,8 @@
 			<var name="portletName" value="Web Content Display" />
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
+
+		<execute macro="IFrame#selectConfigurationFrame" />
 
 		<execute macro="Portlet#selectApplicationDecorator">
 			<var name="decorator" value="Borderless" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/util/lookandfeel/LookAndFeel.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/util/lookandfeel/LookAndFeel.testcase
@@ -38,6 +38,8 @@
 
 		<execute macro="Portlet#configureCustomStylesViaLookandfeelPG" />
 
+		<execute macro="PortletEntry#save" />
+
 		<execute macro="Navigator#openURL" />
 
 		<execute macro="Portlet#viewCustomStylesViaLookandfeelPG" />
@@ -82,6 +84,8 @@
 			<var name="decorator" value="Borderless" />
 		</execute>
 
+		<execute macro="PortletEntry#save" />
+
 		<execute macro="Portlet#gotoPortletOptions">
 			<var name="portletName" value="Web Content Display" />
 			<var name="portletOption" value="Look and Feel Configuration" />
@@ -90,6 +94,8 @@
 		<execute macro="Portlet#selectApplicationDecorator">
 			<var name="decorator" value="Barebone" />
 		</execute>
+
+		<execute macro="PortletEntry#save" />
 
 		<execute macro="Navigator#openURL" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/usecase/WebcontentUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentadministration/usecase/WebcontentUsecase.testcase
@@ -850,6 +850,47 @@
 		<execute function="AssertTextNotPresent" value1="WC WebContent Content" />
 	</command>
 
+	<command name="AddWebContentViaSourceEditor" priority="5">
+		<property name="portal.acceptance" value="pending" />
+		<property name="testray.component.names" value="Training,Web Content Administration" />
+
+		<execute macro="Page#add">
+			<var name="pageName" value="Test Page Name" />
+		</execute>
+
+		<execute macro="Portlet#addPG">
+			<var name="portletName" value="Web Content Display" />
+		</execute>
+
+		<execute macro="Navigator#gotoPage">
+			<var name="pageName" value="Test Page Name" />
+		</execute>
+
+		<execute macro="WebContentNavigator#gotoAddPGViaWCD" />
+
+		<execute macro="WebContent#addCP">
+			<var name="webContentTitle" value="Basic S.P.A.C.E. Banner" />
+		</execute>
+
+		<execute macro="AlloyEditor#addSourceContent">
+			<var name="content"><![CDATA[
+<h2 class="text-center">Space Program Academy of Continuing Education</h2>
+
+<p class="text-center">Dare to Dream out of this world</p>
+]]></var>
+		</execute>
+
+		<execute macro="Button#clickPublish" />
+
+		<execute macro="Navigator#gotoPage">
+			<var name="pageName" value="Test Page Name" />
+		</execute>
+
+		<execute macro="WebContent#viewPGViaWCD">
+			<var name="webContentContent" value="Space Program Academy of Continuing Education Dare to Dream out of this world" />
+		</execute>
+	</command>
+
 	<command name="AddWebContentViaWCDWithGlobalStructureAndLocalTemplate" priority="4">
 		<property name="testray.component.names" value="Web Content Administration" />
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
@@ -60,6 +60,8 @@
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
 
+		<execute macro="IFrame#selectConfigurationFrame" />
+
 		<execute macro="Portlet#configureCustomTitleViaLookandfeelPG">
 			<var name="portletName" value="Asset Publisher" />
 		</execute>
@@ -75,6 +77,8 @@
 		<execute macro="Portlet#gotoPortletOptions">
 			<var name="portletOption" value="Look and Feel Configuration" />
 		</execute>
+
+		<execute macro="IFrame#selectConfigurationFrame" />
 
 		<execute macro="Portlet#selectApplicationDecorator">
 			<var name="decorator" value="Barebone" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wcm/webcontentpublication/pgassetpublisher/PGAssetpublisher.testcase
@@ -66,6 +66,8 @@
 			<var name="portletName" value="Asset Publisher" />
 		</execute>
 
+		<execute macro="PortletEntry#save" />
+
 		<execute macro="Navigator#gotoPage">
 			<var name="pageName" value="Asset Publisher Page" />
 		</execute>
@@ -83,6 +85,8 @@
 		<execute macro="Portlet#selectApplicationDecorator">
 			<var name="decorator" value="Barebone" />
 		</execute>
+
+		<execute macro="PortletEntry#save" />
 
 		<execute macro="Navigator#gotoPage">
 			<var name="pageName" value="Asset Publisher Page" />
@@ -350,6 +354,8 @@
 		<execute macro="Portlet#configureCustomTitleViaLookandfeelPG">
 			<var name="portletName" value="Asset Publisher" />
 		</execute>
+
+		<execute macro="PortletEntry#save" />
 
 		<execute macro="Portlet#configureApplicationDecoratorViaLookandfeelPG">
 			<var name="applicationDecorator" value="Decorate" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -1293,7 +1293,7 @@
 			<var name="fieldName" value="ds.lock.timeout.milliseconds" />
 		</execute>
 
-		<execute macro="Button#clickUpdate" />
+		<execute macro="Button#clickSave" />
 
 		<execute macro="FormFields#viewFieldValidationErrorMessage">
 			<var name="fieldName" value="ds.lock.timeout.milliseconds" />

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/webformsanddatalists/forms/Forms.testcase
@@ -2650,6 +2650,7 @@
 		<execute macro="FormsAdminNavigator#gotoView" />
 
 		<execute macro="FormFields#viewParagraphField">
+			<var name="fieldName" value="Paragraph" />
 			<var name="fieldTitle" value="New Paragraph" />
 			<var name="fieldValue" value="New Paragraph body text." />
 		</execute>


### PR DESCRIPTION
/cc @ericyanLr 

Notes from Eric:

> This pr mainly focuses on handling nulls when retrieving a field.
> 
> **Note: Additional Change when adding onblur validation listener(s)**
> While working on adding null checks for the method that adds onblur validation listeners, I noticed that it only retrieved one field per key:
> ``` var field = A.one('[name="<portlet:namespace />' + key + '"]');```
> 
> This meant that if a **radio type** field was used with multiple options, only **one radio option** would have a registered listener.
> 
> So, I added an additional change to retrieve all the fields associated with the key, to account for the radio type:
> ```var fields = A.all('[name="<portlet:namespace />' + key + '"]');```
> 
> This allows us to handle the null check by utilizing the returned [NodeList:](http://alloyui.com/api/classes/NodeList.html#method_each)
> ```fields.each(addOnBlurFieldValidation);```
> 
> **Original Tickets:**
> [LPS-73629](https://issues.liferay.com/browse/LPS-73629)
> [LPP-25030](https://issues.liferay.com/browse/LPP-25030)