### PR TITLE
LPS-74132

### DIFF
--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/bnd.bnd
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/bnd.bnd
@@ -9,5 +9,5 @@ Export-Package:\
 	com.liferay.mobile.device.rules.service.permission
 Liferay-Releng-Module-Group-Description:
 Liferay-Releng-Module-Group-Title: Mobile Device Rules
-Liferay-Require-SchemaVersion: 1.0.1
+Liferay-Require-SchemaVersion: 1.0.2
 Liferay-Service: true

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRRuleGroupInstanceUpgrade.java
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRRuleGroupInstanceUpgrade.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.mobile.device.rules.internal.upgrade;
+
+import com.liferay.mobile.device.rules.model.MDRRuleGroupInstance;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.dao.jdbc.DataAccess;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.RoleConstants;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.StringBundler;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Alec Shay
+ */
+public class MDRRuleGroupInstanceUpgrade extends UpgradeProcess {
+
+	@Override
+	public void doUpgrade() throws Exception {
+		populateResourcePermissions();
+	}
+
+	public long getMDRRuleGroupInstanceActionIds() throws Exception {
+		long actionIds = 0;
+
+		String className = MDRRuleGroupInstance.class.getName();
+
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			ps = connection.prepareStatement(
+				"select bitwisevalue from ResourceAction where name = ?");
+
+			ps.setString(1, className);
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long bitwiseValue = rs.getLong(1);
+
+				actionIds |= bitwiseValue;
+			}
+		}
+		finally {
+			DataAccess.cleanUp(ps, rs);
+		}
+
+		return actionIds;
+	}
+
+	public Map<Long, Long> getOwnerRoleIds() throws Exception {
+		Map<Long, Long> ownerRoleIds = new HashMap<>();
+
+		String roleName = RoleConstants.OWNER;
+		int roleType = RoleConstants.TYPE_REGULAR;
+
+		PreparedStatement ps = null;
+		ResultSet rs = null;
+
+		try {
+			ps = connection.prepareStatement(
+				"select companyId, roleId from Role_ where name = ? and " +
+					"type_ = ?");
+
+			ps.setString(1, roleName);
+			ps.setInt(2, roleType);
+
+			rs = ps.executeQuery();
+
+			while (rs.next()) {
+				long companyId = rs.getLong(1);
+				long roleId = rs.getLong(2);
+
+				ownerRoleIds.put(companyId, roleId);
+			}
+		}
+		finally {
+			DataAccess.cleanUp(ps, rs);
+		}
+
+		return ownerRoleIds;
+	}
+
+	public void populateResourcePermissions() throws Exception {
+		StringBundler sb = new StringBundler();
+
+		sb.append("select MDRRuleGroupInstance.companyId, ");
+		sb.append("MDRRuleGroupInstance.ruleGroupInstanceId, ");
+		sb.append("MDRRuleGroupInstance.userId from MDRRuleGroupInstance ");
+		sb.append("where not exists (select 1 from ResourcePermission where ");
+		sb.append("(MDRRuleGroupInstance.companyId = ResourcePermission.");
+		sb.append("companyId) and (MDRRuleGroupInstance.ruleGroupInstanceId =");
+		sb.append("ResourcePermission.primKeyId) and (MDRRuleGroupInstance.");
+		sb.append("userId = ResourcePermission.ownerId) and ");
+		sb.append("(ResourcePermission.name = '");
+		sb.append(MDRRuleGroupInstance.class.getName());
+		sb.append("'))");
+
+		StringBundler sb2 = new StringBundler();
+
+		sb2.append("insert into ResourcePermission (resourcePermissionId, ");
+		sb2.append("companyId, name, scope, primKey, primKeyId, roleId, ");
+		sb2.append("ownerId, actionIds, viewActionId) values (?, ?, ?, ?, ?, ");
+		sb2.append("?, ?, ?, ?, ?)");
+
+		Map<Long, Long> ownerRoleIds = getOwnerRoleIds();
+		long actionIds = getMDRRuleGroupInstanceActionIds();
+
+		try (PreparedStatement ps1 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection, sb2.toString());
+
+			PreparedStatement ps2 = connection.prepareStatement(
+				sb.toString())) {
+
+			try (ResultSet rs = ps2.executeQuery()) {
+				while (rs.next()) {
+					long companyId = rs.getLong(1);
+					long ruleGroupInstanceId = rs.getLong(2);
+					long userId = rs.getLong(3);
+
+					ps1.setLong(
+						1, increment(ResourcePermission.class.getName()));
+					ps1.setLong(2, companyId);
+					ps1.setString(3, MDRRuleGroupInstance.class.getName());
+					ps1.setInt(4, 4);
+					ps1.setString(5, String.valueOf(ruleGroupInstanceId));
+					ps1.setLong(6, ruleGroupInstanceId);
+					ps1.setLong(7, ownerRoleIds.get(companyId));
+					ps1.setLong(8, userId);
+					ps1.setLong(9, actionIds);
+					ps1.setBoolean(10, true);
+
+					ps1.addBatch();
+				}
+
+				ps1.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRRuleGroupInstanceUpgrade.java
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRRuleGroupInstanceUpgrade.java
@@ -35,6 +35,7 @@ public class MDRRuleGroupInstanceUpgrade extends UpgradeProcess {
 
 	@Override
 	public void doUpgrade() throws Exception {
+		populateCompanyIds();
 		populateResourcePermissions();
 	}
 
@@ -98,6 +99,41 @@ public class MDRRuleGroupInstanceUpgrade extends UpgradeProcess {
 		}
 
 		return ownerRoleIds;
+	}
+
+	public void populateCompanyIds() throws Exception {
+		StringBundler sb = new StringBundler();
+
+		sb.append("select MDRRuleGroup.companyId, ");
+		sb.append("MDRRuleGroupInstance.RuleGroupInstanceId from ");
+		sb.append("MDRRuleGroup left join MDRRuleGroupInstance on ");
+		sb.append("MDRRuleGroup.ruleGroupId = ");
+		sb.append("MDRRuleGroupInstance.ruleGroupId where ");
+		sb.append("MDRRuleGroupInstance.companyId = 0");
+
+		try (PreparedStatement ps1 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update MDRRuleGroupInstance set companyId = ? where " +
+						"ruleGroupInstanceId = ?");
+
+			PreparedStatement ps2 = connection.prepareStatement(
+				sb.toString())) {
+
+			try (ResultSet rs = ps2.executeQuery()) {
+				while (rs.next()) {
+					long companyId = rs.getLong(1);
+					long ruleGroupInstanceId = rs.getLong(2);
+
+					ps1.setLong(1, companyId);
+					ps1.setLong(2, ruleGroupInstanceId);
+
+					ps1.addBatch();
+				}
+
+				ps1.executeBatch();
+			}
+		}
 	}
 
 	public void populateResourcePermissions() throws Exception {

--- a/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRServiceUpgrade.java
+++ b/modules/apps/foundation/mobile-device-rules/mobile-device-rules-service/src/main/java/com/liferay/mobile/device/rules/internal/upgrade/MDRServiceUpgrade.java
@@ -34,6 +34,10 @@ public class MDRServiceUpgrade implements UpgradeStepRegistrator {
 		registry.register(
 			"com.liferay.mobile.device.rules.service", "1.0.0", "1.0.1",
 			new MDRActionUpgrade(), new MDRRuleUpgrade());
+
+		registry.register(
+			"com.liferay.mobile.device.rules.service", "1.0.1", "1.0.2",
+			new MDRRuleGroupInstanceUpgrade());
 	}
 
 }


### PR DESCRIPTION
/cc @SamZiemer

@jonathanmccann Sending this to you directly as per request from Angelo, as it's for a high-priority issue. Will also be talking to you about this at some point regardless because we will need to seek an SDH. Please feel free to reach out for any questions.

Thanks.

> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-26741
> https://issues.liferay.com/browse/LPS-74132
> 
> When upgrading from 6.1 to DXP/master (whether or not upgrading to 6.2 as an intermediate step), entries in the `MDRRuleGroupInstance` table are missing associated ResourcePermissions, as well as a companyId, that entries created in newer versions would have. Although these do not seem to be critical to have in 6.1 or 6.2, in DXP/master these ResourcePermissions are needed for managing the mobile device rule group instances, and without them the owner cannot manage or even view them (an Exception is thrown and the page fails to load correctly).
> 
> This fix adds one UpgradeProcess with two steps. The first step finds any `MDRRuleGroupInstance` entries missing a companyId and populates it (using the companyId from the associated `MDRRuleGroup`, since it should be the same). The second step determines which entries do not have an associated `ResourcePermission` entry (which should match a few columns, including that companyId), and adds new entries where missing.
> 
> Please let me know if there are any problems moving forward with this. Thank you!