### PR TITLE
J cords lps 74454 revised

### DIFF
--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalService.java
@@ -147,22 +147,63 @@ public interface CalendarBookingLocalService extends BaseLocalService,
 	public CalendarBooking deleteCalendarBooking(long calendarBookingId,
 		boolean allRecurringInstances) throws PortalException;
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing) throws PortalException;
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings) throws PortalException;
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing) throws PortalException;
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
 		boolean deleteRecurringCalendarBookings) throws PortalException;
 
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex, boolean allFollowing)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, int instanceIndex,
+		boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing)
+		throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		CalendarBooking calendarBooking, long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings) throws PortalException;
+
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@java.lang.Deprecated
 	public void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing) throws PortalException;
+
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws PortalException;
 
 	public void deleteCalendarBookings(long calendarId)
 		throws PortalException;

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceUtil.java
@@ -155,6 +155,10 @@ public class CalendarBookingLocalServiceUtil {
 			allRecurringInstances);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing)
@@ -164,6 +168,10 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		int instanceIndex, boolean allFollowing,
@@ -174,6 +182,10 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing)
@@ -183,6 +195,10 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
 		long startTime, boolean allFollowing,
@@ -193,12 +209,62 @@ public class CalendarBookingLocalServiceUtil {
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking,
+			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
+			allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBooking, startTime,
+			allFollowing, deleteRecurringCalendarBookings);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	public static void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		getService()
 			.deleteCalendarBookingInstance(calendarBookingId, startTime,
 			allFollowing);
+	}
+
+	public static void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService()
+			.deleteCalendarBookingInstance(userId, calendarBookingId,
+			startTime, allFollowing);
 	}
 
 	public static void deleteCalendarBookings(long calendarId)

--- a/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-api/src/main/java/com/liferay/calendar/service/CalendarBookingLocalServiceWrapper.java
@@ -154,6 +154,10 @@ public class CalendarBookingLocalServiceWrapper
 			allRecurringInstances);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -163,6 +167,10 @@ public class CalendarBookingLocalServiceWrapper
 			instanceIndex, allFollowing);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -173,6 +181,10 @@ public class CalendarBookingLocalServiceWrapper
 			instanceIndex, allFollowing, deleteRecurringCalendarBookings);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -182,6 +194,10 @@ public class CalendarBookingLocalServiceWrapper
 			startTime, allFollowing);
 	}
 
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
 	@Override
 	public void deleteCalendarBookingInstance(
 		com.liferay.calendar.model.CalendarBooking calendarBooking,
@@ -193,11 +209,63 @@ public class CalendarBookingLocalServiceWrapper
 	}
 
 	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		int instanceIndex, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, instanceIndex, allFollowing,
+			deleteRecurringCalendarBookings);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		com.liferay.calendar.model.CalendarBooking calendarBooking,
+		long startTime, boolean allFollowing,
+		boolean deleteRecurringCalendarBookings)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBooking, startTime, allFollowing,
+			deleteRecurringCalendarBookings);
+	}
+
+	/**
+	* @deprecated As of 7.0.0, with no direct replacement
+	*/
+	@Deprecated
+	@Override
 	public void deleteCalendarBookingInstance(long calendarBookingId,
 		long startTime, boolean allFollowing)
 		throws com.liferay.portal.kernel.exception.PortalException {
 		_calendarBookingLocalService.deleteCalendarBookingInstance(calendarBookingId,
 			startTime, allFollowing);
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(long userId,
+		long calendarBookingId, long startTime, boolean allFollowing)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_calendarBookingLocalService.deleteCalendarBookingInstance(userId,
+			calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -448,9 +448,49 @@ public class CalendarBookingLocalServiceImpl
 		return calendarBooking;
 	}
 
-	@Override
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public void deleteCalendarBookingInstance(
 			CalendarBooking calendarBooking, int instanceIndex,
+			boolean allFollowing)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, int instanceIndex,
+			boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, long startTime,
+			boolean allFollowing)
+		throws PortalException {
+	}
+
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
+	public void deleteCalendarBookingInstance(
+			CalendarBooking calendarBooking, long startTime,
+			boolean allFollowing, boolean deleteRecurringCalendarBookings)
+		throws PortalException {
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing)
 		throws PortalException {
 
@@ -459,13 +499,13 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, int instanceIndex,
+			long userId, CalendarBooking calendarBooking, int instanceIndex,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -474,23 +514,23 @@ public class CalendarBookingLocalServiceImpl
 				calendarBooking, instanceIndex);
 
 		deleteCalendarBookingInstance(
-			calendarBooking, calendarBookingInstance.getStartTime(),
+			userId, calendarBooking, calendarBookingInstance.getStartTime(),
 			allFollowing, deleteRecurringCalendarBookings);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing)
 		throws PortalException {
 
 		deleteCalendarBookingInstance(
-			calendarBooking, startTime, allFollowing, false);
+			userId, calendarBooking, startTime, allFollowing, false);
 	}
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			boolean allFollowing, boolean deleteRecurringCalendarBookings)
 		throws PortalException {
 
@@ -504,7 +544,7 @@ public class CalendarBookingLocalServiceImpl
 		if (allFollowing) {
 			if (deleteRecurringCalendarBookings) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -547,15 +587,24 @@ public class CalendarBookingLocalServiceImpl
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
 	}
 
-	@Override
+	/**
+	 * @deprecated As of 7.0.0, with no direct replacement
+	 */
+	@Deprecated
 	public void deleteCalendarBookingInstance(
 			long calendarBookingId, long startTime, boolean allFollowing)
+		throws PortalException {
+	}
+
+	@Override
+	public void deleteCalendarBookingInstance(
+			long userId, long calendarBookingId, long startTime, boolean allFollowing)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, allFollowing);
+		deleteCalendarBookingInstance(userId, calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
@@ -832,7 +881,7 @@ public class CalendarBookingLocalServiceImpl
 
 			if (allFollowing) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(calendarBooking, startTime);
+					splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -860,7 +909,7 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			deleteCalendarBookingInstance(
-				calendarBooking, startTime, allFollowing);
+				userId, calendarBooking, startTime, allFollowing);
 
 			calendarBooking = addCalendarBooking(
 				userId, calendarId, childCalendarIds, 0,
@@ -1330,7 +1379,7 @@ public class CalendarBookingLocalServiceImpl
 		String oldRecurrence = calendarBooking.getRecurrence();
 
 		deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing, false);
+			userId, calendarBooking, instanceIndex, allFollowing, false);
 
 		Map<Locale, String> updatedTitleMap = calendarBooking.getTitleMap();
 
@@ -1345,7 +1394,7 @@ public class CalendarBookingLocalServiceImpl
 			Calendar calendar = calendarLocalService.getCalendar(calendarId);
 
 			List<CalendarBooking> recurringCalendarBookings =
-				splitCalendarBookingInstances(calendarBooking, startTime);
+				splitCalendarBookingInstances(userId, calendarBooking, startTime);
 
 			List<String> unmodifiedAttributesNames =
 				getUnmodifiedAttributesNames(
@@ -2018,7 +2067,7 @@ public class CalendarBookingLocalServiceImpl
 	}
 
 	protected CalendarBooking splitCalendarBookingInstance(
-			CalendarBooking calendarBooking, long startTime,
+			long userId, CalendarBooking calendarBooking, long startTime,
 			Recurrence recurrence)
 		throws PortalException {
 
@@ -2046,13 +2095,13 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getSecondReminderType(),
 			ServiceContextThreadLocal.getServiceContext());
 
-		deleteCalendarBookingInstance(calendarBooking, startTime, true, false);
+		deleteCalendarBookingInstance(userId, calendarBooking, startTime, true, false);
 
 		return calendarBookingInstance;
 	}
 
 	protected List<CalendarBooking> splitCalendarBookingInstances(
-			CalendarBooking calendarBooking, long startTime)
+			long userId, CalendarBooking calendarBooking, long startTime)
 		throws PortalException {
 
 		List<CalendarBooking> recurringCalendarBookings =
@@ -2105,7 +2154,7 @@ public class CalendarBookingLocalServiceImpl
 
 						CalendarBooking newCalendarBooking =
 							splitCalendarBookingInstance(
-								recurringCalendarBooking,
+								userId, recurringCalendarBooking,
 								newStartTimeJCalendar.getTimeInMillis(),
 								recurrenceSplit.getSecondRecurrence());
 

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingLocalServiceImpl.java
@@ -535,6 +535,9 @@ public class CalendarBookingLocalServiceImpl
 		throws PortalException {
 
 		Date now = new Date();
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setUserId(userId);
 
 		java.util.Calendar startTimeJCalendar = JCalendarUtil.getJCalendar(
 			startTime, calendarBooking.getTimeZone());
@@ -544,7 +547,8 @@ public class CalendarBookingLocalServiceImpl
 		if (allFollowing) {
 			if (deleteRecurringCalendarBookings) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(userId, calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -554,6 +558,10 @@ public class CalendarBookingLocalServiceImpl
 			}
 
 			if (startTime == calendarBooking.getStartTime()) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -573,6 +581,10 @@ public class CalendarBookingLocalServiceImpl
 				RecurrenceUtil.getCalendarBookingInstance(calendarBooking, 1);
 
 			if (calendarBookingInstance == null) {
+				_sendChildrenNotifications(
+					calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+					serviceContext);
+
 				calendarBookingLocalService.deleteCalendarBooking(
 					calendarBooking, false);
 
@@ -585,6 +597,10 @@ public class CalendarBookingLocalServiceImpl
 		String recurrence = RecurrenceSerializer.serialize(recurrenceObj);
 
 		updateChildCalendarBookings(calendarBooking, now, recurrence);
+
+		_sendChildrenNotifications(
+			calendarBooking, NotificationTemplateType.MOVED_TO_TRASH,
+			serviceContext);
 	}
 
 	/**
@@ -598,13 +614,15 @@ public class CalendarBookingLocalServiceImpl
 
 	@Override
 	public void deleteCalendarBookingInstance(
-			long userId, long calendarBookingId, long startTime, boolean allFollowing)
+			long userId, long calendarBookingId, long startTime,
+			boolean allFollowing)
 		throws PortalException {
 
 		CalendarBooking calendarBooking =
 			calendarBookingPersistence.findByPrimaryKey(calendarBookingId);
 
-		deleteCalendarBookingInstance(userId, calendarBooking, startTime, allFollowing);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, allFollowing);
 	}
 
 	@Override
@@ -881,7 +899,8 @@ public class CalendarBookingLocalServiceImpl
 
 			if (allFollowing) {
 				List<CalendarBooking> recurringCalendarBookings =
-					splitCalendarBookingInstances(userId, calendarBooking, startTime);
+					splitCalendarBookingInstances(
+						userId, calendarBooking, startTime);
 
 				for (CalendarBooking recurringCalendarBooking :
 						recurringCalendarBookings) {
@@ -1394,7 +1413,8 @@ public class CalendarBookingLocalServiceImpl
 			Calendar calendar = calendarLocalService.getCalendar(calendarId);
 
 			List<CalendarBooking> recurringCalendarBookings =
-				splitCalendarBookingInstances(userId, calendarBooking, startTime);
+				splitCalendarBookingInstances(
+					userId, calendarBooking, startTime);
 
 			List<String> unmodifiedAttributesNames =
 				getUnmodifiedAttributesNames(
@@ -2095,7 +2115,8 @@ public class CalendarBookingLocalServiceImpl
 			calendarBooking.getSecondReminderType(),
 			ServiceContextThreadLocal.getServiceContext());
 
-		deleteCalendarBookingInstance(userId, calendarBooking, startTime, true, false);
+		deleteCalendarBookingInstance(
+			userId, calendarBooking, startTime, true, false);
 
 		return calendarBookingInstance;
 	}
@@ -2298,6 +2319,27 @@ public class CalendarBookingLocalServiceImpl
 
 	@ServiceReference(type = TrashEntryLocalService.class)
 	protected TrashEntryLocalService trashEntryLocalService;
+
+	private void _sendChildrenNotifications(
+		CalendarBooking calendarBooking,
+		NotificationTemplateType notificationType,
+		ServiceContext serviceContext) {
+
+		List<CalendarBooking> childCalendarBookings =
+			calendarBooking.getChildCalendarBookings();
+
+		for (CalendarBooking childCalendarBooking : childCalendarBookings) {
+			if (childCalendarBooking.equals(calendarBooking)) {
+				continue;
+			}
+
+			sendNotification(
+				childCalendarBooking, notificationType, serviceContext);
+
+			_sendChildrenNotifications(
+				childCalendarBooking, notificationType, serviceContext);
+		}
+	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		CalendarBookingLocalServiceImpl.class);

--- a/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-service/src/main/java/com/liferay/calendar/service/impl/CalendarBookingServiceImpl.java
@@ -203,7 +203,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing);
+			getUserId(), calendarBooking, instanceIndex, allFollowing);
 	}
 
 	@Override
@@ -220,7 +220,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBooking, instanceIndex, allFollowing,
+			getUserId(), calendarBooking, instanceIndex, allFollowing,
 			deleteRecurringCalendarBookings);
 	}
 
@@ -237,7 +237,7 @@ public class CalendarBookingServiceImpl extends CalendarBookingServiceBaseImpl {
 			CalendarActionKeys.MANAGE_BOOKINGS);
 
 		calendarBookingLocalService.deleteCalendarBookingInstance(
-			calendarBookingId, startTime, allFollowing);
+			getUserId(), calendarBookingId, startTime, allFollowing);
 	}
 
 	@Override

--- a/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
+++ b/modules/apps/forms-and-workflow/calendar/calendar-test/src/testIntegration/java/com/liferay/calendar/service/test/CalendarBookingLocalServiceTest.java
@@ -580,7 +580,7 @@ public class CalendarBookingLocalServiceTest {
 				calendarBooking, 2, titleMap, serviceContext);
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 1, true, true);
+			_user.getUserId(), calendarBooking, 1, true, true);
 
 		calendarBookingInstance =
 			CalendarBookingLocalServiceUtil.fetchCalendarBooking(
@@ -658,7 +658,7 @@ public class CalendarBookingLocalServiceTest {
 		long calendarBookingId = calendarBooking.getCalendarBookingId();
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 0, false);
+			_user.getUserId(), calendarBooking, 0, false);
 
 		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
 			calendarBookingId);
@@ -666,7 +666,7 @@ public class CalendarBookingLocalServiceTest {
 		Assert.assertNotNull(calendarBooking);
 
 		CalendarBookingLocalServiceUtil.deleteCalendarBookingInstance(
-			calendarBooking, 0, false);
+			_user.getUserId(), calendarBooking, 0, false);
 
 		calendarBooking = CalendarBookingLocalServiceUtil.fetchCalendarBooking(
 			calendarBookingId);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-74454
https://issues.liferay.com/browse/LPP-26631

I deprecated instead of changing original deleteCalendarBookingInstance methods. I also addressed the issues present with tests.

Older Notes:
Deleting an instance or multiple instances (with Following option) of a recurring calendar booking will now notify participants.
The children of the calendar event were found through different logic than what deletes the events because changing the deleteCalendarBooking method here and elsewhere would create cascade of changes to the portlet.
Originally I found that the best pattern to follow would be:
-Users aren't notified if the deleted event is in the past.
-User is notified with Deleted template if 1 occurrence is deleted
-User is notified with Updated template if multiple occurrences are deleted
However, our framework doesn't have the supporting methods necessary to easily implement this. In particular calendarBooking.getStartTime() is not updated when the first event in a recurring series is deleted. As such, I just to the Delete Notification Template when a user deletes 1 or more instances of a Calendar Booking. This breaks with the implementation a little, but it doesn't seem worth the effort to follow it perfectly in this case.