### PR TITLE
[TECHNICAL-SUPPORT] LPS-74810

### DIFF
--- a/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
+++ b/modules/apps/foundation/roles/roles-admin-web/src/main/java/com/liferay/roles/admin/web/internal/portlet/RolesAdminPortlet.java
@@ -94,6 +94,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
+		"com.liferay.portlet.add-default-resource=true",
 		"com.liferay.portlet.css-class-wrapper=portlet-users-admin",
 		"com.liferay.portlet.display-category=category.hidden",
 		"com.liferay.portlet.header-portlet-css=/css/main.css",


### PR DESCRIPTION
/cc @Alec-Shay 

Notes from Alec:
> Relevant tickets:
> 
> https://issues.liferay.com/browse/LPP-26490
> https://issues.liferay.com/browse/LPS-74810
> 
> Organization Owners do not have access to the portlet (popup) when editing Organization members, to assign Organization roles. They can still assign them by clicking "Assign Organization Roles," however, in the "My Organizations" page.
> 
> The reason for this is that the portlet popups (for both of these ways of adding Organization roles) are considered "control panel" portlets, for which access is not normally granted unless the user has access to the Control Panel -- which an Organization Owner does not necessarily need to have.
> 
> The portlet that pops up when you click "Assign Organization Roles," however, is a bit different, because that is the `RolesSelectorPortlet`, whereas the one that pops up when editing the user is the `RolesAdminPortlet`. In `ControlPanelLayoutTypeAccessPolicy.java`, if a user does not normally have permission to access the portlet, they can still get access through a couple of special cases, such as if [isAccessGrantedByPortletAuthenticationToken(request, layout, portlet)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/web-experience/layout/layout-type-controller/layout-type-controller-control-panel/src/main/java/com/liferay/layout/type/controller/control/panel/internal/access/policy/ControlPanelLayoutTypeAccessPolicy.java#L66) returns true. For this to work, the portlet must have its `_addDefaultResource` value set to true (see [this line in RolesSelectorPortlet.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/foundation/roles/roles-selector-web/src/main/java/com/liferay/roles/selector/web/internal/portlet/RolesSelectorPortlet.java#L37).
> 
> I cannot see any particular reason why the `RolesSelectorPortlet` would have this value set to true, but the `RolesAdminPortlet` would not; the variable as a whole is confusing to me, as I don't see any documentation or explanations for it and I don't know what "default resource" it could be referring to.
> 
> However, it seems to me that the value for `RolesSelectorPortlet` was set to true for a similar type of permissions-related issue; see [LPS-59607](https://issues.liferay.com/browse/LPS-59607) (as you can see, [the fix for it is almost identical](https://github.com/brianchandotcom/liferay-portal/pull/37696/commits/7581d803e6ccc3cd18f5edf927f1c36e21b4659c)). Thus, I think this is a reasonable precedent for pushing this fix forward.
> 
> Let me know if I overlooked anything, or if there may be other problems with this. Thanks!