### PR TITLE
LPS 75045 - Reindex affected users when changing parent organization.

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -48,7 +48,6 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.tree.TreeModelTasksAdapter;
 import com.liferay.portal.kernel.tree.TreePathUtil;
@@ -1895,13 +1894,13 @@ public class OrganizationLocalServiceImpl
 
 			indexer.reindex(reindexOrganizations);
 
-			long userCount = UserLocalServiceUtil.getOrganizationUsersCount(
+			long userCount = userLocalService.getOrganizationUsersCount(
 				organizationId);
 
 			Indexer<User> userIndexer = IndexerRegistryUtil.nullSafeGetIndexer(
 				User.class);
 
-			for (int i = 0; i < userCount; i+= 10000) {
+			for (int i = 0; i < userCount; i += 10000) {
 				int start = i;
 				int end = i + 10000;
 

--- a/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/OrganizationLocalServiceImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.tree.TreeModelTasksAdapter;
 import com.liferay.portal.kernel.tree.TreePathUtil;
@@ -68,6 +69,7 @@ import com.liferay.portal.kernel.util.comparator.OrganizationIdComparator;
 import com.liferay.portal.kernel.util.comparator.OrganizationNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.model.impl.OrganizationImpl;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.service.base.OrganizationLocalServiceBaseImpl;
 import com.liferay.portal.util.PropsUtil;
 import com.liferay.portal.util.PropsValues;
@@ -1892,6 +1894,26 @@ public class OrganizationLocalServiceImpl
 			}
 
 			indexer.reindex(reindexOrganizations);
+
+			long userCount = UserLocalServiceUtil.getOrganizationUsersCount(
+				organizationId);
+
+			Indexer<User> userIndexer = IndexerRegistryUtil.nullSafeGetIndexer(
+				User.class);
+
+			for (int i = 0; i < userCount; i+= 10000) {
+				int start = i;
+				int end = i + 10000;
+
+				List<User> users = organizationPersistence.getUsers(
+					organizationId, start, end);
+
+				for (User user : users) {
+					userIndexer.reindex(user);
+
+					PermissionCacheUtil.clearCache(user.getUserId());
+				}
+			}
 		}
 		else {
 			indexer.reindex(organization);


### PR DESCRIPTION
@wanderlast

Notes from Lianne:

> ### Links:
> LPS: https://issues.liferay.com/browse/LPS-75045
> Related LPP: https://issues.liferay.com/browse/LPP-27284
> 
> Hi @ericyanLr 
> 
> ## _Synopsis_
> The issue is that when a parent organization is added or removed from an organization the permissions of the organization members are not updated. The problem can be 'fixed' currently by restarting the server, or in Liferay's control panel under Server Administration -> "Clear content cached across the cluster".
> 
> The root cause of the bug is that users are not reindexed when organizations are updated, meaning that adding or removing a parent organization does not update the user's organizational permissions as it should.
> 
> ## _Related History_
> This problem has cropped up multiple times with other, similar areas of the code. Specifically [LPS-68988](https://issues.liferay.com/browse/LPS-68988) fixed it with regards to UserLocalServiceImpl functions. This fix is near identical to the fix I applied--calling a reindex whenever a change is made.
> 
> Please let me know if you have any questions. Thanks!