### PR TITLE
LPS-75045 - Reindex affected users when parent organization changes

### DIFF
--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -11,6 +11,7 @@
 	<bean class="com.liferay.portal.model.LayoutSetModelListener" id="com.liferay.portal.model.LayoutSetModelListener" />
 	<bean class="com.liferay.portal.model.PortletPreferencesModelListener" id="com.liferay.portal.model.PortletPreferencesModelListener" />
 	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
+	<bean class="com.liferay.portal.security.permission.OrganizationModelListener" id="com.liferay.portal.security.permission.OrganizationModelListener" />
 	<bean class="com.liferay.portal.security.permission.ResourceBlockModelListener" id="com.liferay.portal.security.permission.ResourceBlockModelListener" />
 	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />
 	<bean class="com.liferay.portal.security.permission.TeamModelListener" id="com.liferay.portal.security.permission.TeamModelListener" />

--- a/portal-impl/src/com/liferay/portal/security/permission/OrganizationModelListener.java
+++ b/portal-impl/src/com/liferay/portal/security/permission/OrganizationModelListener.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.security.permission;
+
+import com.liferay.portal.kernel.concurrent.ThreadPoolExecutor;
+import com.liferay.portal.kernel.executor.PortalExecutorManagerUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+
+/**
+ * @author Lianne Louie
+ */
+public class OrganizationModelListener extends BaseModelListener<Organization> {
+
+	@Override
+	public void onAfterUpdate(Organization organization) {
+		updateOrganizationUsers(organization);
+	}
+
+	@Override
+	public void onBeforeUpdate(Organization organization) {
+		_organizationId = organization.getOrganizationId();
+
+		try {
+			Organization oldOrg = OrganizationLocalServiceUtil.getOrganization(
+				_organizationId);
+
+			_oldParentId = oldOrg.getParentOrganizationId();
+		}
+		catch (Exception e) {
+			_log.error("Unable to fetch organization: " + _organizationId);
+
+			_oldParentId = organization.getParentOrganizationId();
+		}
+	}
+
+	protected void updateOrganizationUsers(Organization organization) {
+		long currentParentId = organization.getParentOrganizationId();
+
+		Callable<Void> callable = new Callable<Void>() {
+
+			@Override
+			public Void call() throws Exception {
+				long currentParentId = organization.getParentOrganizationId();
+
+				if (_oldParentId == currentParentId) {
+					return null;
+				}
+
+				Indexer<User> userIndexer =
+					IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+				long userCount = UserLocalServiceUtil.getOrganizationUsersCount(
+					_organizationId);
+
+				for (int i = 0; i < userCount; i += 10000) {
+					int start = i;
+					int end = i + 10000;
+
+					List<User> users =
+						UserLocalServiceUtil.getOrganizationUsers(
+							_organizationId, start, end);
+
+					for (User user : users) {
+						userIndexer.reindex(user);
+
+						PermissionCacheUtil.clearCache(user.getUserId());
+					}
+				}
+
+				return null;
+			}
+
+		};
+
+		ThreadPoolExecutor threadPoolExecutor =
+			PortalExecutorManagerUtil.getPortalExecutor(
+				OrganizationModelListener.class.getName());
+
+		if (_oldParentId == currentParentId) {
+			TransactionCommitCallbackUtil.registerCallback(
+				new Callable<Void>() {
+
+					@Override
+					public Void call() throws Exception {
+						threadPoolExecutor.submit(callable);
+
+						return null;
+					}
+
+				});
+		}
+		else {
+			threadPoolExecutor.submit(callable);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		OrganizationModelListener.class);
+
+	private long _oldParentId;
+	private long _organizationId;
+
+}


### PR DESCRIPTION
Notes from @wanderlast:

> ### Links:
> LPS: https://issues.liferay.com/browse/LPS-75045
> Related LPP: https://issues.liferay.com/browse/LPP-27284
> 
> Hi!
> 
> ## _Synopsis_
> The issue is that when a parent organization is added or removed from an organization the permissions of the organization members are not updated. The problem can be 'fixed' currently by restarting the server, or in Liferay's control panel under Server Administration -> "Clear content cached across the cluster".
> 
> The root cause of the bug is that users are not reindexed when organizations are updated, meaning that adding or removing a parent organization does not update the user's organizational permissions as it should.
> 
> ## _Related History_
> This problem has cropped up multiple times with other, similar areas of the code. Specifically [LPS-68988](https://issues.liferay.com/browse/LPS-68988) fixed it with regards to UserLocalServiceImpl functions. This fix is near identical to the fix I applied--calling a reindex whenever a change is made.
> 
> Model listeners were used to handle cache errors in a similar manner to this fix in [LPS-75016](https://issues.liferay.com/browse/LPS-75016), although reindexing is not performed in these listeners--only the cache clear.
> 
> ## _Fix_
> The fix itself that was used is a model listener, per Minchau's suggestion. The model listener listens to any updates to the organization and performs a reindex if the parent organization's ID has changed. Separate threads are used to prevent the portal from hanging in the case of a large organization reindex.
> 
> Please let me know if you have any questions. Thanks!