### PR TITLE
LPS-74863

### DIFF
--- a/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
@@ -127,9 +127,10 @@ public class RandomTestUtil {
 	public static int randomInt(int min, int max)
 		throws IllegalArgumentException {
 
-		if ((min < 0) || (max < 0)) {
+		if (((long)max - (long)min) >= Integer.MAX_VALUE) {
 			throw new IllegalArgumentException(
-				"Both min and max values must be positive");
+				"The difference between max and min must be less than " +
+					Integer.MAX_VALUE);
 		}
 
 		if (max < min) {
@@ -137,16 +138,7 @@ public class RandomTestUtil {
 				"Max value must be greater than the min value");
 		}
 
-		int value = _random.nextInt(max - min + 1) + min;
-
-		if (value > 0) {
-			return value;
-		}
-		else if (value == 0) {
-			return randomInt(min, max);
-		}
-
-		return -value;
+		return _random.nextInt(max - min + 1) + min;
 	}
 
 	public static Map<Locale, String> randomLocaleStringMap() {

--- a/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
@@ -111,17 +111,7 @@ public class RandomTestUtil {
 	}
 
 	public static int randomInt() {
-		int value = _random.nextInt();
-
-		if (value > 0) {
-			return value;
-		}
-		else if (value == 0) {
-			return randomInt();
-		}
-		else {
-			return -value;
-		}
+		return randomInt(1, Integer.MAX_VALUE);
 	}
 
 	public static int randomInt(int min, int max)

--- a/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
+++ b/portal-test/src/com/liferay/portal/kernel/test/util/RandomTestUtil.java
@@ -135,7 +135,7 @@ public class RandomTestUtil {
 
 		if (max < min) {
 			throw new IllegalArgumentException(
-				"Max value must be greater than the min value");
+				"Max value must be greater than or equal to the min value");
 		}
 
 		return _random.nextInt(max - min + 1) + min;


### PR DESCRIPTION
We call `RandomTestUtil.randomInt(0, x)` all the time from other tests in our code. So I can't fix this by simply disallowing 0 as an input. I decided to make the method more versatile instead and allow it to take negative numbers as an input.