### PR TITLE
 LPS-75134 S3Store leaks HTTP connections when serving files as stream

### DIFF
--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCacheImpl.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCacheImpl.java
@@ -112,6 +112,8 @@ public class S3FileCacheImpl implements S3FileCache {
 		if (cacheFile.exists() &&
 			(cacheFile.lastModified() >= lastModifiedDate.getTime())) {
 
+			cacheFile.setLastModified(System.currentTimeMillis());
+
 			StreamUtil.cleanUp(inputStream);
 
 			return cacheFile;

--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -71,6 +71,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -200,10 +202,14 @@ public class S3Store extends BaseStore {
 			String versionLabel)
 		throws PortalException {
 
-		S3Object s3Object = getS3Object(
-			companyId, repositoryId, fileName, versionLabel);
+		File file = getFile(companyId, repositoryId, fileName, versionLabel);
 
-		return s3Object.getObjectContent();
+		try {
+			return new FileInputStream(file);
+		}
+		catch (FileNotFoundException fnfe) {
+			throw new SystemException(fnfe);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-75134

Hi @jonathanmccann,

**Regarding the second commit:**
Currently, when we request a file, the following happens:
1. Retrieve the file from the cache
2. Cleanup the cache (Delete cached files with lastModified < a set # of days)
3. Return the retrieved cache file

Currently, a cached file's lastModified date is never updated.
This means that if we retrieve a cached file, it's possible the cleanup process would delete that file.
That means the returned cache file would actually no longer be available.

This commit makes it so the cache file's **lastModified** will be updated with the current time. 
This should prevent the **clean up process** from removing recently used cache files.

Reference: [S3Store.java#L188-L190](https://github.com/ericyanLr/liferay-portal/blob/1588c214eff7ec976f5bafcae4edf300b08d964f/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java#L188-L190)

----
Please let me know if you have any questions or concerns.
Thanks!
