### PR TITLE
LPS-75240

### DIFF
--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_1_0/UpgradeUserNotificationEvent.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_1_0/UpgradeUserNotificationEvent.java
@@ -78,6 +78,13 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 					"UserNotificationEvent");
 			ResultSet rs = ps.executeQuery()) {
 
+			runSQL("update UserNotificationEvent set delivered = TRUE");
+
+			runSQL(
+				"update UserNotificationEvent set deliveryType = " +
+					UserNotificationDeliveryConstants.TYPE_WEBSITE + " where " +
+						"deliveryType = 0 or deliveryType is null");
+
 			while (rs.next()) {
 				long userNotificationEventId = rs.getLong(
 					"userNotificationEventId");
@@ -86,15 +93,6 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 				UserNotificationEvent userNotificationEvent =
 					_userNotificationEventLocalService.getUserNotificationEvent(
 						userNotificationEventId);
-
-				userNotificationEvent.setDelivered(true);
-
-				int deliveryType = userNotificationEvent.getDeliveryType();
-
-				if (deliveryType == 0) {
-					userNotificationEvent.setDeliveryType(
-						UserNotificationDeliveryConstants.TYPE_WEBSITE);
-				}
 
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 					payload);

--- a/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_1_0/UpgradeUserNotificationEvent.java
+++ b/modules/apps/collaboration/notifications/notifications-web/src/main/java/com/liferay/notifications/web/internal/upgrade/v2_1_0/UpgradeUserNotificationEvent.java
@@ -14,6 +14,7 @@
 
 package com.liferay.notifications.web.internal.upgrade.v2_1_0;
 
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
@@ -73,10 +74,16 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 
 	protected void updateUserNotificationEvents() throws Exception {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
-			PreparedStatement ps = connection.prepareStatement(
-				"select userNotificationEventId, payload from " +
-					"UserNotificationEvent");
-			ResultSet rs = ps.executeQuery()) {
+			PreparedStatement ps1 = connection.prepareStatement(
+				"select userNotificationEventId, payload, actionRequired " +
+					"from UserNotificationEvent where payload like " +
+						"'%actionRequired%'");
+			PreparedStatement ps2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update UserNotificationEvent set payload = ?, " +
+						"actionRequired = ? where userNotificationEventId = ?");
+			ResultSet rs = ps1.executeQuery()) {
 
 			runSQL("update UserNotificationEvent set delivered = TRUE");
 
@@ -89,28 +96,24 @@ public class UpgradeUserNotificationEvent extends UpgradeProcess {
 				long userNotificationEventId = rs.getLong(
 					"userNotificationEventId");
 				String payload = rs.getString("payload");
-
-				UserNotificationEvent userNotificationEvent =
-					_userNotificationEventLocalService.getUserNotificationEvent(
-						userNotificationEventId);
+				boolean actionRequired = rs.getBoolean("actionRequired");
 
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject(
 					payload);
 
-				boolean actionRequired = jsonObject.getBoolean(
-					"actionRequired");
+				actionRequired |= jsonObject.getBoolean("actionRequired");
 
 				jsonObject.remove("actionRequired");
 
-				userNotificationEvent.setPayload(jsonObject.toString());
+				ps2.setString(1, jsonObject.toString());
 
-				if (!userNotificationEvent.isActionRequired()) {
-					userNotificationEvent.setActionRequired(actionRequired);
-				}
+				ps2.setBoolean(2, actionRequired);
+				ps2.setLong(3, userNotificationEventId);
 
-				_userNotificationEventLocalService.updateUserNotificationEvent(
-					userNotificationEvent);
+				ps2.addBatch();
 			}
+
+			ps2.executeBatch();
 		}
 	}
 


### PR DESCRIPTION
Hi @jonathanmccann,

This fix does not break the [Golden rule](https://grow.liferay.com/people/DXP-+How+to+code+upgrade+process+and+backport+rules#section-DXP-+How+to+code+upgrade+process+and+backport+rules-Golden+rule) for coding upgrade processes because the Golden rule was already broken beforehand as we were querying specific columns of the UserNotificationEvent table directly. Furthermore, in my testing, the this fix improved the performance from  4636724 ms (77 minutes) to 227877 ms (4 minutes) for my test data, according to the output of the logging timer. With these numbers, I would argue that this fix qualifies for the [exception to the Golden rule](https://grow.liferay.com/people/DXP-+How+to+code+upgrade+process+and+backport+rules#section-DXP-+How+to+code+upgrade+process+and+backport+rules-Exception) anyway. 

Granted, my test data didn't have any payloads with actionRequired set. I tried altering the test data so that about half the payloads had an actionRequired variable in them, and the method took 1758741 ms (29 minutes) to run. This is still noticeably better than the previous time taken of 77 minutes, although the difference isn't as stark. My guess though is that actionRequired variable isn't included in the payload most of the time though - it sounds like something that would only be used for Workflow notifications.