### PR TITLE
LPS-75134 S3Store leaks HTTP connections when serving files as stream

### DIFF
--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCacheImpl.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3FileCacheImpl.java
@@ -111,6 +111,8 @@ public class S3FileCacheImpl implements S3FileCache {
 			if (cacheFile.exists() &&
 				(cacheFile.lastModified() >= lastModifiedDate.getTime())) {
 
+				cacheFile.setLastModified(System.currentTimeMillis());
+
 				return cacheFile;
 			}
 

--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -70,6 +70,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -199,10 +201,14 @@ public class S3Store extends BaseStore {
 			String versionLabel)
 		throws PortalException {
 
-		S3Object s3Object = getS3Object(
-			companyId, repositoryId, fileName, versionLabel);
+		File file = getFile(companyId, repositoryId, fileName, versionLabel);
 
-		return s3Object.getObjectContent();
+		try {
+			return new FileInputStream(file);
+		}
+		catch (FileNotFoundException fnfe) {
+			throw new SystemException(fnfe);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-75134

Hi @jonathanmccann,

**Regarding the second commit:**
Currently, when we request a file, the following happens:
1. Retrieve the file from the cache
2. Cleanup the cache (Delete cached files with lastModified < a set # of days)
3. Return the retrieved cache file

Reference: [S3Store.java#L187-L191](https://github.com/ericyanLr/liferay-portal/blob/f6d08808b2939b7e294e6c00a086ca7b7ec26f0f/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java#L187-L191)

Currently, a cached file's lastModified date is never updated.
This means that if we retrieve a cached file, it's possible the cleanup process would delete that file.
If that we're to happen, the returned cache file would actually be no longer available.

This commit makes it so the cache file's **lastModified** will be updated with the current time whenever it is used. 

Having an updated **lastModified** timestamp would prevent the **clean up process** from removing recently used cache files.

----
Please let me know if you have any questions or concerns.
Thanks!
