### PR TITLE
LPS-75134 S3Store leaks HTTP connections when serving files as stream

### DIFF
--- a/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
+++ b/modules/apps/foundation/portal-store/portal-store-s3/src/main/java/com/liferay/portal/store/s3/S3Store.java
@@ -70,6 +70,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.store.s3.configuration.S3StoreConfiguration;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -199,10 +201,14 @@ public class S3Store extends BaseStore {
 			String versionLabel)
 		throws PortalException {
 
-		S3Object s3Object = getS3Object(
-			companyId, repositoryId, fileName, versionLabel);
+		File file = getFile(companyId, repositoryId, fileName, versionLabel);
 
-		return s3Object.getObjectContent();
+		try {
+			return new FileInputStream(file);
+		}
+		catch (FileNotFoundException fnfe) {
+			throw new SystemException(fnfe);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Ticket: https://issues.liferay.com/browse/LPS-75134
Previous pr: https://github.com/shuyangzhou/liferay-portal/pull/5049#issuecomment-338330907

Hi @jonathanmccann,

## Recap
In our previous discussion, I brought up a topic about how a retrieved cached file might get deleted by a cleanUp process, before it can even be consumed/used. 

This was a unique case that would occur only if the S3 Store was configured with these two settings:
- Cache Directory Clean Up Expunge (Set the number of days a file is kept in the cache)
    - value: 0
- Cache Directory Clean Up Frequency (Set this property to 1 to always clean)
    - value: 1

We noted that this might be a way for a user to make it so the retrieved file is always using the latest and not a cached file.

## Update
After thinking about this some more and discussing with MCD, we concluded that setting **Cache Directory Clean Up Expunge** to **0** does not do what we think it does.

This means that using the above settings does not make it as if it were an option to bypass the cache.

## Removed second commit
In the previous pr, I provided a commit that tried to handle the case where a retrieved cached file might get deleted by a cleanUp process, before it can even be consumed/used. 

Since this case would only happen if **Cache Directory Clean Up Expunge** is set to **0**, I decided to not include it, since setting the value to **0** was not intended to begin with.

I think that if we want to handle that case, a separate ticket can be created.

----
Please let me know if you have any questions or concerns.
Thanks!
