### PR TITLE
LPS-75793

### DIFF
--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -159,7 +159,8 @@
 			WHERE
 				(Group_.companyId = ?) AND
 				(Group_.parentGroupId = ?) AND
-				(Group_.site = ?)
+				(Group_.site = ?) AND
+				(Group_.active_ = [$TRUE$])
 		]]>
 	</sql>
 	<sql id="com.liferay.portal.kernel.service.persistence.GroupFinder.findByLiveGroups">


### PR DESCRIPTION
With this fix, if you have an inactive site that has an active child site, neither the parent nor child will be displayed. I thought this behavior made more sense than displaying the child site unattached to its parent. Also, the same behavior already exists if you have a site without layouts that has a child site with layouts.

I thought we should fix it in the GroupFinder, rather than in page.jsp, because the GroupFinder method seems like it is supposed to be used to find sites whose layouts can be visited, so inactive sites should not be returned by it. Everything I could find that called this method seemed like it would benefit from not returning inactive sites.