### PR TITLE
LPS-76766

### DIFF
--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -380,13 +380,6 @@ public class AssetBrowserDisplayContext {
 
 		portletURL.setParameter("groupId", String.valueOf(getGroupId()));
 
-		long[] selectedGroupIds = getSelectedGroupIds();
-
-		if (selectedGroupIds.length > 0) {
-			portletURL.setParameter(
-				"selectedGroupIds", StringUtil.merge(selectedGroupIds));
-		}
-
 		long selectedGroupId = ParamUtil.getLong(_request, "selectedGroupId");
 
 		if (selectedGroupId > 0) {

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -292,6 +292,8 @@ public class AssetBrowserDisplayContext {
 		List<ManagementBarFilterItem> managementBarFilterItems =
 			new ArrayList<>();
 
+		PortletURL groupURL = getPortletURL();
+
 		long selectedGroupId = ParamUtil.getLong(_request, "selectedGroupId");
 
 		long[] selectedGroupIds = PortalUtil.getSharedContentSiteGroupIds(
@@ -320,8 +322,6 @@ public class AssetBrowserDisplayContext {
 			else {
 				label = LanguageUtil.get(_request, "all");
 			}
-
-			PortletURL groupURL = getPortletURL();
 
 			groupURL.setParameter(
 				"groupId", String.valueOf(curGroup.getGroupId()));

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -293,8 +292,11 @@ public class AssetBrowserDisplayContext {
 		List<ManagementBarFilterItem> managementBarFilterItems =
 			new ArrayList<>();
 
-		long[] selectedGroupIds = ArrayUtil.append(
-			new long[] {0}, getSelectedGroupIds());
+		long selectedGroupId = ParamUtil.getLong(_request, "selectedGroupId");
+
+		long[] selectedGroupIds = PortalUtil.getSharedContentSiteGroupIds(
+			themeDisplay.getCompanyId(), selectedGroupId,
+			themeDisplay.getUserId());
 
 		for (long curGroupId : selectedGroupIds) {
 			Group curGroup = GroupLocalServiceUtil.fetchGroup(curGroupId);

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -312,25 +312,14 @@ public class AssetBrowserDisplayContext {
 		List<Group> groups = GroupLocalServiceUtil.getGroups(selectedGroupIds);
 
 		for (Group curGroup : groups) {
-			if ((curGroup == null) && (curGroup.getGroupId() > 0)) {
-				continue;
-			}
-
 			boolean active = false;
 
 			if (getGroupId() == curGroup.getGroupId()) {
 				active = true;
 			}
 
-			label = StringPool.BLANK;
-
-			if (curGroup != null) {
-				label = HtmlUtil.escape(
-					curGroup.getDescriptiveName(themeDisplay.getLocale()));
-			}
-			else {
-				label = LanguageUtil.get(_request, "all");
-			}
+			label = HtmlUtil.escape(
+				curGroup.getDescriptiveName(themeDisplay.getLocale()));
 
 			groupURL.setParameter(
 				"groupId", String.valueOf(curGroup.getGroupId()));

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -298,16 +298,16 @@ public class AssetBrowserDisplayContext {
 			themeDisplay.getCompanyId(), selectedGroupId,
 			themeDisplay.getUserId());
 
-		for (long curGroupId : selectedGroupIds) {
-			Group curGroup = GroupLocalServiceUtil.fetchGroup(curGroupId);
+		List<Group> groups = GroupLocalServiceUtil.getGroups(selectedGroupIds);
 
-			if ((curGroup == null) && (curGroupId > 0)) {
+		for (Group curGroup : groups) {
+			if ((curGroup == null) && (curGroup.getGroupId() > 0)) {
 				continue;
 			}
 
 			boolean active = false;
 
-			if (getGroupId() == curGroupId) {
+			if (getGroupId() == curGroup.getGroupId()) {
 				active = true;
 			}
 
@@ -323,7 +323,8 @@ public class AssetBrowserDisplayContext {
 
 			PortletURL groupURL = getPortletURL();
 
-			groupURL.setParameter("groupId", String.valueOf(curGroupId));
+			groupURL.setParameter(
+				"groupId", String.valueOf(curGroup.getGroupId()));
 
 			ManagementBarFilterItem managementBarFilterItem =
 				new ManagementBarFilterItem(active, label, groupURL.toString());

--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -292,7 +292,16 @@ public class AssetBrowserDisplayContext {
 		List<ManagementBarFilterItem> managementBarFilterItems =
 			new ArrayList<>();
 
+		String label = LanguageUtil.get(_request, "all");
+
 		PortletURL groupURL = getPortletURL();
+
+		groupURL.setParameter("groupId", "0");
+
+		ManagementBarFilterItem managementBarFilterItem =
+			new ManagementBarFilterItem(false, label, groupURL.toString());
+
+		managementBarFilterItems.add(managementBarFilterItem);
 
 		long selectedGroupId = ParamUtil.getLong(_request, "selectedGroupId");
 
@@ -313,7 +322,7 @@ public class AssetBrowserDisplayContext {
 				active = true;
 			}
 
-			String label = StringPool.BLANK;
+			label = StringPool.BLANK;
 
 			if (curGroup != null) {
 				label = HtmlUtil.escape(
@@ -326,8 +335,8 @@ public class AssetBrowserDisplayContext {
 			groupURL.setParameter(
 				"groupId", String.valueOf(curGroup.getGroupId()));
 
-			ManagementBarFilterItem managementBarFilterItem =
-				new ManagementBarFilterItem(active, label, groupURL.toString());
+			managementBarFilterItem = new ManagementBarFilterItem(
+				active, label, groupURL.toString());
 
 			managementBarFilterItems.add(managementBarFilterItem);
 		}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-76766

The first 5 commits make a moderate performance boost by not fetching each group one at a time, and not calling getPortletURL() over and over.

The final commit resolves an issue where the managementBarFilterItems list has too many large values, resulting in memory issues.  This issue utilizes changes from LPS-74910 in order to calculate the selectedGroupIds list after the request, so we don't have to load it up with 40,000+ characters for 5000 entries.

Please let me know if you have any questions, thanks!