### PR TITLE
LPS-76854

### DIFF
--- a/modules/util/portal-tools-db-support/src/main/java/com/liferay/portal/tools/db/support/commands/CleanServiceBuilderCommand.java
+++ b/modules/util/portal-tools-db-support/src/main/java/com/liferay/portal/tools/db/support/commands/CleanServiceBuilderCommand.java
@@ -26,7 +26,9 @@ import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
 import java.sql.Connection;
+import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 
@@ -155,8 +157,15 @@ public class CleanServiceBuilderCommand extends BaseCommand {
 	private void _dropTable(Connection connection, String tableName)
 		throws SQLException {
 
-		try (Statement statement = connection.createStatement()) {
-			statement.executeUpdate("DROP TABLE IF EXISTS " + tableName);
+		DatabaseMetaData databaseMetaData = connection.getMetaData();
+
+		try (Statement statement = connection.createStatement();
+			ResultSet rs = databaseMetaData.getTables(
+				null, null, tableName.toUpperCase(), new String[] {"TABLE"})) {
+
+			if (rs.next()) {
+				statement.executeUpdate("DROP TABLE " + tableName);
+			}
 		}
 	}
 


### PR DESCRIPTION
Hi @jonathanmccann,

I'm not completely sure why the tests were failing, since I couldn't figure out what exactly junit was doing to connect to all those databases. My guess is that it was emulating each of the databases somehow, since I don't have most of them installed on my system. The reason the SQL Server tests were passing is probably because it was either emulating SQL Server 2016, or the emulator was just not accurate.

When I modified the logic for checking if a table exists to utilize the same [logic that the tests use](https://github.com/liferay/liferay-portal/blob/master/modules/util/portal-tools-db-support/src/test/java/com/liferay/portal/tools/db/support/util/DBTestUtil.java#L73-L74), the tests ran successfully.