### PR TITLE
LPS-76952 Added a document trigger to adjust portlet size

### DIFF
--- a/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal.js
+++ b/modules/apps/foundation/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portal.js
@@ -67,6 +67,8 @@
 			}
 
 			Liferay.fire('showTab', details);
+
+			$(document).trigger('screenChange.lexicon.sidenav');
 		},
 		['aui-base']
 	);


### PR DESCRIPTION
If the version history of a Document is too long, the display will extend past the portlet and overlay on top of other portlets.

I added a trigger that will check for the documents new size and adjust the size of the portlet. This will keep all the information inside the portlet.