### PR TITLE
LPS-77365

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletContainerImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletContainerImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portlet;
 
+import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -58,6 +59,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.util.comparator.PortletConfigurationIconComparator;
@@ -593,6 +595,14 @@ public class PortletContainerImpl implements PortletContainer {
 						PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE)) {
 
 					String[] values = entry.getValue();
+
+					if (publicRenderParameter.getIdentifier().equals("tag") &&
+						Validator.isNotNull(values[0]) &&
+						!AssetTagLocalServiceUtil.hasTag(
+							layout.getGroupId(), values[0])) {
+
+						values[0] = StringPool.BLANK;
+					}
 
 					if (lifecycleAction) {
 						String[] oldValues = publicRenderParameters.get(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-77365

This results in the tag not being looked at, but the URL stays the same (the tag is still shown).  I could probably have it scrubbed from the URL as well, I just figured this was cleaner to do than redirecting.

Let me know if you have any questions.