### PR TITLE
LPS-76859

### DIFF
--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/BaseJournalArticlePortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/BaseJournalArticlePortletConfigurationIcon.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.content.web.internal.portlet.configuration.icon;
+
+import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.BaseJSPPortletConfigurationIcon;
+import com.liferay.portal.kernel.theme.PortletDisplay;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletResponse;
+
+/**
+ * @author Fortunato Maldonado
+ */
+public abstract class BaseJournalArticlePortletConfigurationIcon
+	extends BaseJSPPortletConfigurationIcon {
+
+	protected JournalContentDisplayContext getJournalContentDisplayContext(
+		PortletRequest portletRequest, PortletResponse portletResponse,
+		long ddmStructureClassNameId) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+		try {
+			return JournalContentDisplayContext.create(
+				portletRequest, portletResponse, portletDisplay,
+				ddmStructureClassNameId);
+		}
+		catch (PortalException pe) {
+			_log.error("Unable to create display context", pe);
+		}
+
+		return null;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		BaseJournalArticlePortletConfigurationIcon.class);
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/DisplaySeparatorPortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/DisplaySeparatorPortletConfigurationIcon.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.content.web.internal.portlet.configuration.icon;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.permission.JournalArticlePermission;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.util.ResourceBundle;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fortunato Maldonado
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + JournalContentPortletKeys.JOURNAL_CONTENT,
+		"path=-"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class DisplaySeparatorPortletConfigurationIcon
+	extends BaseJournalArticlePortletConfigurationIcon {
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon/web_content_display_separator.jsp";
+	}
+
+	public String getMessage(PortletRequest portletRequest) {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", getLocale(portletRequest), getClass());
+
+		return LanguageUtil.get(resourceBundle, "web-content");
+	}
+
+	public double getWeight() {
+		return 0.8;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		JournalContentDisplayContext journalContentDisplayContext =
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		JournalArticle article = journalContentDisplayContext.getArticle();
+
+		if (article == null) {
+			return false;
+		}
+
+		try {
+			if (journalContentDisplayContext.isShowEditArticleIcon() ||
+				journalContentDisplayContext.isShowEditTemplateIcon() ||
+				JournalArticlePermission.contains(
+					permissionChecker, article, ActionKeys.PERMISSIONS)) {
+
+				return true;
+			}
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+
+			return false;
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.journal.content.web)",
+		unbind = "-"
+	)
+	public void setServletContext(ServletContext servletContext) {
+		super.setServletContext(servletContext);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		DisplaySeparatorPortletConfigurationIcon.class);
+
+	private long _ddmStructureClassNameId;
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditJournalArticlePortletConfigurationIcon.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.content.web.internal.portlet.configuration.icon;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+
+import java.util.ResourceBundle;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fortunato Maldonado
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + JournalContentPortletKeys.JOURNAL_CONTENT,
+		"path=-"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class EditJournalArticlePortletConfigurationIcon
+	extends BaseJournalArticlePortletConfigurationIcon {
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon/edit_article.jsp";
+	}
+
+	@Override
+	public String getMessage(PortletRequest portletRequest) {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", getLocale(portletRequest), getClass());
+
+		return LanguageUtil.get(resourceBundle, "edit-web-content");
+	}
+
+	@Override
+	public double getWeight() {
+		return 0.5;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		JournalContentDisplayContext journalContentDisplayContext =
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
+
+		try {
+			if (journalContentDisplayContext.isShowEditArticleIcon()) {
+				return true;
+			}
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+
+			return false;
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.journal.content.web)",
+		unbind = "-"
+	)
+	public void setServletContext(ServletContext servletContext) {
+		super.setServletContext(servletContext);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		EditJournalArticlePortletConfigurationIcon.class);
+
+	private long _ddmStructureClassNameId;
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditTemplatePortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/EditTemplatePortletConfigurationIcon.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.content.web.internal.portlet.configuration.icon;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fortunato Maldonado
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + JournalContentPortletKeys.JOURNAL_CONTENT,
+		"path=-"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class EditTemplatePortletConfigurationIcon
+	extends BaseJournalArticlePortletConfigurationIcon {
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon/edit_template.jsp";
+	}
+
+	@Override
+	public double getWeight() {
+		return 0.2;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		JournalContentDisplayContext journalContentDisplayContext =
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
+
+		if (journalContentDisplayContext.isShowEditTemplateIcon()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean isToolTip() {
+		return false;
+	}
+
+	@Override
+	public boolean isUseDialog() {
+		return true;
+	}
+
+	@Override
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.journal.content.web)",
+		unbind = "-"
+	)
+	public void setServletContext(ServletContext servletContext) {
+		super.setServletContext(servletContext);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
+	private long _ddmStructureClassNameId;
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/JournalPermissionsPortletConfigurationIcon.java
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/portlet/configuration/icon/JournalPermissionsPortletConfigurationIcon.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.content.web.internal.portlet.configuration.icon;
+
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.journal.constants.JournalContentPortletKeys;
+import com.liferay.journal.content.web.internal.display.context.JournalContentDisplayContext;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.permission.JournalArticlePermission;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfigurationIcon;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.ServletContext;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Fortunato Maldonado
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + JournalContentPortletKeys.JOURNAL_CONTENT,
+		"path=-"
+	},
+	service = PortletConfigurationIcon.class
+)
+public class JournalPermissionsPortletConfigurationIcon
+	extends BaseJournalArticlePortletConfigurationIcon {
+
+	@Override
+	public String getJspPath() {
+		return "/configuration/icon/edit_permissions.jsp";
+	}
+
+	@Override
+	public double getWeight() {
+		return 0.1;
+	}
+
+	@Override
+	public boolean isShow(PortletRequest portletRequest) {
+		JournalContentDisplayContext journalContentDisplayContext =
+			getJournalContentDisplayContext(
+				portletRequest, null, _ddmStructureClassNameId);
+
+		PermissionChecker permissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
+		JournalArticle article = journalContentDisplayContext.getArticle();
+
+		if (article == null) {
+			return false;
+		}
+
+		try {
+			if (JournalArticlePermission.contains(
+					permissionChecker, article, ActionKeys.PERMISSIONS)) {
+
+				return true;
+			}
+		}
+		catch (PortalException pe) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(pe, pe);
+			}
+
+			return false;
+		}
+
+		return false;
+	}
+
+	@Override
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.journal.content.web)",
+		unbind = "-"
+	)
+	public void setServletContext(ServletContext servletContext) {
+		super.setServletContext(servletContext);
+	}
+
+	@Reference(unbind = "-")
+	protected void setPortal(Portal portal) {
+		_ddmStructureClassNameId = portal.getClassNameId(DDMStructure.class);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		JournalPermissionsPortletConfigurationIcon.class);
+
+	private long _ddmStructureClassNameId;
+
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/edit_article.jsp
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/edit_article.jsp
@@ -16,23 +16,22 @@
 
 <%@ include file="/init.jsp" %>
 
-<c:if test="<%= journalContentDisplayContext.isShowEditTemplateIcon() %>">
+<c:if test="<%= journalContentDisplayContext.isShowEditArticleIcon() %>">
 
 	<%
-	DDMTemplate ddmTemplate = journalContentDisplayContext.getDDMTemplate();
-
+	JournalArticle latestArticle =
+		journalContentDisplayContext.getLatestArticle();
 	Map<String, Object> data = new HashMap<String, Object>();
-
 	data.put("destroyOnHide", true);
 	data.put("id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
-	data.put("title", HtmlUtil.escape(ddmTemplate.getName(locale)));
+	data.put("title", HtmlUtil.escape(latestArticle.getTitle(locale)));
 	%>
 
 	<liferay-ui:icon
 		data="<%= data %>"
-		id="editTemplateIcon"
-		message="edit-template"
-		url="<%= journalContentDisplayContext.getURLEditTemplate() %>"
+		id="editWebContentIcon"
+		message="edit-web-content"
+		url="<%= journalContentDisplayContext.getURLEdit() %>"
 		useDialog="<%= true %>"
 	/>
 </c:if>

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/edit_permissions.jsp
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/edit_permissions.jsp
@@ -16,23 +16,23 @@
 
 <%@ include file="/init.jsp" %>
 
-<c:if test="<%= journalContentDisplayContext.isShowEditTemplateIcon() %>">
+<%
+JournalArticle article = journalContentDisplayContext.getArticle();
+%>
 
-	<%
-	DDMTemplate ddmTemplate = journalContentDisplayContext.getDDMTemplate();
-
-	Map<String, Object> data = new HashMap<String, Object>();
-
-	data.put("destroyOnHide", true);
-	data.put("id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
-	data.put("title", HtmlUtil.escape(ddmTemplate.getName(locale)));
-	%>
+<c:if test="<%= JournalArticlePermission.contains(permissionChecker, article, ActionKeys.PERMISSIONS) %>">
+	<liferay-security:permissionsURL
+		modelResource="<%= JournalArticle.class.getName() %>"
+		modelResourceDescription="<%= HtmlUtil.escape(article.getTitle(locale)) %>"
+		resourcePrimKey="<%= String.valueOf(article.getResourcePrimKey()) %>"
+		var="permissionsURL"
+		windowState="<%= LiferayWindowState.POP_UP.toString() %>"
+	/>
 
 	<liferay-ui:icon
-		data="<%= data %>"
-		id="editTemplateIcon"
-		message="edit-template"
-		url="<%= journalContentDisplayContext.getURLEditTemplate() %>"
+		message="permissions"
+		method="get"
+		url="<%= permissionsURL %>"
 		useDialog="<%= true %>"
 	/>
 </c:if>

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/web_content_display_separator.jsp
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/configuration/icon/web_content_display_separator.jsp
@@ -16,23 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<c:if test="<%= journalContentDisplayContext.isShowEditTemplateIcon() %>">
-
-	<%
-	DDMTemplate ddmTemplate = journalContentDisplayContext.getDDMTemplate();
-
-	Map<String, Object> data = new HashMap<String, Object>();
-
-	data.put("destroyOnHide", true);
-	data.put("id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
-	data.put("title", HtmlUtil.escape(ddmTemplate.getName(locale)));
-	%>
-
-	<liferay-ui:icon
-		data="<%= data %>"
-		id="editTemplateIcon"
-		message="edit-template"
-		url="<%= journalContentDisplayContext.getURLEditTemplate() %>"
-		useDialog="<%= true %>"
-	/>
-</c:if>
+<liferay-ui:icon
+	cssClass="portlet-content"
+	id="WebContentSeparatorIcon"
+	message="web-content"
+/>

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
@@ -5,3 +5,13 @@
 		}
 	}
 }
+
+.portlet-content {
+	.taglib-text-icon {
+		border-bottom: 1px solid gray;
+		color: #6B6C7E;
+		display: block;
+		font-weight: bold;
+		text-transform: uppercase;
+	}
+}

--- a/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/web-experience/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -133,69 +133,6 @@ AssetRendererFactory<JournalArticle> assetRendererFactory = AssetRendererFactory
 							<liferay-asset:asset-addon-entry-display assetAddonEntries="<%= journalContentDisplayContext.getSelectedUserToolAssetAddonEntries() %>" />
 						</div>
 
-						<div class="pull-right visible-interaction">
-							<liferay-ui:icon-menu direction="left-side" icon="<%= StringPool.BLANK %>" markupView="lexicon" message="<%= StringPool.BLANK %>" showWhenSingleIcon="<%= true %>">
-								<c:if test="<%= journalContentDisplayContext.isShowEditArticleIcon() %>">
-
-									<%
-									JournalArticle latestArticle = journalContentDisplayContext.getLatestArticle();
-
-									Map<String, Object> data = new HashMap<String, Object>();
-
-									data.put("destroyOnHide", true);
-									data.put("id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
-									data.put("title", HtmlUtil.escape(latestArticle.getTitle(locale)));
-									%>
-
-									<liferay-ui:icon
-										data="<%= data %>"
-										id="editWebContentIcon"
-										message="edit-web-content"
-										url="<%= journalContentDisplayContext.getURLEdit() %>"
-										useDialog="<%= true %>"
-									/>
-								</c:if>
-
-								<c:if test="<%= journalContentDisplayContext.isShowEditTemplateIcon() %>">
-
-									<%
-									DDMTemplate ddmTemplate = journalContentDisplayContext.getDDMTemplate();
-
-									Map<String, Object> data = new HashMap<String, Object>();
-
-									data.put("destroyOnHide", true);
-									data.put("id", HtmlUtil.escape(portletDisplay.getNamespace()) + "editAsset");
-									data.put("title", HtmlUtil.escape(ddmTemplate.getName(locale)));
-									%>
-
-									<liferay-ui:icon
-										data="<%= data %>"
-										id="editTemplateIcon"
-										message="edit-template"
-										url="<%= journalContentDisplayContext.getURLEditTemplate() %>"
-										useDialog="<%= true %>"
-									/>
-								</c:if>
-
-								<c:if test="<%= JournalArticlePermission.contains(permissionChecker, article, ActionKeys.PERMISSIONS) %>">
-									<liferay-security:permissionsURL
-										modelResource="<%= JournalArticle.class.getName() %>"
-										modelResourceDescription="<%= HtmlUtil.escape(article.getTitle(locale)) %>"
-										resourcePrimKey="<%= String.valueOf(article.getResourcePrimKey()) %>"
-										var="permissionsURL"
-										windowState="<%= LiferayWindowState.POP_UP.toString() %>"
-									/>
-
-									<liferay-ui:icon
-										message="permissions"
-										method="get"
-										url="<%= permissionsURL %>"
-										useDialog="<%= true %>"
-									/>
-								</c:if>
-							</liferay-ui:icon-menu>
-						</div>
-
 						<div class="journal-content-article">
 							<%= articleDisplay.getContent() %>
 						</div>


### PR DESCRIPTION
The Web Content options in a web content display can potentially be covered and rendered useless for the user. The solution that Engineering came up with is to move the options to the topper and separate them from portlet options.

To do this, I created PortletConfigurationIcons for the Edit Web Content, Edit Template, Permissions, and a separator, created their jsp files, and removed the options from view.jsp.

I also created new CSS statement for the separator. The CSS might not be needed if the wanted change can be created in the respective jsp.

Any questions or feedback please let me know.
Thank you.