### PR TITLE
LPS-77365 Make sure the tag is valid before we display it on the page.

### DIFF
--- a/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/init.jsp
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/init.jsp
@@ -28,6 +28,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.asset.kernel.model.AssetCategory" %><%@
 page import="com.liferay.asset.kernel.model.AssetVocabulary" %><%@
 page import="com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil" %><%@
+page import="com.liferay.asset.kernel.service.AssetTagLocalServiceUtil" %><%@
 page import="com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@

--- a/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
+++ b/modules/apps/web-experience/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
@@ -27,6 +27,12 @@ if (portletURL == null) {
 long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 String assetTagName = ParamUtil.getString(request, "tag");
 
+if (Validator.isNotNull(assetTagName)) {
+	if (!AssetTagLocalServiceUtil.hasTag(layout.getGroupId(), assetTagName)) {
+		assetTagName = null;
+	}
+}
+
 String assetCategoryTitle = null;
 String assetVocabularyTitle = null;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-77365

See https://github.com/shuyangzhou/liferay-portal/pull/5642

I don't love this fix by any means, but I think it's the simplest way we can resolve this issue without having any files get out of scope.  We cannot remove, update, ignore, etc the tag parameter once it's in the request.  And we cannot intercept beforehand to prevent it (this is why the last PR failed).

The best we can do is simply ignore it if it's invalid in the asset-taglib module, which is where we end up displaying it on the page.

Let me know if you have any questions.