### PR TITLE
Pr 20

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -794,6 +794,16 @@ public class PortletPreferencesFactoryImpl
 				ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
 			}
 		}
+		else {
+			if (uniquePerGroup) {
+				if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
+					ownerId = siteGroupId;
+				}
+				else {
+					ownerId = layoutGroupId;
+				}
+			}
+		}
 
 		if (strictMode) {
 			return PortletPreferencesLocalServiceUtil.getStrictPreferences(

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -794,14 +794,12 @@ public class PortletPreferencesFactoryImpl
 				ownerType = PortletKeys.PREFS_OWNER_TYPE_COMPANY;
 			}
 		}
-		else {
-			if (uniquePerGroup) {
-				if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
-					ownerId = siteGroupId;
-				}
-				else {
-					ownerId = layoutGroupId;
-				}
+		else if (uniquePerGroup) {
+			if (siteGroupId > LayoutConstants.DEFAULT_PLID) {
+				ownerId = siteGroupId;
+			}
+			else {
+				ownerId = layoutGroupId;
 			}
 		}
 


### PR DESCRIPTION
CC @wanderlast
From Lianne:

> LPP: https://issues.liferay.com/browse/LPP-28517
> LPS: https://issues.liferay.com/browse/LPS-77428
> 
> Certain portlet types share portlet preferences across sites due to using the 'shared' portlet id and 'shared' owner id of 0 and 0. While this is understandable for certain portlets (e.g. those that are designated as "company wide"), this makes less sense for those that are explicitly designated as "unique per layout" and "unique per group". This causes these portlets (Forms being one of the primary offenders) to not be displayed in the staging menu under the "since last publish" option if any other staging site has been published after the form was made.
> 
> The fix has these portlets each have their own preferences based on groupid/ownerid, ensuring that these preferences stay unique per group.
> 
> If you have any other questions or concerns, please let me know. Thanks!