### PR TITLE
LPS-77796 Created a check to add the changeableDefaultLanguage to ava…

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -858,6 +858,19 @@ AUI.add(
 
 						var defaultLocale = translationManager.get('defaultLocale');
 
+						var changeableDefaultLanguage = translationManager.get('changeableDefaultLanguage');
+
+						if (changeableDefaultLanguage &&
+						   typeof availableLocales !== "undefined" &&
+						   availableLocales.indexOf(defaultLocale) == -1) {
+
+							var length = availableLocales.length;
+
+							availableLocales[length] = defaultLocale;
+
+							instance.set('availableLocales', availableLocales);
+						}
+
 						var localizable = instance.get('localizable');
 
 						var locales = [defaultLocale].concat(availableLocales);


### PR DESCRIPTION
…ilableLocales

When the OSGi property "changeableDefaultLanguage" is active, it will allow the user to change the default language while creating a web content. When changing the default language, the new language is not stored in the availableLocales and its content will not be saved.

I created a check to detect when "changeableDefaultLanguage" is active and store the new language in availableLocales if it is not already there. This will then be able to store the content of the language.