### PR TITLE
LPS-77839 Wrap Vertical Card div in hyperlink to the card's URL so it…

### DIFF
--- a/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/page.jsp
+++ b/modules/apps/foundation/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/card/vertical_card/page.jsp
@@ -18,14 +18,15 @@
 
 <%@ include file="/card/vertical_card/start.jspf" %>
 
-<div class="aspect-ratio <%= imageCSSClass %> <%= backgroundImage ? "aspect-ratio-bg-center aspect-ratio-bg-cover" : StringPool.BLANK %>" style="<%= backgroundImage ? "background-image: url('" + imageUrl + "')" : StringPool.BLANK %>">
-	<aui:a href="<%= url %>">
-		<img alt="" class="<%= backgroundImage ? " sr-only" : StringPool.BLANK %>" src="<%= imageUrl %>" />
-	</aui:a>
+<aui:a href="<%= url %>">
+	<div class="aspect-ratio <%= imageCSSClass %> <%= backgroundImage ? "aspect-ratio-bg-center aspect-ratio-bg-cover" : StringPool.BLANK %>" style="<%= backgroundImage ? "background-image: url('" + imageUrl + "')" : StringPool.BLANK %>">
 
-	<c:if test="<%= Validator.isNotNull(stickerBottom) %>">
-		<%= stickerBottom %>
-	</c:if>
-</div>
+		<img alt="" class="<%= backgroundImage ? " sr-only" : StringPool.BLANK %>" src="<%= imageUrl %>" />
+
+		<c:if test="<%= Validator.isNotNull(stickerBottom) %>">
+			<%= stickerBottom %>
+		</c:if>
+	</div>
+</aui:a>
 
 <%@ include file="/card/vertical_card/end.jspf" %>


### PR DESCRIPTION
… is clickable

I assessed whether this would make sense to apply to icon_vertical_card as well and determined that, since the link attribute was never present in that file, it doesn't need to be applied there. 

Also note that this fix applies to all uses of the liferay-frontend:vertical-card taglib, including document-library, journal, blogs, layout-admin, site-admin, item-selector, and site-browser.