### PR TITLE
Lps 77632

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
+++ b/portal-impl/src/com/liferay/portal/servlet/BrowserSnifferImpl.java
@@ -166,6 +166,13 @@ public class BrowserSnifferImpl implements BrowserSniffer {
 	}
 
 	@Override
+	public boolean isIe11(HttpServletRequest request) {
+		BrowserMetadata browserMetadata = getBrowserMetadata(request);
+
+		return browserMetadata.isIe11();
+	}
+
+	@Override
 	public boolean isIeOnWin32(HttpServletRequest request) {
 		BrowserMetadata browserMetadata = getBrowserMetadata(request);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/JSONPortletResponseUtil.java
@@ -66,7 +66,9 @@ public class JSONPortletResponseUtil {
 		HttpServletRequest request = PortalUtil.getHttpServletRequest(
 			portletRequest);
 
-		if (BrowserSnifferUtil.isIe(request)) {
+		if (BrowserSnifferUtil.isIe(request) &&
+			!BrowserSnifferUtil.isIe11(request)) {
+
 			contentType = ContentTypes.TEXT_HTML;
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserMetadata.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserMetadata.java
@@ -97,6 +97,14 @@ public class BrowserMetadata {
 		return false;
 	}
 
+	public boolean isIe11() {
+		if (isIe() && _userAgent.contains("rv:11.0")) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isIeOnWin32() {
 		if (isIe() && !_userAgent.contains("wow64") &&
 			!_userAgent.contains("win64")) {

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSniffer.java
@@ -104,6 +104,8 @@ public interface BrowserSniffer {
 
 	public boolean isIe(HttpServletRequest request);
 
+	public boolean isIe11(HttpServletRequest request);
+
 	public boolean isIeOnWin32(HttpServletRequest request);
 
 	public boolean isIeOnWin64(HttpServletRequest request);

--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSnifferUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/BrowserSnifferUtil.java
@@ -86,6 +86,10 @@ public class BrowserSnifferUtil {
 		return getBrowserSniffer().isIe(request);
 	}
 
+	public static boolean isIe11(HttpServletRequest request) {
+		return getBrowserSniffer().isIe11(request);
+	}
+
 	public static boolean isIeOnWin32(HttpServletRequest request) {
 		return getBrowserSniffer().isIeOnWin32(request);
 	}


### PR DESCRIPTION
Through the SME Request, https://issues.liferay.com/browse/LPP-28899, we found that the issue is being caused by the wrong content-type being sent. It seems that problems arise when trying to use text/html as the content type for file names. The behavior was originally this way for IE because in IE7-10, content-type application/json is not supported. However, it appears to now be supported in IE11. 

Please let me know if you find any issues with my solution or how I implemented it.