### PR TITLE
LPS-76228

### DIFF
--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -350,35 +350,21 @@ public class LayoutStagedModelDataHandler
 		long layoutId = GetterUtil.getLong(
 			referenceElement.attributeValue("layout-id"));
 
-		Group layoutGroup = null;
-		LayoutSet layoutSet = null;
+		Layout layout = layouts.get(layoutId);
 
-		try {
-			layoutGroup = _groupLocalService.getGroup(groupId);
-		}
-		catch (PortalException e) {
-			_log.debug("No group found for groupId" + groupId);
-		}
-
-		try {
-			layoutSet = _layoutSetLocalService.getLayoutSet(
-				groupId,privateLayout);
-		}
-		catch (PortalException e) {
-			_log.debug(
-				"No layout set found for groupId " + groupId
-				+ " and privateLayout value of: " + privateLayout);
-		}
+		Group layoutGroup = layout.getGroup();
+		LayoutSet layoutSet = layout.getLayoutSet();
 
 		Group existingLayoutGroup = existingLayout.getGroup();
 		LayoutSet existingLayoutSet = existingLayout.getLayoutSet();
 
 		if (existingLayoutGroup.equals(layoutGroup) &&
 			existingLayoutSet.equals(layoutSet)) {
+
 			layouts.put(layoutId, existingLayout);
 
 			Map<Long, Long> layoutPlids =
-				(Map<Long, Long>) portletDataContext.getNewPrimaryKeysMap(
+				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 					Layout.class);
 
 			long plid = GetterUtil.getLong(

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -350,16 +350,42 @@ public class LayoutStagedModelDataHandler
 		long layoutId = GetterUtil.getLong(
 			referenceElement.attributeValue("layout-id"));
 
-		layouts.put(layoutId, existingLayout);
+		Group layoutGroup = null;
+		LayoutSet layoutSet = null;
 
-		Map<Long, Long> layoutPlids =
-			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-				Layout.class);
+		try {
+			layoutGroup = _groupLocalService.getGroup(groupId);
+		}
+		catch (PortalException e) {
+			_log.debug("No group found for groupId" + groupId);
+		}
 
-		long plid = GetterUtil.getLong(
-			referenceElement.attributeValue("class-pk"));
+		try {
+			layoutSet = _layoutSetLocalService.getLayoutSet(
+				groupId,privateLayout);
+		}
+		catch (PortalException e) {
+			_log.debug(
+				"No layout set found for groupId " + groupId
+				+ " and privateLayout value of: " + privateLayout);
+		}
 
-		layoutPlids.put(plid, existingLayout.getPlid());
+		Group existingLayoutGroup = existingLayout.getGroup();
+		LayoutSet existingLayoutSet = existingLayout.getLayoutSet();
+
+		if (existingLayoutGroup.equals(layoutGroup) &&
+			existingLayoutSet.equals(layoutSet)) {
+			layouts.put(layoutId, existingLayout);
+
+			Map<Long, Long> layoutPlids =
+				(Map<Long, Long>) portletDataContext.getNewPrimaryKeysMap(
+					Layout.class);
+
+			long plid = GetterUtil.getLong(
+				referenceElement.attributeValue("class-pk"));
+
+			layoutPlids.put(plid, existingLayout.getPlid());
+		}
 	}
 
 	@Override

--- a/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/web-experience/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -351,16 +351,23 @@ public class LayoutStagedModelDataHandler
 			referenceElement.attributeValue("layout-id"));
 
 		Layout layout = layouts.get(layoutId);
+		boolean collision = false;
 
-		Group layoutGroup = layout.getGroup();
-		LayoutSet layoutSet = layout.getLayoutSet();
+		if (layout != null) {
+			Group layoutGroup = layout.getGroup();
+			LayoutSet layoutSet = layout.getLayoutSet();
 
-		Group existingLayoutGroup = existingLayout.getGroup();
-		LayoutSet existingLayoutSet = existingLayout.getLayoutSet();
+			Group existingLayoutGroup = existingLayout.getGroup();
+			LayoutSet existingLayoutSet = existingLayout.getLayoutSet();
 
-		if (existingLayoutGroup.equals(layoutGroup) &&
-			existingLayoutSet.equals(layoutSet)) {
+			if (!existingLayoutGroup.equals(layoutGroup) &&
+				!existingLayoutSet.equals(layoutSet)) {
 
+				collision = true;
+			}
+		}
+
+		if (!collision) {
 			layouts.put(layoutId, existingLayout);
 
 			Map<Long, Long> layoutPlids =


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-76228

Notes from @wanderlast:

> The Issue:
> Currently, if a web content that contains a URL link to another page in the portal is displayed in a WCM Display and then exported, the WCM Display will appear blank upon import. This is due to the fact that the linked portal page is considered a missing reference and overwrites the correct layout for the page which the link is located on. To fix the issue, we check if the layout's group and layoutset match the layout being overwritten before attempting to overwrite it.
> 
> This issue is not reproducible in master. It was fixed in master through a Technical Task (LPS-67838). However, this is being submitted to master due to a request made by Tamás here, which mentions that since the code exists in master it may still affect the portal in ways we're simply not aware of.
> 
> I made some minor changes since my last PR: I fixed the failed tests by explicitly handling the case where there is no possible overwrite and I also rebased to a more recent version of master.
> 
> Please let me know if you have any questions I can answer. Thanks!