### PR TITLE
LPS-78493 - don't automatically capitalize the word 'this' in language keys

### DIFF
--- a/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
+++ b/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
@@ -579,18 +579,7 @@ public class LangBuilder {
 		// http://titlecapitalization.com
 		// http://www.imdb.com
 
-		if (value.contains(" this ")) {
-			if (value.contains(".") || value.contains("?") ||
-				value.contains(":") ||
-				key.equals(
-					"the-url-of-the-page-comparing-this-page-content-with-" +
-						"the-previous-version")) {
-			}
-			else {
-				value = StringUtil.replace(value, " this ", " This ");
-			}
-		}
-		else {
+		if (value.contains(" From ")) {
 			value = StringUtil.replace(value, " From ", " from ");
 		}
 

--- a/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
+++ b/modules/util/lang-builder/src/main/java/com/liferay/lang/builder/LangBuilder.java
@@ -573,7 +573,7 @@ public class LangBuilder {
 		}
 	}
 
-	private String _fixEnglishTranslation(String key, String value) {
+	private String _fixEnglishTranslation(String value) {
 
 		// http://en.wikibooks.org/wiki/Basic_Book_Design/Capitalizing_Words_in_Titles
 		// http://titlecapitalization.com
@@ -688,7 +688,7 @@ public class LangBuilder {
 					if (Validator.isNotNull(value)) {
 						value = _fixTranslation(line.substring(pos + 1));
 
-						value = _fixEnglishTranslation(key, value);
+						value = _fixEnglishTranslation(value);
 
 						if (_portalLanguageProperties != null) {
 							String portalValue = String.valueOf(


### PR DESCRIPTION
Hi Jonathan!

LPP: https://issues.liferay.com/browse/LPP-27641
LPS: https://issues.liferay.com/browse/LPS-78493

Currently the word 'this' is automatically capitalized when running buildlang. While in-line with general capitalization rules for titles, it's not necessarily a safe assumption that a language key with no punctuation at the end is a title. Material Design standards state that punctuation should, in fact, be avoided at the end of most lines. The fix I'm sending is simply removing the automatic capitalization.

Let me know if you have any questions or concerns. Thanks!