### PR TITLE
LPS-78476

### DIFF
--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -112,6 +112,12 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 								</aui:a>
 							</h5>
 
+							<c:if test="<%= journalDisplayContext.isSearch()%>">
+								<h5>
+									<%= JournalUtil.getAbsolutePath(liferayPortletRequest, curArticle.getFolderId()) %>
+								</h5>
+							</c:if>
+
 							<h6 class="text-default">
 								<aui:workflow-status markupView="lexicon" showIcon="<%= false %>" showLabel="<%= false %>" status="<%= curArticle.getStatus() %>" />
 							</h6>

--- a/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/web-experience/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -112,7 +112,7 @@ String searchContainerId = ParamUtil.getString(request, "searchContainerId");
 								</aui:a>
 							</h5>
 
-							<c:if test="<%= journalDisplayContext.isSearch()%>">
+							<c:if test="<%= journalDisplayContext.isSearch() %>">
 								<h5>
 									<%= JournalUtil.getAbsolutePath(liferayPortletRequest, curArticle.getFolderId()) %>
 								</h5>


### PR DESCRIPTION
From Lianne:

> LPP: https://issues.liferay.com/browse/LPP-29068
> LPS: https://issues.liferay.com/browse/LPS-78476
> 
> The issue being addressed in this PR is that content with identical titles, but different folder locations/content are indistinguishable in web content search. The solution was to re-add the breadcrumbs back to the search results which was done in accordance with the suggestions made by the Lexicon team in https://issues.liferay.com/browse/PTR-276. Breadcrumb 1 already exists, so only breadcrumb 2 was added.
> 
> Please let me know if you have any questions or concerns. Thanks!