### PR TITLE
LPS-78745 Strip HTML Tags from Wiki Search Result Content

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/search.jsp
@@ -117,7 +117,7 @@ portletURL.setParameter("keywords", keywords);
 				commentRelatedSearchResults="<%= searchResult.getCommentRelatedSearchResults() %>"
 				containerName="<%= curNode.getName() %>"
 				cssClass='<%= MathUtil.isEven(index) ? "search" : "search alt" %>'
-				description="<%= (summary != null) ? summary.getContent() : wikiPage.getSummary() %>"
+				description="<%= (summary != null) ? HtmlUtil.stripHtml(summary.getContent()) : HtmlUtil.stripHtml(wikiPage.getSummary()) %>"
 				fileEntryRelatedSearchResults="<%= searchResult.getFileEntryRelatedSearchResults() %>"
 				highlightEnabled="<%= queryConfig.isHighlightEnabled() %>"
 				queryTerms="<%= hits.getQueryTerms() %>"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-78745
Resent from https://github.com/gregory-bretall/liferay-portal/pull/41 with call to StripHTML added to both cases of the description.

CI Test results found here: https://github.com/gregory-bretall/liferay-portal/pull/41#issuecomment-372458951

@brianikim