### PR TITLE
LPS-78710 Return blank value instead of null if the DatePicker hasn't…

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1122,6 +1122,10 @@ AUI.add(
 
 						var datePicker = instance.getDatePicker();
 
+						if (!datePicker) {
+							return '';
+						}
+
 						var selectedDate = datePicker.getDate();
 
 						var formattedDate = A.DataType.Date.format(selectedDate);
@@ -1156,6 +1160,10 @@ AUI.add(
 						var instance = this;
 
 						var datePicker = instance.getDatePicker();
+
+						if (!datePicker) {
+							return;
+						}
 
 						datePicker.set('activeInput', instance.getInputNode());
 


### PR DESCRIPTION
… been registered as a component yet.

https://issues.liferay.com/browse/LPS-78710

This is relevant only when the DatePicker is nested as the code to repeat the DateField will be run by the parent field first, before the nested DateField is registered as a component. From what I can tell, the repeat functionality from the parent field needs to resolve to register various functions such as drag to the DateField in this first call of getValue. However, the proper component registration and getValue function calls for the DateField will run when the nested DateField itself is reached. This can be viewed by looking at how renderUI is called twice on the dateField, once before the component is registered and once after.