### PR TITLE
LPS-79071

### DIFF
--- a/modules/core/petra/petra-io/src/main/java/com/liferay/petra/io/OutputStreamWriter.java
+++ b/modules/core/petra/petra-io/src/main/java/com/liferay/petra/io/OutputStreamWriter.java
@@ -149,9 +149,14 @@ public class OutputStreamWriter extends Writer {
 
 		_inputCharBuffer.flip();
 
-		_encodeLoop(_inputCharBuffer, endOfInput);
+		try {
+			_encodeLoop(_inputCharBuffer, endOfInput);
 
-		_inputCharBuffer.compact();
+			_inputCharBuffer.compact();
+		}
+		finally {
+			_inputCharBuffer.clear();
+		}
 	}
 
 	private void _encodeLoop(CharBuffer inputCharBuffer, boolean endOfInput)

--- a/portal-kernel/src/com/liferay/portal/kernel/io/OutputStreamWriter.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/io/OutputStreamWriter.java
@@ -149,9 +149,14 @@ public class OutputStreamWriter extends Writer {
 
 		_inputCharBuffer.flip();
 
-		_encodeLoop(_inputCharBuffer, endOfInput);
+		try {
+			_encodeLoop(_inputCharBuffer, endOfInput);
 
-		_inputCharBuffer.compact();
+			_inputCharBuffer.compact();
+		}
+		finally {
+			_inputCharBuffer.clear();
+		}
 	}
 
 	private void _encodeLoop(CharBuffer inputCharBuffer, boolean endOfInput)


### PR DESCRIPTION
CC @joshuacords

From Josh:
https://issues.liferay.com/browse/LPS-79071
https://issues.liferay.com/browse/LPP-29463

BufferOverflowException will be thrown if https://github.com/joshuacords/liferay-portal/blob/fa4d4fcbbf37fddccc03cb7d90016e74ee250c5e/portal-kernel/src/com/liferay/portal/kernel/io/OutputStreamWriter.java#L119 called and the _inputCharBuffer's limit was set to 1. Under normal circumstances this won't happen, however the use of the flip method which can set the limit to 1 here: https://github.com/joshuacords/liferay-portal/blob/fa4d4fcbbf37fddccc03cb7d90016e74ee250c5e/portal-kernel/src/com/liferay/portal/kernel/io/OutputStreamWriter.java#L150 relies on the compact() call to reset the limit. However, the next call to the _encodeLoop method can throw an Exception which allows the compact() method to never be called.

I've added a finally to clear the _inputCharBuffer to reset its position and limit in case the exception is thrown.