### PR TITLE
LPS-78908

### DIFF
--- a/modules/apps/wysiwyg/wysiwyg-web/build.gradle
+++ b/modules/apps/wysiwyg/wysiwyg-web/build.gradle
@@ -8,8 +8,8 @@ dependencies {
 	provided group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	provided project(":apps:foundation:petra:petra-xml")
 	provided project(":apps:foundation:portal:portal-upgrade-api")
+	provided project(":apps:web-experience:export-import:export-import-api")
 	provided project(":core:petra:petra-lang")
 	provided project(":core:petra:petra-string")
 	provided project(":core:registry-api")
-	provided project(":apps:web-experience:export-import:export-import-api")
 }

--- a/modules/apps/wysiwyg/wysiwyg-web/build.gradle
+++ b/modules/apps/wysiwyg/wysiwyg-web/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 	provided project(":core:petra:petra-lang")
 	provided project(":core:petra:petra-string")
 	provided project(":core:registry-api")
+	provided project(":apps:web-experience:export-import:export-import-api")
 }

--- a/modules/apps/wysiwyg/wysiwyg-web/src/main/java/com/liferay/wysiwyg/web/internal/exportimport/data/handler/WYSIWYGPortletDataHandler.java
+++ b/modules/apps/wysiwyg/wysiwyg-web/src/main/java/com/liferay/wysiwyg/web/internal/exportimport/data/handler/WYSIWYGPortletDataHandler.java
@@ -1,0 +1,118 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.wysiwyg.web.internal.exportimport.data.handler;
+
+import com.liferay.exportimport.kernel.lar.BasePortletDataHandler;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
+import com.liferay.exportimport.kernel.lar.PortletDataHandler;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.wysiwyg.web.internal.constants.WYSIWYGPortletKeys;
+
+import javax.portlet.PortletPreferences;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lianne Louie
+ */
+@Component(
+	immediate = true,
+	property = {"javax.portlet.name=" + WYSIWYGPortletKeys.WYSIWYG},
+	service = {PortletDataHandler.class}
+)
+public class WYSIWYGPortletDataHandler extends BasePortletDataHandler {
+
+	@Override
+	public PortletPreferences processExportPortletPreferences(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			return doProcessExportPortletPreferences(
+				portletDataContext, portletId, portletPreferences);
+		}
+		catch (PortletDataException pde) {
+			throw pde;
+		}
+		catch (Exception e) {
+			throw new PortletDataException(e);
+		}
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			return doProcessImportPortletPreferences(
+				portletDataContext, portletId, portletPreferences);
+		}
+		catch (PortletDataException pde) {
+			throw pde;
+		}
+		catch (Exception e) {
+			throw new PortletDataException(e);
+		}
+	}
+
+	protected PortletPreferences doProcessExportPortletPreferences(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		String message = portletPreferences.getValue(
+			"message", StringPool.BLANK);
+
+		long groupId = portletDataContext.getGroupId();
+
+		StringBundler sb = new StringBundler(2);
+
+		sb.append("/documents/");
+		sb.append(groupId);
+		String newMessage = message.replace(
+			sb.toString(), "/documents/[$groupId$]");
+
+		portletPreferences.setValue("message", newMessage);
+
+		return portletPreferences;
+	}
+
+	protected PortletPreferences doProcessImportPortletPreferences(
+			PortletDataContext portletDataContext, String portletId,
+			PortletPreferences portletPreferences)
+		throws Exception {
+
+		String message = portletPreferences.getValue(
+			"message", StringPool.BLANK);
+
+		long groupId = portletDataContext.getGroupId();
+		StringBundler sb = new StringBundler(2);
+
+		sb.append("/documents/");
+		sb.append(groupId);
+		String newMessage = message.replace(
+			"/documents/[$groupId$]", sb.toString());
+
+		portletPreferences.setValue("message", newMessage);
+
+		return portletPreferences;
+	}
+
+}


### PR DESCRIPTION
CC @wanderlast 

From Lianne:

> LPS: https://issues.liferay.com/browse/LPS-78908
> LPP: https://issues.liferay.com/browse/LPP-29392
> 
> The fix is pretty self-explanatory, it replaces groupIds in document links to "[$groupId$]" on export and reverses that upon import with the new groupId. The addition of /documents/ in the find/replace value is to prevent it from catching a number in the portlet's content that coincidentally matches the groupId.

Also, I double checked to see what would happen in the event of linking to an image from a different site, and how it compares to doing the same with a web content (since Lianne's fix only cares about the current site).  Basically, with a web content, if we cannot find the reference, the import fails completely.  With the WYSIWYG portlet, the import succeeds, however there will be a broken link in the display, since it's trying to retrieve something it cannot find.   I think this is alright, given we cannot also export the content from a different site.

Let me know if you have any questions.  Thanks!