### PR TITLE
LPS-79241 Save Keyword Results in Web Content Display

### DIFF
--- a/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -417,6 +417,10 @@ public class AssetBrowserDisplayContext {
 			portletURL.setParameter("listable", String.valueOf(getListable()));
 		}
 
+		if (getKeywords() != null) {
+			portletURL.setParameter("keywords", String.valueOf(getKeywords()));
+		}
+
 		portletURL.setParameter("eventName", getEventName());
 
 		return portletURL;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79241

Hello @jonathanmccann ,

The issue is that currently when you search using keywords in the search bar for Web Content Display, and you update any settings such as ordering (ASC or DESC), the keyword is reset to null which forces the page to refresh and show the default available web contents.

The reason for this issue is that in 

https://github.com/liferay/liferay-portal/blob/e30a30cca37bddf78cbda9acbc52966d32f6f1e4/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java#L386-L423

there is no check to see whether keywords exist or not which means that, every time an update occurs, 

https://github.com/liferay/liferay-portal/blob/e30a30cca37bddf78cbda9acbc52966d32f6f1e4/modules/apps/web-experience/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java#L259-L267

will return an empty string because the keywords are not saved when the request is fetched.

Therefore, the simple fix is to add a conditional that checks whether keywords exist and set the keywords as part of the portletURL parameter so that existing keywords are saved.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim
