### PR TITLE
LPS-79235 Disable Edit View Access to Users Without Edit Permission

### DIFF
--- a/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
+++ b/modules/apps/forms-and-workflow/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/view_form_instance.jsp
@@ -45,6 +45,10 @@ portletURL.setParameter("displayStyle", displayStyle);
 					<portlet:param name="displayStyle" value="<%= displayStyle %>" />
 				</portlet:renderURL>
 
+				<%
+				rowURL = ddmFormAdminDisplayContext.isShowEditFormInstanceIcon(formInstance) ? rowURL : "";
+				%>
+
 				<c:choose>
 					<c:when test='<%= displayStyle.equals("descriptive") %>'>
 						<liferay-ui:search-container-column-icon


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-79235

Hello @jonathanmccann ,

The issue here is that a user with permissions to view forms in Site Administration is able to access the individual form's edit page. However, the user is unable to save any updates.

This is inconsistent with current behavior in Forms as for users without edit permission, ddmFormAdminDisplayContext.isShowEditFormInstanceIcon(formInstance), will always return false which means that users without edit permission does not see the edit menu. Therefore, it makes sense that users should not be able to click his or her way into viewing the edit page for Forms.

The reason for this inconsistency is that all other content managements such as (documents and media) consider the view page as the default state when clicked and provides access to the edit page only through the permissions menu. However, Forms does the opposite in that the edit page is the default state. Furthermore, the view.jsp for Forms is located in:

modules\apps\forms-and-workflow\dynamic-data-mapping\dynamic-data-mapping-form-web\src\main\resources\META-INF\resources\display\view.jsp

which means that view_form_instance.jsp cannot access it in order to provide a consistent behavior.

I have included the suggested changes from here:
https://github.com/rafaprax/liferay-portal/pull/454

by checking whether users have permission to edit, and changing the rowURL to be an empty string when they do not have edit permission. 

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim