### PR TITLE
LPS-79246

### DIFF
--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -1624,7 +1624,10 @@
     #company.default.locale=en_US
 
     #
-    # This sets the default time zone of the portal.
+    # This sets the default time zone of the portal during initial setup.
+    #
+    # To change the default time zone of an existing portal instance, please
+    # use the control panel options present within Liferay.
     #
     company.default.time.zone=UTC
 


### PR DESCRIPTION
From @wanderlast:

> LPS: https://issues.liferay.com/browse/LPS-79246
> 
> Currently, the property "company.default.time.zone" has the description:
> 
> "This sets the default time zone of the portal."
> 
> This is not strictly true. For many of its operations Liferay uses the timezone of the 'default user' as its baseline. This "default user" is created in CompanyLocalServiceImpl, if it does not exist, and the above property is used to give the default user its time zone (see line 360 in Master). However, if the default user already exists, the default user is fetched and no changes are made. The property is not touched once a default user exists and therefore has no effect on the portal's default time zone after that point.
> 
> LPP-28115 shows that at least one client was clearly confused by the property description. Please let me know if you have any questions. Thanks!