### PR TITLE
LPS-79302 Fix Inconsistencies in Entry Deletion Between Activities an…

### DIFF
--- a/modules/apps/collaboration/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
+++ b/modules/apps/collaboration/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java
@@ -49,6 +49,7 @@ import com.liferay.subscription.service.SubscriptionLocalService;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -213,21 +214,28 @@ public class MicroblogsEntryLocalServiceImpl
 			MicroblogsEntry microblogsEntry)
 		throws PortalException {
 
-		// Microblogs entry
+		List<MicroblogsEntry> totalEntries = new ArrayList<>();
 
-		microblogsEntryPersistence.remove(microblogsEntry);
+		getAllRelatedMicroblogsEntries(totalEntries, microblogsEntry);
 
-		// Asset
+		for (MicroblogsEntry mbEntry : totalEntries) {
 
-		assetEntryLocalService.deleteEntry(
-			MicroblogsEntry.class.getName(),
-			microblogsEntry.getMicroblogsEntryId());
+			// Microblogs entry
 
-		// Social
+			microblogsEntryPersistence.remove(mbEntry);
 
-		socialActivityLocalService.deleteActivities(
-			MicroblogsEntry.class.getName(),
-			microblogsEntry.getMicroblogsEntryId());
+			// Asset
+
+			assetEntryLocalService.deleteEntry(
+				MicroblogsEntry.class.getName(),
+				mbEntry.getMicroblogsEntryId());
+
+			// Social
+
+			socialActivityLocalService.deleteActivities(
+				MicroblogsEntry.class.getName(),
+				mbEntry.getMicroblogsEntryId());
+		}
 
 		return microblogsEntry;
 	}
@@ -548,6 +556,25 @@ public class MicroblogsEntryLocalServiceImpl
 			serviceContext.getAssetTagNames());
 
 		return microblogsEntry;
+	}
+
+	protected void getAllRelatedMicroblogsEntries(
+		List<MicroblogsEntry> totalEntries, MicroblogsEntry microblogsEntry) {
+
+		totalEntries.add(microblogsEntry);
+		totalEntries.addAll(
+			microblogsEntryPersistence.findByT_P(
+				MicroblogsEntryConstants.TYPE_REPLY,
+				microblogsEntry.getMicroblogsEntryId()));
+
+		List<MicroblogsEntry> repostEntries =
+			microblogsEntryPersistence.findByT_P(
+				MicroblogsEntryConstants.TYPE_REPOST,
+				microblogsEntry.getMicroblogsEntryId());
+
+		for (MicroblogsEntry mbEntry : repostEntries) {
+			getAllRelatedMicroblogsEntries(totalEntries, mbEntry);
+		}
 	}
 
 	protected long getSubscriptionId(


### PR DESCRIPTION
…d Microblogs Portlet

Hello @jonathanmccann ,

https://issues.liferay.com/browse/LPS-79302

I am sending you a new PR for LPS-79302 based on the discussions we had.

The issue here is that in the activities portlet, the activity about the main Microblog Entry is deleted, but the activity about the comments on that Entry is still displayed in the activities portlet.

The reason for this issue is that:

https://github.com/liferay/liferay-portal/blob/2cb0efee0124b8eff4a925835e3878af38c13aa9/modules/apps/collaboration/microblogs/microblogs-service/src/main/java/com/liferay/microblogs/service/impl/MicroblogsEntryLocalServiceImpl.java#L212-L232

fails to account for child comments of the parent Microblogs Entry in updating the activities after deletion.
My fix maintains the current existing functionality of the Microblogs portlet in which if you delete the parent comment, all the child comments are deleted. The fix adds this capability to the activities portlet so that the activities portlet also updates itself so that the child comments no longer display. Furthermore, the fix runs a recursive helper function to check repost loops so we can update reposts that need to be deleted as well.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim