### PR TITLE
LPS-79312

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/init.jsp
@@ -30,6 +30,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.background.task.kernel.util.comparator.BackgroundTaskComparatorFactoryUtil" %><%@
 page import="com.liferay.document.library.configuration.DLConfiguration" %><%@
+page import="com.liferay.document.library.constants.DLPortletKeys" %><%@
 page import="com.liferay.dynamic.data.mapping.exception.StructureDuplicateStructureKeyException" %><%@
 page import="com.liferay.exportimport.constants.ExportImportPortletKeys" %><%@
 page import="com.liferay.exportimport.kernel.background.task.BackgroundTaskExecutorNames" %><%@

--- a/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/web-experience/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -149,6 +149,10 @@ Map<String, String[]> parameterMap = (Map<String, String[]>)settingsMap.get("par
 											continue;
 										}
 
+										if (portlet.getPortletId().equals(DLPortletKeys.DOCUMENT_LIBRARY)) {
+											continue;
+										}
+
 										portletDataHandlerClassNames.add(portletDataHandlerClassName);
 
 										settingsMap.put("portletId", portlet.getRootPortletId());


### PR DESCRIPTION
CC @wanderlast 

LPS: https://issues.liferay.com/browse/LPS-79312
LPP: https://issues.liferay.com/browse/LPP-28517

I spoke with Lianne and made sure this was only happening with the DL(Admin) portlets, and it's not possible (at the moment) for other portlets to be effected.

Notes from Lianne:

> This fix addresses the issue outlined in the LPP for Documents & Media. It is not a consistently reproducible issue on Master/Branch, but CS has been able to replicate it and it is easily seen in any of the Liferay bundles.
> 
> The issue itself is caused by Liferay loading DLPortlet before DLAdminPortlet--both share the same rank and DataPortletHandler, so only one is loaded to represent Documents & Media. If DLPortlet is loaded first the last publish date is shared between sites and can therefore be overwritten by another staged site being published. The solution I have in this fix is to 'pass' over DLPortlet if it is called first.
> 
> Essentially:
> 
> If DLPortlet is listed first, DLAdminPortlet second: DLPortlet is skipped over, so DLAdminPortlet's information is used.
> If DLAdminPortlet is listed first, DLPortlet is listed second: DLAdminPortlet is used, its DataPortletHandler is added to the list of "portletDataHandlerClassNames" and DLPortlet is therefore skipped per normal operation.
> This fix assumes the existence of a DLAdminPortlet with DLPortlet. If a state ever somehow exists where a DLAdminPortlet does not exist, but a DLPortlet does then the listing on the page will erroneously not show any Documents & Media.