### PR TITLE
LPS-79311

### DIFF
--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/WebBundleDeployer.java
@@ -68,7 +68,7 @@ public class WebBundleDeployer {
 	}
 
 	public ServiceRegistration<PortalProfile> doStart(Bundle bundle) {
-		_eventUtil.sendEvent(bundle, EventUtil.DEPLOYING, null, false);
+		_eventUtil.sendEvent(bundle, EventUtil.DEPLOYING, null, true);
 
 		String contextPath = WabUtil.getWebContextPath(bundle);
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
@@ -15,6 +15,8 @@
 package com.liferay.portal.osgi.web.wab.extender.internal.event;
 
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapDictionary;
 import com.liferay.portal.osgi.web.wab.extender.internal.WabUtil;
@@ -99,9 +101,9 @@ public class EventUtil
 			WabUtil.getWebContextPath(bundle));
 
 		if (collision) {
-			properties.put("collision", contextPath);
-
 			List<Long> collidedBundleIds = new ArrayList<>();
+
+			String collidedBundleNames = bundle.toString();
 
 			BundleContext bundleContext = bundle.getBundleContext();
 
@@ -118,10 +120,20 @@ public class EventUtil
 					curContextPath.equals(contextPath)) {
 
 					collidedBundleIds.add(curBundle.getBundleId());
+					collidedBundleNames += "," + curBundle.toString();
 				}
 			}
 
-			properties.put("collision.bundles", collidedBundleIds);
+			if (!collidedBundleIds.isEmpty()) {
+				properties.put("collision", contextPath);
+
+				properties.put("collision.bundles", collidedBundleIds);
+
+				_log.warn("Bundles " + collidedBundleNames +
+				" have the same Web-ContextPath. This can lead to" +
+				" unexpected behavior when the bundles are deployed" +
+				" to the same layout");
+			}
 		}
 
 		properties.put("context.path", contextPath);
@@ -154,6 +166,8 @@ public class EventUtil
 
 		_eventAdmin.sendEvent(event);
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(EventUtil.class);
 
 	private final BundleContext _bundleContext;
 	private EventAdmin _eventAdmin;

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
@@ -129,10 +129,11 @@ public class EventUtil
 
 				properties.put("collision.bundles", collidedBundleIds);
 
-				_log.warn("Bundles " + collidedBundleNames +
-				" have the same Web-ContextPath. This can lead to" +
-				" unexpected behavior when the bundles are deployed" +
-				" to the same layout");
+				_log.error(
+					"Bundles " + collidedBundleNames +
+						" have the same Web-ContextPath. This can lead to " +
+							"unexpected behavior when the bundles are " +
+								"deployed to the same layout");
 			}
 		}
 

--- a/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
+++ b/modules/apps/static/portal-osgi-web/portal-osgi-web-wab-extender/src/main/java/com/liferay/portal/osgi/web/wab/extender/internal/event/EventUtil.java
@@ -103,7 +103,7 @@ public class EventUtil
 		if (collision) {
 			List<Long> collidedBundleIds = new ArrayList<>();
 
-			String collidedBundleNames = bundle.toString();
+			List<String> collidedBundleNames = new ArrayList<>();
 
 			BundleContext bundleContext = bundle.getBundleContext();
 
@@ -120,7 +120,8 @@ public class EventUtil
 					curContextPath.equals(contextPath)) {
 
 					collidedBundleIds.add(curBundle.getBundleId());
-					collidedBundleNames += "," + curBundle.toString();
+
+					collidedBundleNames.add(curBundle.getSymbolicName());
 				}
 			}
 
@@ -129,11 +130,17 @@ public class EventUtil
 
 				properties.put("collision.bundles", collidedBundleIds);
 
-				_log.error(
-					"Bundles " + collidedBundleNames +
-						" have the same Web-ContextPath. This can lead to " +
-							"unexpected behavior when the bundles are " +
-								"deployed to the same layout");
+				StringBuilder sb = new StringBuilder(7);
+
+				sb.append("Newly added bundle: \"");
+				sb.append(bundle.getSymbolicName());
+				sb.append("\" has the same Web-ContextPath as the following ");
+				sb.append("bundles: ");
+				sb.append(collidedBundleNames);
+				sb.append(". This can lead to unexpected behavior when the ");
+				sb.append("bundles are deployed to the same layout");
+
+				_log.error(sb.toString());
 			}
 		}
 


### PR DESCRIPTION
LPS: https://issues.liferay.com/browse/LPS-79311
LPP: https://issues.liferay.com/browse/LPP-29419

From @joshuacords:
> These changes make sense to me. I'm not 100% on moving the properties.put("collision", contextPath) into the if (!collidedBundleIds.isEmpty()) brackets, but I don't see why you would want to set the property if it isn't a real collision and it wasn't ever called before anyways. (Because "false" was never passed in for collision before.)
> 
> The one downside I see is that when the bundles are started, both conflicting modules will be throwing a collision error. (Or if there's N modules, I would assume 2^N errors would be thrown). Considering that preventing this would take extra checks or addition variables, I believe it's fine to leave it as it is.
> 
> Notes from @JaredDomio
> Problem: When two bundles have the same Web-ContextPath no log message is displayed to illustrate the potential problem having two Web-ContextPath set to the same value can have. Having the Web-ContextPath set to the same value can cause unexpected behavior for the portlets with the same Web-ContextPath. Without an error or warning message it can be difficult for the user to identify the root cause of the issue.
> 
> Solution: There already exists a collision check in EventUtil.java that can identify when multiple bundles have the same Web-ContextPath. I made slight modifications to the collision check and added a log statement at the end of the collision check. The collision check is triggered when a portlet is first deployed. The log will give user a warning and list out all bundles that have collisions if a collision is detected.