### PR TITLE
LPS-80113 Allow User Input to Set Number of Items to Display

### DIFF
--- a/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/web-experience/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/display/context/AssetPublisherDisplayContext.java
@@ -531,7 +531,15 @@ public class AssetPublisherDisplayContext {
 	}
 
 	public Integer getDelta() {
-		return _assetPublisherCustomizer.getDelta(_request);
+		if (_delta != null) {
+			return _delta;
+		}
+
+		_delta = GetterUtil.getInteger(
+			_portletPreferences.getValue("delta", StringPool.BLANK),
+			_assetPublisherCustomizer.getDelta(_request));
+
+		return _delta;
 	}
 
 	public String getDisplayStyle() {
@@ -1573,6 +1581,7 @@ public class AssetPublisherDisplayContext {
 	private String _ddmStructureFieldName;
 	private String _ddmStructureFieldValue;
 	private Boolean _defaultAssetPublisher;
+	private Integer _delta;
 	private String _displayStyle;
 	private Long _displayStyleGroupId;
 	private Boolean _enableCommentRatings;


### PR DESCRIPTION
Hello @jonathanmccann ,

https://issues.liferay.com/browse/LPS-80113

The issue is that in the recent content portlet, changing the number of items to display in the configuration->display settings does nothing and will always be set to 5 items.

The reason for this is that _assetPublisherCustomizer.getDelta(_request) fetches the value set in the portal property recent.content.max.display.items which is set to a default of five.

My change ensures that the user input is used to set the number of items to display. However, I keep the core functionality by ensuring that if the user input is empty, the default will be used.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian Kim