### PR TITLE
LPS-80316 Unescape File Names for Database Queries.

### DIFF
--- a/modules/apps/collaboration/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/WikiAttachmentsHelper.java
+++ b/modules/apps/collaboration/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/WikiAttachmentsHelper.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.TrashedModel;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -113,7 +114,8 @@ public class WikiAttachmentsHelper {
 
 		long nodeId = ParamUtil.getLong(actionRequest, "nodeId");
 		String title = ParamUtil.getString(actionRequest, "title");
-		String attachment = ParamUtil.getString(actionRequest, "fileName");
+		String attachment = HtmlUtil.unescape(
+			ParamUtil.getString(actionRequest, "fileName"));
 
 		TrashedModel trashedModel = null;
 
@@ -142,7 +144,8 @@ public class WikiAttachmentsHelper {
 	public void restoreEntries(ActionRequest actionRequest) throws Exception {
 		long nodeId = ParamUtil.getLong(actionRequest, "nodeId");
 		String title = ParamUtil.getString(actionRequest, "title");
-		String fileName = ParamUtil.getString(actionRequest, "fileName");
+		String fileName = HtmlUtil.unescape(
+			ParamUtil.getString(actionRequest, "fileName"));
 
 		_wikiPageService.restorePageAttachmentFromTrash(
 			nodeId, title, fileName);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80316

Hello @jonathanmccann ,

The issue here is that the files with names that have ampersand (ex. %%file.txt) attached on a wiki page cannot be moved to the recycle bin and/or deleted using the available options.

The reason for this issue is that in WikiAttachmentsHelper, the file name is being fetched from the request. However, the request stores the names in their escaped forms which means that when database queries are done, it will return null as the database stores the fie as "%%file.txt" while the query is being done for "%amp;%amp;file.txt".

My fix ensures that when the fileNames are being used for any backend searches and/or queries, they are done using the unescaped strings.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian KIm