### PR TITLE
LPS-80345

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -434,10 +434,13 @@ public class LayoutReferencesExportImportContentProcessor
 						urlSB.append(remoteGroupUuid);
 					}
 				}
-				else if (urlGroup.isStaged()) {
+				else if (urlGroup.isStagingGroup()) {
 					Group liveGroup = urlGroup.getLiveGroup();
 
 					urlSB.append(liveGroup.getUuid());
+				}
+				else if (urlGroup.isStaged()) {
+					urlSB.append(urlGroup.getUuid());
 				}
 				else if (!urlGroup.isControlPanel()) {
 					urlSB.append(urlGroup.getFriendlyURL());

--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -148,7 +148,10 @@ public class DefaultExportImportContentProcessorTest {
 
 		_externalGroup = GroupTestUtil.addGroup();
 		_liveGroup = GroupTestUtil.addGroup();
-		_stagingGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(_liveGroup);
+
+		_stagingGroup = _liveGroup.getStagingGroup();
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -414,7 +417,10 @@ public class DefaultExportImportContentProcessorTest {
 			content,
 			content.contains(
 				"@data_handler_group_friendly_url@@" +
-					_stagingGroup.getFriendlyURL() + "@"));
+					_liveGroup.getUuid() + "@"));
+		Assert.assertFalse(content, content.contains(_stagingGroup.getUuid()));
+		Assert.assertFalse(
+			content, content.contains(_stagingGroup.getFriendlyURL()));
 		Assert.assertTrue(
 			content, content.contains("@data_handler_path_context@/en@"));
 		Assert.assertFalse(
@@ -484,7 +490,10 @@ public class DefaultExportImportContentProcessorTest {
 			content,
 			content.contains(
 				"@data_handler_group_friendly_url@@" +
-					_stagingGroup.getFriendlyURL() + "@"));
+					_liveGroup.getUuid() + "@"));
+		Assert.assertFalse(content, content.contains(_stagingGroup.getUuid()));
+		Assert.assertFalse(
+			content, content.contains(_stagingGroup.getFriendlyURL()));
 		Assert.assertFalse(content, content.contains("/en/en"));
 
 		setFinalStaticField(
@@ -1215,10 +1224,7 @@ public class DefaultExportImportContentProcessorTest {
 	private PortletDataContext _portletDataContextExport;
 	private PortletDataContext _portletDataContextImport;
 	private StagedModel _referrerStagedModel;
-
-	@DeleteAfterTestRun
 	private Group _stagingGroup;
-
 	private Layout _stagingPrivateLayout;
 	private Layout _stagingPublicLayout;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80345

The root cause of this issue is the difference between the group.isStaged() and group.isStagingGroup() methods.  Originally, we had a check for isStaged(), which returns true if the group is a part of a staged environment (if the group is the live or staging site, it returns true).  However, this would cause a NPE when trying to retrieve the liveGroup from the live group; there wouldn't be one.  Instead, I made changes which only retrieves the liveGroup from the staging group, otherwise if the group we are looking at is already live, it just uses it instead.  This way, the live group is always being used, whether it's the current group or the current group's liveGroup.

As for the tests, I needed the _stagingGroup and _liveGroup Group objects to actually be that; staging and live for each other.  Because I adjusted them accordingly, some tests failed, so I've fixed them.

Lastly, this issue is blocked by a couple problems in master HEAD.  First is LPS-79935 which prevents adding any content to the portal.  The second is an issue where every content has it's status changed to "pending" and cannot be published fully (even with no workflows enabled).  to overcome these issues, I reverted to ca1a79164c54989f2210678cbf29c8b169874a34 as well as put a breakpoint in JournalArticlePersistenceImpl.updateArticle() to manually change the status to 0 (or "approved").

Please let me know if you have any questions.