### PR TITLE
LPS-80343 Unescape File Names for Database Queries

### DIFF
--- a/modules/apps/collaboration/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageAttachmentsMVCActionCommand.java
+++ b/modules/apps/collaboration/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/portlet/action/EditMessageAttachmentsMVCActionCommand.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -71,7 +72,8 @@ public class EditMessageAttachmentsMVCActionCommand
 
 		long messageId = ParamUtil.getLong(actionRequest, "messageId");
 
-		String fileName = ParamUtil.getString(actionRequest, "fileName");
+		String fileName = HtmlUtil.unescape(
+			ParamUtil.getString(actionRequest, "fileName"));
 
 		if (moveToTrash) {
 			_mbMessageService.moveMessageAttachmentToTrash(messageId, fileName);
@@ -169,7 +171,8 @@ public class EditMessageAttachmentsMVCActionCommand
 
 		long messageId = ParamUtil.getLong(actionRequest, "messageId");
 
-		String fileName = ParamUtil.getString(actionRequest, "fileName");
+		String fileName = HtmlUtil.unescape(
+			ParamUtil.getString(actionRequest, "fileName"));
 
 		_mbMessageService.restoreMessageAttachmentFromTrash(
 			messageId, fileName);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-80343

Hello @jonathanmccann ,

The issue here is that the files with names that have ampersand (ex. %%file.txt) attached on a messageboards thread cannot be moved to the recycle bin and/or deleted using the available options.

It is the same scenario as https://github.com/jonathanmccann/liferay-portal/pull/1617, but for MessageBoards.

However, the solution is implemented differently because an attachmentshelper class does not exist for messageboards.

For messageboards, the unescape needs to happen in EditMessageAttachmentsMVCActionCommand.java as that is where the fileNames are being fetched from the requests before being passed off to  MBMessageServiceImpl and MBMessageLocalServiceImpl for permission checks and queries.

If you have any questions, please let me know. Thanks.

Sincerely,
Brian KIm



