### PR TITLE
LPS-81531 Check the layout for an embedded portlet to remove the case…

### DIFF
--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -257,7 +257,8 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 			boolean writeObject = false;
 
 			if (persistSettings &&
-				!themeDisplay.isPortletEmbedded(portlet.getPortletId())) {
+				!layout.isPortletEmbedded(
+					portlet.getPortletId(), layout.getGroupId())) {
 
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 					themeDisplay.getCompanyId(), themeDisplay.getScopeGroupId(),


### PR DESCRIPTION
… where an embedded portlet has to yet to render causing it to fail the isPortletEmbedded check

https://issues.liferay.com/browse/LPS-81531

This issue is caused by the caching of whether or not a portlet is embedded added in https://issues.liferay.com/browse/LPS-74281 causing the wrong value to be cached when a page with an embedded portlet is loaded for the first time as the value is cached before the portlet loads onto the page.