### PR TITLE
LPS-82316 Add check to keep secondary options menu open while a menu …

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/portlet/_controls.scss
@@ -79,6 +79,12 @@ body.portlet {
 	}
 
 	&:active, &:hover, &:focus, &.active {
+		.visible-interaction{
+			display: inherit;
+		}
+	}
+
+	&.open {
 		.visible-interaction {
 			display: inherit;
 		}


### PR DESCRIPTION
…is open, even when hovering over the menu

https://issues.liferay.com/browse/LPS-82316

Fix based on the current behavior seen when using the options menu in the portlet topper.