### PR TITLE
LPS-82327 Created a check for the filename to prevent xss

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/ServletResponseUtil.java
@@ -637,6 +637,10 @@ public class ServletResponseUtil {
 				HttpHeaders.CACHE_CONTROL_PRIVATE_VALUE);
 		}
 
+		if (fileName.matches("(?i).*\\.html#.*")) {
+			fileName = fileName.replaceAll("(?i)\\.html#", StringPool.DOUBLE_DASH);
+		}
+
 		if (Validator.isNull(fileName)) {
 			return;
 		}


### PR DESCRIPTION
Resent from https://github.com/gregory-bretall/liferay-portal/pull/82

Test Results: https://github.com/gregory-bretall/liferay-portal/pull/82#issuecomment-396761800

https://issues.liferay.com/browse/LPS-82327

Explanation for changes found here: https://github.com/gregory-bretall/liferay-portal/pull/82#issue-194417357

Please note that the purpose of replacing the .html# with a string instead of empty string is cover the case where a file named .html#.{image file extension} is uploaded and keeping that file name valid.
