### PR TITLE
LPS-82726

### DIFF
--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -28,7 +28,7 @@
 if (!themeDisplay.isSignedIn() && layout.isPublicLayout()) {
 	String completeURL = PortalUtil.getCurrentCompleteURL(request);
 
-	String canonicalURL = PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout);
+	String canonicalURL = PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false);
 %>
 
 	<link data-senna-track="temporary" href="<%= HtmlUtil.escapeAttribute(canonicalURL) %>" rel="canonical" />

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -194,7 +194,7 @@
 				String completeURL = PortalUtil.getCurrentCompleteURL(request);
 				%>
 
-				return '<%= PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout) %>';
+				return '<%= PortalUtil.getCanonicalURL(completeURL, themeDisplay, layout, false, false) %>';
 			},
 			getCDNBaseURL: function() {
 				return '<%= themeDisplay.getCDNBaseURL() %>';


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82726

I would have simply removed the "includeQueryString" parameter from PortalImpl.getCanonicalURL(), however this would cause a possible breaking change, and [it was noted](https://issues.liferay.com/browse/PTR-365?focusedCommentId=1362370&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1362370) this feature was intended, although not desired here.

Please let me know if you have any questions.  Thanks!