### PR TITLE
LPS-83016 Added tooltip to Web Content portlet's content options menu

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/dynamic_include/portlet_header.jsp
@@ -25,7 +25,7 @@ JournalArticle article = journalContentDisplayContext.getArticle();
 		direction="left-side"
 		icon="<%= StringPool.BLANK %>"
 		markupView="lexicon"
-		message="<%= StringPool.BLANK %>"
+		message="<%= "Content Options" %>"
 		showWhenSingleIcon="<%= true %>"
 	>
 		<c:if test="<%= journalContentDisplayContext.isShowEditArticleIcon() %>">


### PR DESCRIPTION
The tooltip message is based off of what the options behind the ellipsis are, there is no precedent I could find for this directly.

https://issues.liferay.com/browse/LPS-83016