### PR TITLE
LPS-75045

### DIFF
--- a/modules/apps/document-library/document-library-analytics/bnd.bnd
+++ b/modules/apps/document-library/document-library-analytics/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Document Library Analytics
 Bundle-SymbolicName: com.liferay.document.library.analytics
-Bundle-Version: 2.0.0
+Bundle-Version: 3.0.0
 Web-ContextPath: /document-library-analytics

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-analytics/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-analytics/bnd.bnd
@@ -1,5 +1,5 @@
 Bundle-Name: Liferay Dynamic Data Mapping Form Analytics
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.form.analytics
-Bundle-Version: 2.0.0
+Bundle-Version: 3.0.0
 Web-ContextPath: /dynamic-data-mapping-form-analytics
 -dsannotations-options: inherit

--- a/portal-impl/src/META-INF/model-listener-spring.xml
+++ b/portal-impl/src/META-INF/model-listener-spring.xml
@@ -9,6 +9,7 @@
 >
 	<bean class="com.liferay.portal.model.LayoutModelListener" id="com.liferay.portal.model.LayoutModelListener" />
 	<bean class="com.liferay.portal.model.LayoutSetModelListener" id="com.liferay.portal.model.LayoutSetModelListener" />
+	<bean class="com.liferay.portal.model.OrganizationModelListener" id="com.liferay.portal.model.OrganizationModelListener" />
 	<bean class="com.liferay.portal.model.PortletPreferencesModelListener" id="com.liferay.portal.model.PortletPreferencesModelListener" />
 	<bean class="com.liferay.portal.security.permission.GroupModelListener" id="com.liferay.portal.security.permission.GroupModelListener" />
 	<bean class="com.liferay.portal.security.permission.ResourcePermissionModelListener" id="com.liferay.portal.security.permission.ResourcePermissionModelListener" />

--- a/portal-impl/src/com/liferay/portal/model/OrganizationModelListener.java
+++ b/portal-impl/src/com/liferay/portal/model/OrganizationModelListener.java
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.model;
+
+import com.liferay.portal.kernel.concurrent.ThreadPoolExecutor;
+import com.liferay.portal.kernel.executor.PortalExecutorManager;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+import com.liferay.portal.model.impl.OrganizationModelImpl;
+import com.liferay.portal.security.permission.PermissionCacheUtil;
+
+/**
+ * @author Lianne Louie
+ * @author Jonathan McCann
+ */
+public class OrganizationModelListener extends BaseModelListener<Organization> {
+
+	@Override
+	public void onBeforeUpdate(Organization organization) {
+		OrganizationModelImpl organizationModelImpl =
+			(OrganizationModelImpl)organization;
+
+		if (organizationModelImpl.getOriginalParentOrganizationId() ==
+				organization.getParentOrganizationId()) {
+
+			return;
+		}
+
+		long[] userIds = OrganizationLocalServiceUtil.getUserPrimaryKeys(
+			organization.getOrganizationId());
+
+		ThreadPoolExecutor threadPoolExecutor =
+			_portalExecutorManager.getPortalExecutor(
+				OrganizationModelListener.class.getName());
+
+		threadPoolExecutor.submit(
+			() -> {
+				UserLocalServiceUtil.reindex(
+					organization.getCompanyId(), userIds);
+
+				PermissionCacheUtil.clearCache();
+
+				return null;
+			});
+	}
+
+	private static volatile PortalExecutorManager _portalExecutorManager =
+		ServiceProxyFactory.newServiceTrackedInstance(
+			PortalExecutorManager.class, OrganizationModelListener.class,
+			"_portalExecutorManager", true);
+
+}

--- a/portal-impl/src/com/liferay/portal/model/OrganizationModelListener.java
+++ b/portal-impl/src/com/liferay/portal/model/OrganizationModelListener.java
@@ -14,12 +14,13 @@
 
 package com.liferay.portal.model;
 
-import com.liferay.portal.kernel.concurrent.ThreadPoolExecutor;
-import com.liferay.portal.kernel.executor.PortalExecutorManager;
+import com.liferay.petra.concurrent.NoticeableExecutorService;
+import com.liferay.petra.executor.PortalExecutorManager;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 import com.liferay.portal.model.impl.OrganizationModelImpl;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
@@ -44,19 +45,26 @@ public class OrganizationModelListener extends BaseModelListener<Organization> {
 		long[] userIds = OrganizationLocalServiceUtil.getUserPrimaryKeys(
 			organization.getOrganizationId());
 
-		ThreadPoolExecutor threadPoolExecutor =
-			_portalExecutorManager.getPortalExecutor(
-				OrganizationModelListener.class.getName());
+		if (userIds.length > 0) {
+			NoticeableExecutorService noticeableExecutorService =
+				_portalExecutorManager.getPortalExecutor(
+					OrganizationModelListener.class.getName());
 
-		threadPoolExecutor.submit(
-			() -> {
-				UserLocalServiceUtil.reindex(
-					organization.getCompanyId(), userIds);
+			TransactionCommitCallbackUtil.registerCallback(
+				() -> {
+					noticeableExecutorService.submit(
+						() -> {
+							UserLocalServiceUtil.reindex(
+								organization.getCompanyId(), userIds);
 
-				PermissionCacheUtil.clearCache();
+							PermissionCacheUtil.clearCache();
 
-				return null;
-			});
+							return null;
+						});
+
+					return null;
+				});
+		}
 	}
 
 	private static volatile PortalExecutorManager _portalExecutorManager =

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -1111,7 +1111,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 				if (ArrayUtil.isNotEmpty(userIds)) {
 					TransactionCommitCallbackUtil.registerCallback(
 						() -> {
-							reindex(group.getCompanyId(), userIds);
+							userLocalService.reindex(
+								group.getCompanyId(), userIds);
 
 							return null;
 						});

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -3680,7 +3680,8 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 			TransactionCommitCallbackUtil.registerCallback(
 				() -> {
-					reindex(group.getCompanyId(), getUserPrimaryKeys(groupId));
+					userLocalService.reindex(
+						group.getCompanyId(), getUserPrimaryKeys(groupId));
 
 					return null;
 				});

--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -27,7 +27,11 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheMapSynchronizeUtil;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.dao.orm.IndexableActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.WildcardMode;
 import com.liferay.portal.kernel.exception.CompanyMaxUsersException;
@@ -79,6 +83,7 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.model.UserGroupRole;
 import com.liferay.portal.kernel.search.BaseModelSearchResult;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
@@ -3120,6 +3125,49 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 	@Override
 	public User loadGetDefaultUser(long companyId) throws PortalException {
 		return userPersistence.findByC_DU(companyId, true);
+	}
+
+	public void reindex(long companyId, long[] userIds) throws PortalException {
+		final Indexer<User> indexer = IndexerRegistryUtil.nullSafeGetIndexer(
+			User.class);
+
+		final IndexableActionableDynamicQuery indexableActionableDynamicQuery =
+			userLocalService.getIndexableActionableDynamicQuery();
+
+		indexableActionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property userId = PropertyFactoryUtil.forName("userId");
+
+				dynamicQuery.add(userId.in(userIds));
+			});
+		indexableActionableDynamicQuery.setCompanyId(companyId);
+		indexableActionableDynamicQuery.setPerformActionMethod(
+			new ActionableDynamicQuery.PerformActionMethod<User>() {
+
+				@Override
+				public void performAction(User user) {
+					if (!user.isDefaultUser()) {
+						try {
+							Document document = indexer.getDocument(user);
+
+							indexableActionableDynamicQuery.addDocuments(
+								document);
+						}
+						catch (PortalException pe) {
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									"Unable to index user " + user.getUserId(),
+									pe);
+							}
+						}
+					}
+				}
+
+			});
+		indexableActionableDynamicQuery.setSearchEngineId(
+			indexer.getSearchEngineId());
+
+		indexableActionableDynamicQuery.performActions();
 	}
 
 	/**

--- a/portal-impl/test/integration/com/liferay/portal/model/OrganizationModelListenerTest.java
+++ b/portal-impl/test/integration/com/liferay/portal/model/OrganizationModelListenerTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.model;
+
+import com.liferay.petra.concurrent.NoticeableExecutorService;
+import com.liferay.petra.executor.PortalExecutorManager;
+import com.liferay.portal.kernel.concurrent.test.TestUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.OrganizationConstants;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Indexer;
+import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserLocalServiceUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ServiceProxyFactory;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.lang.ArrayUtils;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Lianne Louie
+ */
+public class OrganizationModelListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_indexer = IndexerRegistryUtil.nullSafeGetIndexer(User.class);
+
+		_portalExecutorManager = ServiceProxyFactory.newServiceTrackedInstance(
+			PortalExecutorManager.class, OrganizationModelListener.class,
+			"_portalExecutorManager", true);
+	}
+
+	@Before
+	public void setUp() throws Exception {
+		_noticeableExecutorService = _portalExecutorManager.getPortalExecutor(
+			OrganizationModelListener.class.getName());
+
+		_childOrganization = OrganizationTestUtil.addOrganization();
+		_grandparentOrganization = OrganizationTestUtil.addOrganization();
+		_parentOrganization = OrganizationTestUtil.addOrganization();
+
+		_user = UserTestUtil.addUser();
+
+		_indexer.reindex(_user);
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		UserLocalServiceUtil.deleteUser(_user);
+
+		OrganizationLocalServiceUtil.deleteOrganization(_childOrganization);
+		OrganizationLocalServiceUtil.deleteOrganization(_parentOrganization);
+		OrganizationLocalServiceUtil.deleteOrganization(
+			_grandparentOrganization);
+	}
+
+	@Test
+	public void testAddMultipleParentOrganizations() throws Exception {
+		_parentOrganization.setParentOrganizationId(
+			_grandparentOrganization.getOrganizationId());
+
+		_parentOrganization = _updateOrganization(_parentOrganization);
+
+		Assert.assertEquals(
+			_grandparentOrganization.getOrganizationId(),
+			_parentOrganization.getParentOrganizationId());
+
+		UserLocalServiceUtil.addOrganizationUser(
+			_childOrganization.getOrganizationId(), _user);
+
+		_childOrganization.setParentOrganizationId(
+			_parentOrganization.getOrganizationId());
+
+		_childOrganization = _updateOrganization(_childOrganization);
+
+		Assert.assertEquals(
+			_parentOrganization.getOrganizationId(),
+			_childOrganization.getParentOrganizationId());
+
+		long parentOrganizationParentId =
+			_parentOrganization.getParentOrganizationId();
+		long childOrganizationParentId =
+			_childOrganization.getParentOrganizationId();
+
+		Document document = _indexer.getDocument(_user);
+
+		String[] indexedParentOrganizationIds = document.getValues(
+			"ancestorOrganizationIds");
+
+		Assert.assertTrue(
+			ArrayUtils.contains(
+				indexedParentOrganizationIds,
+				String.valueOf(parentOrganizationParentId)));
+
+		Assert.assertTrue(
+			ArrayUtils.contains(
+				indexedParentOrganizationIds,
+				String.valueOf(childOrganizationParentId)));
+	}
+
+	@Test
+	public void testAddParentOrganization() throws Exception {
+		UserLocalServiceUtil.addOrganizationUser(
+			_childOrganization.getOrganizationId(), _user);
+
+		_childOrganization.setParentOrganizationId(
+			_parentOrganization.getOrganizationId());
+
+		_childOrganization = _updateOrganization(_childOrganization);
+
+		Assert.assertEquals(
+			_parentOrganization.getOrganizationId(),
+			_childOrganization.getParentOrganizationId());
+
+		String[] expectedParentOrganizationIds = new String[1];
+
+		expectedParentOrganizationIds[0] = String.valueOf(
+			_childOrganization.getParentOrganizationId());
+
+		Document document = _indexer.getDocument(_user);
+
+		String[] indexedParentOrganizationIds = document.getValues(
+			"ancestorOrganizationIds");
+
+		Assert.assertArrayEquals(
+			expectedParentOrganizationIds, indexedParentOrganizationIds);
+	}
+
+	@Test
+	public void testRemoveParentOrganization() throws Exception {
+		UserLocalServiceUtil.addOrganizationUser(
+			_childOrganization.getOrganizationId(), _user);
+
+		_childOrganization.setParentOrganizationId(
+			_parentOrganization.getOrganizationId());
+
+		_childOrganization = _updateOrganization(_childOrganization);
+
+		Assert.assertEquals(
+			_parentOrganization.getOrganizationId(),
+			_childOrganization.getParentOrganizationId());
+
+		_childOrganization.setParentOrganizationId(
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+
+		_childOrganization = _updateOrganization(_childOrganization);
+
+		Assert.assertEquals(
+			_childOrganization.getParentOrganizationId(),
+			OrganizationConstants.DEFAULT_PARENT_ORGANIZATION_ID);
+
+		Document document = _indexer.getDocument(_user);
+
+		String[] indexedParentOrganizationIds = document.getValues(
+			"ancestorOrganizationIds");
+
+		String[] expectedParentOrganizationIds = new String[0];
+
+		Assert.assertArrayEquals(
+			expectedParentOrganizationIds, indexedParentOrganizationIds);
+	}
+
+	private Organization _updateOrganization(Organization organization)
+		throws Exception {
+
+		try {
+			Group organizationGroup = organization.getGroup();
+
+			return OrganizationLocalServiceUtil.updateOrganization(
+				organization.getCompanyId(), organization.getOrganizationId(),
+				organization.getParentOrganizationId(), organization.getName(),
+				organization.getType(), organization.getRegionId(),
+				organization.getCountryId(), organization.getStatusId(),
+				organization.getComments(), false, null,
+				organizationGroup.isSite(), null);
+		}
+		finally {
+			Thread.sleep(TestUtil.LONG_WAIT);
+
+			_noticeableExecutorService.shutdown();
+
+			Assert.assertTrue(
+				_noticeableExecutorService.awaitTermination(
+					10, TimeUnit.MINUTES));
+		}
+	}
+
+	private static Organization _childOrganization;
+	private static Organization _grandparentOrganization;
+	private static Indexer<User> _indexer;
+	private static NoticeableExecutorService _noticeableExecutorService;
+	private static Organization _parentOrganization;
+	private static PortalExecutorManager _portalExecutorManager;
+	private static User _user;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalService.java
@@ -1637,6 +1637,10 @@ public interface UserLocalService extends BaseLocalService,
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public User loadGetDefaultUser(long companyId) throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public void reindex(long companyId, long[] userIds)
+		throws PortalException;
+
 	/**
 	* Returns an ordered range of all the users who match the keywords and
 	* status, without using the indexer. It is preferable to use the indexed

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceUtil.java
@@ -2023,6 +2023,11 @@ public class UserLocalServiceUtil {
 		return getService().loadGetDefaultUser(companyId);
 	}
 
+	public static void reindex(long companyId, long[] userIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		getService().reindex(companyId, userIds);
+	}
+
 	/**
 	* Returns an ordered range of all the users who match the keywords and
 	* status, without using the indexer. It is preferable to use the indexed

--- a/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/UserLocalServiceWrapper.java
@@ -2175,6 +2175,12 @@ public class UserLocalServiceWrapper implements UserLocalService,
 		return _userLocalService.loadGetDefaultUser(companyId);
 	}
 
+	@Override
+	public void reindex(long companyId, long[] userIds)
+		throws com.liferay.portal.kernel.exception.PortalException {
+		_userLocalService.reindex(companyId, userIds);
+	}
+
 	/**
 	* Returns an ordered range of all the users who match the keywords and
 	* status, without using the indexer. It is preferable to use the indexed

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.30.0
+version 1.31.0


### PR DESCRIPTION
See https://github.com/jonathanmccann/liferay-portal/pull/1652

CC @wanderlast

https://issues.liferay.com/browse/LPS-75045
See ChrisKian#52

I've rebased the fix onto the lastest master, and there are no conflicts.  From Lianne:

The issue displayed in this LPS is that users were not reindexed upon an Organization's parent organization changing. This meant that, upon a change, users did not have access to content they should have access to until a reindex was triggered. The solution in this LPS is a model listener that, upon a change to an organization, triggers a reindex of all relevant users.

Please let me know if you have any questions, thanks!