### PR TITLE
LPS-83034 Only automatically update end time for Calendar Event when …

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/interval_selector.js
@@ -155,7 +155,7 @@ AUI.add(
 
 						instance._setStartTime();
 
-						if (instance._validDate) {
+						if (instance._validDate && (instance._endDate.valueOf() - instance._startDate.valueOf()) <= 0) {
 							instance._endDate = new Date(instance._startDate.valueOf() + instance._duration);
 
 							instance._setEndDatePickerDate();


### PR DESCRIPTION
…the start time would be the same or later than the end time.

https://issues.liferay.com/browse/LPS-83034