### PR TITLE
LPS-83543

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
@@ -136,38 +136,31 @@ public class JournalFolderStagedModelDataHandler
 
 		long groupId = portletDataContext.getScopeGroupId();
 
+		JournalFolder existingFolder = null;
+
 		if (portletDataContext.isDataStrategyMirror()) {
-			JournalFolder existingFolder = fetchStagedModelByUuidAndGroupId(
+			existingFolder = fetchStagedModelByUuidAndGroupId(
 				folder.getUuid(), groupId);
 
-			if (existingFolder == null) {
-				String name = _journalFolderLocalService.getUniqueFolderName(
-					null, groupId, parentFolderId, folder.getName(), 2);
-
-				serviceContext.setUuid(folder.getUuid());
-
-				importedFolder = _journalFolderLocalService.addFolder(
-					userId, groupId, parentFolderId, name,
-					folder.getDescription(), serviceContext);
-			}
-			else {
-				String name = _journalFolderLocalService.getUniqueFolderName(
-					folder.getUuid(), groupId, parentFolderId, folder.getName(),
-					2);
-
-				importedFolder = _journalFolderLocalService.updateFolder(
-					userId, serviceContext.getScopeGroupId(),
-					existingFolder.getFolderId(), parentFolderId, name,
-					folder.getDescription(), false, serviceContext);
-			}
+			serviceContext.setUuid(folder.getUuid());
 		}
-		else {
+
+		if (existingFolder == null) {
 			String name = _journalFolderLocalService.getUniqueFolderName(
 				null, groupId, parentFolderId, folder.getName(), 2);
 
 			importedFolder = _journalFolderLocalService.addFolder(
 				userId, groupId, parentFolderId, name, folder.getDescription(),
 				serviceContext);
+		}
+		else {
+			String name = _journalFolderLocalService.getUniqueFolderName(
+				folder.getUuid(), groupId, parentFolderId, folder.getName(), 2);
+
+			importedFolder = _journalFolderLocalService.updateFolder(
+				userId, serviceContext.getScopeGroupId(),
+				existingFolder.getFolderId(), parentFolderId, name,
+				folder.getDescription(), false, serviceContext);
 		}
 
 		importFolderDDMStructures(portletDataContext, folder, importedFolder);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalFolderStagedModelDataHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.internal.exportimport.data.handler;
 
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
@@ -27,7 +28,9 @@ import com.liferay.journal.model.JournalFolderConstants;
 import com.liferay.journal.service.JournalFolderLocalService;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.WorkflowDefinitionLink;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -149,9 +152,36 @@ public class JournalFolderStagedModelDataHandler
 			String name = _journalFolderLocalService.getUniqueFolderName(
 				null, groupId, parentFolderId, folder.getName(), 2);
 
-			importedFolder = _journalFolderLocalService.addFolder(
-				userId, groupId, parentFolderId, name, folder.getDescription(),
-				serviceContext);
+			importedFolder = _journalFolderLocalService.createJournalFolder(
+				_counterLocalService.increment());
+
+			importedFolder.setUuid(serviceContext.getUuid());
+			importedFolder.setGroupId(groupId);
+			importedFolder.setCompanyId(folder.getCompanyId());
+			importedFolder.setUserId(userId);
+			importedFolder.setUserName(folder.getUserName());
+			importedFolder.setParentFolderId(parentFolderId);
+			importedFolder.setTreePath(folder.buildTreePath());
+			importedFolder.setName(name);
+			importedFolder.setDescription(folder.getDescription());
+			importedFolder.setExpandoBridgeAttributes(serviceContext);
+			importedFolder.setRestrictionType(folder.getRestrictionType());
+
+			_journalFolderLocalService.updateJournalFolder(importedFolder);
+
+			WorkflowDefinitionLink workflowDefinitionLink =
+				_workflowDefinitionLinkLocalService.fetchWorkflowDefinitionLink(
+					folder.getCompanyId(), groupId,
+					JournalFolder.class.getName(), folder.getFolderId(), -1);
+
+			if (workflowDefinitionLink != null) {
+				_workflowDefinitionLinkLocalService.addWorkflowDefinitionLink(
+					userId, importedFolder.getCompanyId(), groupId,
+					JournalFolder.class.getName(), importedFolder.getFolderId(),
+					workflowDefinitionLink.getTypePK(),
+					workflowDefinitionLink.getWorkflowDefinitionName(),
+					workflowDefinitionLink.getWorkflowDefinitionVersion());
+			}
 		}
 		else {
 			String name = _journalFolderLocalService.getUniqueFolderName(
@@ -258,6 +288,13 @@ public class JournalFolderStagedModelDataHandler
 	}
 
 	@Reference(unbind = "-")
+	protected void setCounterLocalService(
+		CounterLocalService counterLocalService) {
+
+		_counterLocalService = counterLocalService;
+	}
+
+	@Reference(unbind = "-")
 	protected void setDDMStructureLocalService(
 		DDMStructureLocalService ddmStructureLocalService) {
 
@@ -271,7 +308,18 @@ public class JournalFolderStagedModelDataHandler
 		_journalFolderLocalService = journalFolderLocalService;
 	}
 
+	@Reference(unbind = "-")
+	protected void setWorkflowDefinitionLinkLocalService(
+		WorkflowDefinitionLinkLocalService workflowDefinitionLinkLocalService) {
+
+		_workflowDefinitionLinkLocalService =
+			workflowDefinitionLinkLocalService;
+	}
+
+	private CounterLocalService _counterLocalService;
 	private DDMStructureLocalService _ddmStructureLocalService;
 	private JournalFolderLocalService _journalFolderLocalService;
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-83543
https://issues.liferay.com/browse/LPP-30862

I create and update the folder [here](https://github.com/jonathanmccann/liferay-portal/commit/efdf4331db7c3bff316a7aabae419b860d5feec1#diff-0eb7781492c6f970fdc29bbfa954471aR155) because I need to ensure the restrictionType value is set correctly, otherwise the workflow isn't used.  There isn't another way of doing this without hitting the DB twice (once for adding, and another for updating with the restrictionType).  If that isn't a big deal, I can definitely make the change, otherwise we just have to deal with a bit more code.

Let me know what you think, thanks!