### PR TITLE
LPS-82997 Add destructor function for calendar that will fire when na…

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -650,4 +650,29 @@ String backURL = PortalUtil.getCurrentURL(request);
 
 	<portlet:namespace />refreshVisibleCalendarRenderingRules();
 	<portlet:namespace />refreshMiniCalendarSelectedDates();
+
+	var destroyMenus = function(event) {
+		window.<portlet:namespace />calendarListsMenu.destroy();
+		window.<portlet:namespace />colorPicker.destroy();
+	
+		var myCalendarList = window.<portlet:namespace />myCalendarList;
+		var otherCalendarList = window.<portlet:namespace />otherCalendarList;
+		var siteCalendarList = window.<portlet:namespace />siteCalendarList;
+
+
+		if (myCalendarList && myCalendarList.simpleMenu) {
+			myCalendarList.simpleMenu.destroy();
+		}
+
+		if (otherCalendarList && otherCalendarList.simpleMenu) {
+			otherCalendarList.simpleMenu.destroy();
+		}
+
+		if (siteCalendarList && siteCalendarList.simpleMenu) {
+			siteCalendarList.simpleMenu.destroy();
+		}
+
+		Liferay.detach('destroyPortlet', destroyMenus);
+	};
+	Liferay.on('destroyPortlet', destroyMenus);
 </aui:script>


### PR DESCRIPTION
…vigating between pages with SPA enabled as normal destructor functions don't seem to work right with SPA enabled

The idea is that the functions don't clean up their own SimpleMenus from the DOM when SPA is enabled. So the destroyMenus function cleans up the 5 simple menus added in view_calendar.jsp and view_calendar_menus.jspf

@Seiphon