### PR TITLE
LPS-82370 | master

### DIFF
--- a/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
@@ -157,12 +157,12 @@ public class IncludeTag extends AttributesTagSupport {
 		HttpServletRequest request = getOriginalServletRequest();
 
 		if (isCleanUpSetAttributes()) {
-			if (_setAttributeNames == null) {
-				_setAttributeNames = new HashSet<>();
+			if (_setAttributes == null) {
+				_setAttributes = new HashSet<>();
 			}
 
 			_trackedRequest = new TrackedServletRequest(
-				request, _setAttributeNames);
+				request, _setAttributes);
 
 			request = _trackedRequest;
 		}
@@ -179,11 +179,11 @@ public class IncludeTag extends AttributesTagSupport {
 
 	protected void cleanUpSetAttributes() {
 		if (isCleanUpSetAttributes() && (_trackedRequest != null)) {
-			for (String name : _setAttributeNames) {
+			for (String name : _setAttributes) {
 				_trackedRequest.removeAttribute(name);
 			}
 
-			_setAttributeNames.clear();
+			_setAttributes.clear();
 
 			_trackedRequest = null;
 		}
@@ -517,7 +517,7 @@ public class IncludeTag extends AttributesTagSupport {
 	private static final Log _log = LogFactoryUtil.getLog(IncludeTag.class);
 
 	private String _page;
-	private Set<String> _setAttributeNames;
+	private Set<String> _setAttributes;
 	private boolean _strict;
 	private TrackedServletRequest _trackedRequest;
 	private boolean _useCustomPage = true;
@@ -527,20 +527,20 @@ public class IncludeTag extends AttributesTagSupport {
 
 		@Override
 		public void setAttribute(String name, Object obj) {
-			_setAttributeNames.add(name);
+			_setAttributes.add(name);
 
 			super.setAttribute(name, obj);
 		}
 
 		private TrackedServletRequest(
-			HttpServletRequest request, Set<String> setAttributeNames) {
+			HttpServletRequest request, Set<String> setAttributes) {
 
 			super(request);
 
-			_setAttributeNames = setAttributeNames;
+			_setAttributes = setAttributes;
 		}
 
-		private final Set<String> _setAttributeNames;
+		private final Set<String> _setAttributes;
 
 	}
 

--- a/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
+++ b/util-taglib/src/com/liferay/taglib/util/IncludeTag.java
@@ -43,6 +43,7 @@ import com.liferay.taglib.servlet.PipingServletResponse;
 
 import java.io.IOException;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -157,12 +158,7 @@ public class IncludeTag extends AttributesTagSupport {
 		HttpServletRequest request = getOriginalServletRequest();
 
 		if (isCleanUpSetAttributes()) {
-			if (_setAttributes == null) {
-				_setAttributes = new HashSet<>();
-			}
-
-			_trackedRequest = new TrackedServletRequest(
-				request, _setAttributes);
+			_trackedRequest = new TrackedServletRequest(request);
 
 			request = _trackedRequest;
 		}
@@ -179,11 +175,9 @@ public class IncludeTag extends AttributesTagSupport {
 
 	protected void cleanUpSetAttributes() {
 		if (isCleanUpSetAttributes() && (_trackedRequest != null)) {
-			for (String name : _setAttributes) {
+			for (String name : _trackedRequest.getSetAttributes()) {
 				_trackedRequest.removeAttribute(name);
 			}
-
-			_setAttributes.clear();
 
 			_trackedRequest = null;
 		}
@@ -517,7 +511,6 @@ public class IncludeTag extends AttributesTagSupport {
 	private static final Log _log = LogFactoryUtil.getLog(IncludeTag.class);
 
 	private String _page;
-	private Set<String> _setAttributes;
 	private boolean _strict;
 	private TrackedServletRequest _trackedRequest;
 	private boolean _useCustomPage = true;
@@ -525,22 +518,31 @@ public class IncludeTag extends AttributesTagSupport {
 	private static class TrackedServletRequest
 		extends HttpServletRequestWrapper {
 
+		public TrackedServletRequest(HttpServletRequest request) {
+			super(request);
+		}
+
+		public Set<String> getSetAttributes() {
+			if (_setAttributes == null) {
+				return Collections.emptySet();
+			}
+			else {
+				return _setAttributes;
+			}
+		}
+
 		@Override
 		public void setAttribute(String name, Object obj) {
+			if (_setAttributes == null) {
+				_setAttributes = new HashSet<>();
+			}
+
 			_setAttributes.add(name);
 
 			super.setAttribute(name, obj);
 		}
 
-		private TrackedServletRequest(
-			HttpServletRequest request, Set<String> setAttributes) {
-
-			super(request);
-
-			_setAttributes = setAttributes;
-		}
-
-		private final Set<String> _setAttributes;
+		private Set<String> _setAttributes;
 
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-82370

This regression bug was caused by [LPS-80552](https://issues.liferay.com/browse/LPS-80552) specifically this commit: 54a0ac1d6c8623a3c51cd8276e3adf957ffe441f

With the memory improving change from LPS-80552 we changed the logic to clear all of the attributes each time IncludeTag was recycled. However before hand we would remember and persist some of the attributes specially the [LIFERAY_SHARED_UNIQUE_ELEMENT_IDS](https://github.com/liferay/liferay-portal/blob/8a284957321871fd29336da5ab1c571aef8c7f7a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java#L638) in the case of this present regression.

After discussing the issue with @holatuwol we determined the small memory improvement from LPS-80552 was not worth it for the regression it caused as well as the other potential regression it may also be causing. Thus reverting the cause was determined to be the best coarse of action.

Please let me know if you have any questions at all.
Thanks!