### PR TITLE
LPS-84477 Add CSS to make the drag handle for image resizing larger f…

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
+++ b/modules/apps/frontend-editor/frontend-editor-alloyeditor-web/src/main/resources/META-INF/resources/alloyeditor.jsp
@@ -139,6 +139,18 @@ if (showSource) {
 name = HtmlUtil.escapeJS(name);
 %>
 
+<style>
+	span .cke_image_resizer {
+		background-clip: content-box;
+		bottom: -15px;
+		height: 40px;
+		outline-color: transparent;
+		padding: 20px 10px 10px 20px;
+		right: -15px;
+		width: 40px;
+	}
+</style>
+
 <aui:script use="<%= modules %>">
 
 	<%


### PR DESCRIPTION
…or AlloyEditor on IE11 where it defaults to using the CKEditor behavior

I added this to the JSP since there is no associated CSS files in Liferay source for AlloyEditor. This change is specifically targeted at bringing the functionality and usability of the image resizer in IE11 to be more inline with the usability of the resizer in other browsers where the AlloyEditor drag handle is used. This is achieved by making a larger area that can be selected to drag from to compensate for the fact that the resizer otherwise disappears if the mouse is moved slightly too far.

Please let me know if there's any questions regarding this solution.

https://issues.liferay.com/browse/LPS-84477