### PR TITLE
LPS-85647

### DIFF
--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java
@@ -50,6 +50,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Dictionary;
+import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -153,6 +154,8 @@ public class DefaultLPKGDeployer implements LPKGDeployer {
 			Bundle lpkgBundle = bundleContext.getBundle(location);
 
 			if (lpkgBundle != null) {
+				_addWarLPKGURLs(_urls, lpkgBundle);
+
 				return Collections.emptyList();
 			}
 
@@ -359,6 +362,44 @@ public class DefaultLPKGDeployer implements LPKGDeployer {
 		}
 		finally {
 			LPKGIndexValidatorThreadLocal.setEnabled(enabled);
+		}
+	}
+
+	private void _addWarLPKGURLs(Map<String, URL> urls, Bundle lpkgBundle) {
+		File file = new File(lpkgBundle.getLocation());
+
+		try (ZipFile zipFile = new ZipFile(file)) {
+			Enumeration<? extends ZipEntry> zipEntries = zipFile.entries();
+
+			while (zipEntries.hasMoreElements()) {
+				ZipEntry zipEntry = zipEntries.nextElement();
+
+				String name = zipEntry.getName();
+
+				if (!name.endsWith(".war")) {
+					continue;
+				}
+
+				URL url = LPKGInnerBundleLocationUtil.generateInnerBundleURL(
+					file, name);
+
+				String[] servletContextNameAndPortalProfileNames =
+					LPKGInnerWarBundleUtil.
+						readServletContextNameAndPortalProfileNames(url);
+
+				String portalProfileNames =
+					servletContextNameAndPortalProfileNames[1];
+				String servletContextName =
+					servletContextNameAndPortalProfileNames[0];
+
+				String lpkgURL = LPKGInnerWarBundleUtil.generateLPKGURL(
+					lpkgBundle, servletContextName, portalProfileNames);
+
+				urls.put(lpkgURL, url);
+			}
+		}
+		catch (Exception e) {
+			_log.error("Unable to check for LPKG URLs in " + lpkgBundle, e);
 		}
 	}
 

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java
@@ -26,8 +26,6 @@ import com.liferay.portal.kernel.lpkg.StaticLPKGResolver;
 import com.liferay.portal.kernel.util.StreamUtil;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
-import com.liferay.portal.kernel.util.URLCodec;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.lpkg.deployer.internal.wrapper.bundle.URLStreamHandlerServiceServiceTrackerCustomizer;
 import com.liferay.portal.lpkg.deployer.internal.wrapper.bundle.WARBundleWrapperBundleActivator;
 import com.liferay.portal.util.PropsValues;
@@ -36,7 +34,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
-import java.net.URI;
 import java.net.URL;
 
 import java.nio.file.FileSystem;
@@ -44,7 +41,6 @@ import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -179,18 +175,8 @@ public class LPKGBundleTrackerCustomizer
 					LPKGInnerBundleLocationUtil.generateInnerBundleLocation(
 						bundle, name);
 
-				StringBundler sb = new StringBundler(4);
-
-				sb.append("jar:");
-
-				URI uri = file.toURI();
-
-				sb.append(URLCodec.decodeURL(uri.toString()));
-
-				sb.append("!/");
-				sb.append(name);
-
-				URL url = new URL(sb.toString());
+				URL url = LPKGInnerBundleLocationUtil.generateInnerBundleURL(
+					file, name);
 
 				if (_isOverridden(symbolicName, url, location)) {
 					continue;
@@ -481,87 +467,18 @@ public class LPKGBundleTrackerCustomizer
 		bundle.uninstall();
 	}
 
-	private String[] _readServletContextNameAndPortalProfileNames(URL url)
-		throws IOException {
-
-		String pathString = url.getPath();
-
-		String servletContextName = pathString.substring(
-			pathString.lastIndexOf('/') + 1, pathString.lastIndexOf(".war"));
-
-		int index = servletContextName.lastIndexOf('-');
-
-		if (index >= 0) {
-			servletContextName = servletContextName.substring(0, index);
-		}
-
-		String portalProfileNames = null;
-
-		Path tempFilePath = Files.createTempFile(null, null);
-
-		try (InputStream inputStream1 = url.openStream()) {
-			Files.copy(
-				inputStream1, tempFilePath,
-				StandardCopyOption.REPLACE_EXISTING);
-
-			try (ZipFile zipFile = new ZipFile(tempFilePath.toFile());
-				InputStream inputStream2 = zipFile.getInputStream(
-					new ZipEntry(
-						"WEB-INF/liferay-plugin-package.properties"))) {
-
-				if (inputStream2 != null) {
-					Properties properties = new Properties();
-
-					properties.load(inputStream2);
-
-					String configuredServletContextName =
-						properties.getProperty("servlet-context-name");
-
-					if (configuredServletContextName != null) {
-						servletContextName = configuredServletContextName;
-					}
-
-					portalProfileNames = properties.getProperty(
-						"liferay-portal-profile-names");
-				}
-			}
-		}
-		finally {
-			Files.delete(tempFilePath);
-		}
-
-		return new String[] {servletContextName, portalProfileNames};
-	}
-
 	private InputStream _toWARWrapperBundle(Bundle bundle, URL url)
 		throws IOException {
 
-		StringBundler sb = new StringBundler(10);
-
-		sb.append("lpkg:/");
-		sb.append(URLCodec.encodeURL(bundle.getSymbolicName()));
-		sb.append(StringPool.DASH);
-		sb.append(bundle.getVersion());
-		sb.append(StringPool.SLASH);
-
 		String[] servletContextNameAndPortalProfileNames =
-			_readServletContextNameAndPortalProfileNames(url);
-
-		String servletContextName = servletContextNameAndPortalProfileNames[0];
-
-		sb.append(servletContextName);
-
-		sb.append(".war");
+			LPKGInnerWarBundleUtil.readServletContextNameAndPortalProfileNames(
+				url);
 
 		String portalProfileNames = servletContextNameAndPortalProfileNames[1];
+		String servletContextName = servletContextNameAndPortalProfileNames[0];
 
-		if (Validator.isNotNull(portalProfileNames)) {
-			sb.append(StringPool.QUESTION);
-			sb.append("liferay-portal-profile-names=");
-			sb.append(portalProfileNames);
-		}
-
-		String lpkgURL = sb.toString();
+		String lpkgURL = LPKGInnerWarBundleUtil.generateLPKGURL(
+			bundle, servletContextName, portalProfileNames);
 
 		// The bundle URL changes after a reboot. To ensure we do not install
 		// the same bundle multiple times over reboots, we must map the ever

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGInnerBundleLocationUtil.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGInnerBundleLocationUtil.java
@@ -14,6 +14,15 @@
 
 package com.liferay.portal.lpkg.deployer.internal;
 
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.URLCodec;
+
+import java.io.File;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+
 import org.osgi.framework.Bundle;
 
 /**
@@ -27,6 +36,23 @@ public class LPKGInnerBundleLocationUtil {
 		String location = path.concat("?lpkgPath=");
 
 		return location.concat(lpkgBundle.getLocation());
+	}
+
+	public static URL generateInnerBundleURL(File lpkgBundleFile, String path)
+		throws MalformedURLException {
+
+		StringBundler sb = new StringBundler(4);
+
+		sb.append("jar:");
+
+		URI uri = lpkgBundleFile.toURI();
+
+		sb.append(URLCodec.decodeURL(uri.toString()));
+
+		sb.append("!/");
+		sb.append(path);
+
+		return new URL(sb.toString());
 	}
 
 }

--- a/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGInnerWarBundleUtil.java
+++ b/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGInnerWarBundleUtil.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.lpkg.deployer.internal;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.URLCodec;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import java.net.URL;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+import java.util.Properties;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+import org.osgi.framework.Bundle;
+
+/**
+ * @author Eric Yan
+ */
+public class LPKGInnerWarBundleUtil {
+
+	protected static String generateLPKGURL(
+		Bundle lpkgBundle, String servletContextName,
+		String portalProfileNames) {
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append("lpkg:/");
+		sb.append(URLCodec.encodeURL(lpkgBundle.getSymbolicName()));
+		sb.append(StringPool.DASH);
+		sb.append(lpkgBundle.getVersion());
+		sb.append(StringPool.SLASH);
+
+		sb.append(servletContextName);
+
+		sb.append(".war");
+
+		if (Validator.isNotNull(portalProfileNames)) {
+			sb.append(StringPool.QUESTION);
+			sb.append("liferay-portal-profile-names=");
+			sb.append(portalProfileNames);
+		}
+
+		return sb.toString();
+	}
+
+	protected static String[] readServletContextNameAndPortalProfileNames(
+			URL warURL)
+		throws IOException {
+
+		String pathString = warURL.getPath();
+
+		String servletContextName = pathString.substring(
+			pathString.lastIndexOf('/') + 1, pathString.lastIndexOf(".war"));
+
+		int index = servletContextName.lastIndexOf('-');
+
+		if (index >= 0) {
+			servletContextName = servletContextName.substring(0, index);
+		}
+
+		String portalProfileNames = null;
+
+		Path tempFilePath = Files.createTempFile(null, null);
+
+		try (InputStream inputStream1 = warURL.openStream()) {
+			Files.copy(
+				inputStream1, tempFilePath,
+				StandardCopyOption.REPLACE_EXISTING);
+
+			try (ZipFile zipFile = new ZipFile(tempFilePath.toFile());
+				InputStream inputStream2 = zipFile.getInputStream(
+					new ZipEntry(
+						"WEB-INF/liferay-plugin-package.properties"))) {
+
+				if (inputStream2 != null) {
+					Properties properties = new Properties();
+
+					properties.load(inputStream2);
+
+					String configuredServletContextName =
+						properties.getProperty("servlet-context-name");
+
+					if (configuredServletContextName != null) {
+						servletContextName = configuredServletContextName;
+					}
+
+					portalProfileNames = properties.getProperty(
+						"liferay-portal-profile-names");
+				}
+			}
+		}
+		finally {
+			Files.delete(tempFilePath);
+		}
+
+		return new String[] {servletContextName, portalProfileNames};
+	}
+
+}


### PR DESCRIPTION
Hi @jonathanmccann ,

https://issues.liferay.com/browse/LPS-85647

The main issue is that WARs within an LPKG may not be deployed properly if the first startup is interrupted. This is due to a **URL map** that is ONLY populated during the first deployment of an LPKG.

In order to deploy a **WAR** that **belongs to an LPKG**, the WabGenerator depends on this **URL map** to retrieve the **specific file path** to that **WAR file** within the **LPKG**.

This fix makes it so that the **URL map** is populated for each LPKG, even though it's already been deployed.

**CI Test Results**
https://github.com/ericyanLr/liferay-portal/pull/80

Please let me know if you have any questions.
Thanks!

----

References to usages of the **URL map**:
- [DefaultLPKGDeployer.java#L709](https://github.com/liferay/liferay-portal/blob/7.1.0-b3/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/DefaultLPKGDeployer.java#L709)
- [LPKGBundleTrackerCustomizer.java#L572](https://github.com/liferay/liferay-portal/blob/7.1.0-b3/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGBundleTrackerCustomizer.java#L572)
- [LPKGURLStreamHandlerService.java#L38](https://github.com/liferay/liferay-portal/blob/7.1.0-b3/modules/apps/static/portal-lpkg-deployer/portal-lpkg-deployer-impl/src/main/java/com/liferay/portal/lpkg/deployer/internal/LPKGURLStreamHandlerService.java#L38)
