### PR TITLE
LPS-85800 Remove portlet hash override as it causes asynchronously up…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -334,10 +334,6 @@
 
 					instance.refreshLayout(portletBound);
 
-					if (window.location.hash) {
-						window.location.hash = 'p_' + portletId;
-					}
-
 					portletBoundary = portletBound;
 
 					var Layout = Liferay.Layout;


### PR DESCRIPTION
…dating portlets to override normal anchors

https://issues.liferay.com/browse/LPS-85800

I am unable to ascertain exactly why this code was added in the first place as there were no helpful commit messages indicating why it was added. I have not seen any issues from removing it in my testing, but currently there is a PTR open (https://issues.liferay.com/browse/PTR-434) to try and see why this code was added.

However, since I am not especially hopefully that we'll find out why this old code was added and because the customer is pushing for a solution I sent the fix into review to try and see what engineering thinks about this. Let me know your thoughts in regards to this as well.