### PR TITLE
LPS-82783 Plug DDWinScroll plugin into the Layout when registering th…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -456,6 +456,17 @@ AUI.add(
 						}
 					);
 
+					Layout.layoutHandler.delegate.dd.plug(
+						{
+							cfg: {
+								horizontal: false,
+								scrollDelay: 30,
+								vertical: true
+							},
+							fn: A.Plugin.DDWinScroll
+						}
+					);
+
 					Layout.INITIALIZED = true;
 				}
 			);


### PR DESCRIPTION
…at layout

https://issues.liferay.com/browse/LPS-82783

Note that this issue is being sent in as a fix because the original reasoning for listing LPS-82783 as a Won't Fix was the existence of a workaround for rearranging portlets on desktop (use of the mouse wheel or arrow keys). This workaround does not, however, exist on mobile. The Product Team confirmed that this means this is more solidly classifiable as a bug here: https://issues.liferay.com/browse/PTR-441?focusedCommentId=1593101&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1593101

In my testing seems to work on all desktop browsers, Android, and iOS.