### PR TITLE
LPS-82783 Move where DDWinScroll is initialized to the layoutModule's…

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/layout.js
@@ -376,15 +376,7 @@ AUI.add(
 					dragConfig: {
 						clickPixelThresh: 0,
 						clickTimeThresh: 250,
-						plugins: [
-							{
-								cfg: {
-									horizontal: false,
-									scrollDelay: 30
-								},
-								fn: A.Plugin.DDWinScroll
-							}
-						]
+						plugins: []
 					},
 					handles: options.handles,
 					invalid: options.invalid
@@ -453,6 +445,17 @@ AUI.add(
 							}
 
 							Layout.getLayoutHandler().destroy();
+						}
+					);
+
+					Layout.getLayoutHandler().delegate.dd.plug(
+						{
+							cfg: {
+								horizontal: false,
+								scrollDelay: 30,
+								vertical: true
+							},
+							fn: A.Plugin.DDWinScroll
 						}
 					);
 


### PR DESCRIPTION
… initialization as DDWinScroll is undefined during the initial call of the init function

https://issues.liferay.com/browse/LPS-82783

Resent with only slight changes suggested by Travis. The reason why it seems not to attach is because the function for A.Plugin.DDWinScroll is not defined at the time that it was initially being plugged in. I'm not exactly sure why this is, but I suspect it may have something to do with when the plugins are loaded. Because we need a quicker solution I elected to just remove plugging it in during the init and instead do so during the initialization of the LayoutModule.