### PR TITLE
LPS-86358

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/jsoncontenttype/JSONContentTypeResponse.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/jsoncontenttype/JSONContentTypeResponse.java
@@ -35,7 +35,7 @@ public class JSONContentTypeResponse extends HttpServletResponseWrapper {
 		if (StringUtil.equalsIgnoreCase(
 				contentType, ContentTypes.APPLICATION_JSON)) {
 
-			contentType = ContentTypes.TEXT_JAVASCRIPT;
+			contentType = ContentTypes.TEXT_PLAIN;
 		}
 
 		super.setContentType(contentType);


### PR DESCRIPTION
Hi @jonathanmccann ,

Tickets:
- https://issues.liferay.com/browse/LPP-31773
- https://issues.liferay.com/browse/LPS-86358

This fix is pretty straight-forward; it's changing the **Content-Type** header to be set as  **text/plain** instead of **text/javascript**.

This logic is only executed for IE browsers when a request is using Content-Type: **application/json**. Basically, IE does not handle **application/json** that well, so we've always changed it to **text/javascript**.

This fix changes it to **text/plain** in order to address a security concern that causes a download prompt to appear instead of displaying the content on the page, due to the provided content.

**Note:** For master, this class is now disabled by default:
```com.liferay.portal.servlet.filters.jsoncontenttype.JSONContentTypeFilter=false```
- This changed default value was introduced by https://issues.liferay.com/browse/LPS-66817
----
**CI Test Results**
- master: https://github.com/ericyanLr/liferay-portal/pull/81
- 70x: https://github.com/ericyanLr/liferay-portal/pull/81

I also did additional testing by using `Liferay.Service` in the browser console. From my testing, Liferay.Service javascript calls are still working as expected for IE 11 and Edge.
- https://dev.liferay.com/en/develop/tutorials/-/knowledge_base/7-0/invoking-liferay-services

Please let me know if you have any questions.
Thanks!