### PR TITLE
LPS-86482 Partial revert of "LPS-73238 Minimize replacement length fo…

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/HtmlImpl.java
@@ -237,24 +237,6 @@ public class HtmlImpl implements Html {
 				if (!_VALID_CHARS[c]) {
 					String replacement = null;
 
-					if (mode == ESCAPE_MODE_ATTRIBUTE) {
-						if (c == CharPool.AMPERSAND) {
-							replacement = StringPool.AMPERSAND_ENCODED;
-						}
-						else if (c == CharPool.APOSTROPHE) {
-							replacement = "&#39;";
-						}
-						else if (c == CharPool.QUOTE) {
-							replacement = "&quot;";
-						}
-						else if (!_isValidXmlCharacter(c)) {
-							replacement = StringPool.SPACE;
-						}
-						else {
-							continue;
-						}
-					}
-
 					if (sb == null) {
 						sb = new StringBuilder(text.length() + 64);
 					}


### PR DESCRIPTION
…r HTML attributes" since it causes problems in how template code is escaped

I decided to only partially revert this since it leaves the rest of the fix intact and only reverts the specific minimized escaping that is erroneously removing new lines and spaces from templates.

https://issues.liferay.com/browse/LPS-86482