### PR TITLE
LPS-86455

### DIFF
--- a/modules/apps/document-library/document-library-preview-pdf/bnd.bnd
+++ b/modules/apps/document-library/document-library-preview-pdf/bnd.bnd
@@ -1,4 +1,9 @@
 Bundle-Name: Liferay Document Library Preview PDF
 Bundle-SymbolicName: com.liferay.document.library.preview.pdf
 Bundle-Version: 1.0.0
+Import-Package:\
+	!org.apache.poi.*,\
+	\
+	*
 Web-ContextPath: /document-library-preview-pdf
+-includeresource: @poi-[0-9]*.jar

--- a/modules/apps/document-library/document-library-preview-pdf/build.gradle
+++ b/modules/apps/document-library/document-library-preview-pdf/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.poi", name: "poi", version: "3.15"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "6.0.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly project(":apps:document-library:document-library-api")

--- a/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/PDFDLPreviewRendererProvider.java
+++ b/modules/apps/document-library/document-library-preview-pdf/src/main/java/com/liferay/document/library/preview/pdf/internal/PDFDLPreviewRendererProvider.java
@@ -28,6 +28,8 @@ import java.util.Optional;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
 
+import org.apache.poi.EncryptedDocumentException;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -59,6 +61,14 @@ public class PDFDLPreviewRendererProvider implements DLPreviewRendererProvider {
 							fileVersion)) {
 
 						throw new DLPreviewGenerationInProcessException();
+					}
+
+					int fileCount = PDFProcessorUtil.getDecryptedPreviewCount(
+						fileVersion);
+
+					if (fileCount == 0) {
+						throw new EncryptedDocumentException(
+							"Unable to create preview of encrypted document");
 					}
 
 					throw new DLPreviewGenerationInProcessException();

--- a/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/util/PDFProcessorImpl.java
@@ -17,6 +17,7 @@ package com.liferay.portlet.documentlibrary.util;
 import com.liferay.document.library.kernel.document.conversion.DocumentConversionUtil;
 import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLProcessorConstants;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalServiceUtil;
 import com.liferay.document.library.kernel.store.DLStoreUtil;
 import com.liferay.document.library.kernel.util.DLPreviewableProcessor;
 import com.liferay.document.library.kernel.util.DLUtil;
@@ -30,6 +31,7 @@ import com.liferay.petra.process.ProcessExecutor;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.fabric.InputResource;
 import com.liferay.portal.fabric.OutputResource;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.GhostscriptUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -107,6 +109,20 @@ public class PDFProcessorImpl
 		throws Exception {
 
 		_generateImages(sourceFileVersion, destinationFileVersion);
+	}
+
+	public int getDecryptedPreviewCount(FileVersion fileVersion)
+		throws PortalException {
+
+		String tempFileId = DLUtil.getTempFileId(
+			fileVersion.getFileEntryId(), fileVersion.getVersion());
+
+		File file = DLFileEntryLocalServiceUtil.getFile(
+			fileVersion.getFileEntryId(), fileVersion.getVersion(), false);
+
+		File decryptedFile = getDecryptedTempFile(tempFileId);
+
+		return _getPreviewFilesCount(file, decryptedFile);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/PDFProcessor.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/PDFProcessor.java
@@ -15,6 +15,7 @@
 package com.liferay.document.library.kernel.util;
 
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.image.ImageTool;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.FileVersion;
@@ -39,6 +40,9 @@ public interface PDFProcessor {
 	public void generateImages(
 			FileVersion sourceFileVersion, FileVersion destinationFileVersion)
 		throws Exception;
+
+	public int getDecryptedPreviewCount(FileVersion fileVersion)
+		throws PortalException;
 
 	public InputStream getPreviewAsStream(FileVersion fileVersion, int index)
 		throws Exception;

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/PDFProcessorUtil.java
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/PDFProcessorUtil.java
@@ -15,6 +15,7 @@
 package com.liferay.document.library.kernel.util;
 
 import com.liferay.document.library.kernel.model.DLProcessorConstants;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.repository.model.FileVersion;
 
 import java.io.InputStream;
@@ -34,6 +35,18 @@ public class PDFProcessorUtil {
 			pdfProcessor.generateImages(
 				sourceFileVersion, destinationFileVersion);
 		}
+	}
+
+	public static int getDecryptedPreviewCount(FileVersion fileVersion)
+		throws PortalException {
+
+		PDFProcessor pdfProcessor = getPDFProcessor();
+
+		if (pdfProcessor == null) {
+			return 0;
+		}
+
+		return pdfProcessor.getDecryptedPreviewCount(fileVersion);
 	}
 
 	public static PDFProcessor getPDFProcessor() {

--- a/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/document/library/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 2.0.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-31835
https://issues.liferay.com/browse/LPS-86455

From @wanderlast: 

> This issue involves encrypted PDFs in the Documents & Media library. Normal operating behavior has the document library create a preview for any uploaded PDFs. Obviously, this doesn't work for encrypted PDFs if a password is not provided. However, the code currently throws the same exception for an encrypted PDF as a PDF that is simply taking a long time to generate a preview. The message "Generating preview will take a few minutes." is misleading since no preview will ever exist.
> 
> Unfortunately, the solution itself is a bit hacky, so if you have any suggestions on improving it, I'm all ears. The code in the method added in commit 5762635 is copied from _generateImagesPB(FileVersion fileVersion, File file) in the same class. However, _generateImagesPB is reliant on several variables found in that code and so I was unable to remove the duplicate code without adding several extra calls within _generateImagesPB. I was unsure which would be preferable (extra calls or cleaning up the code), so I erred on the side of the former.
> 
> As a note on testing: the LPP has an encrypted PDF to test on that end. To test against a situation where the "Generating preview will take a few minutes" is legitimate, I used a PDF from the Liferay training materials.
> 
> Please let me know if you have any suggestions or questions. Thanks!
> 
> ETA: Rebased since the last pull and it looks like it resolved most of the test failures. You can see where I ran the tests here (wanderlast#10) but I'll run them again just in case.