### PR TITLE
LPS-86608 added null check

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -544,6 +544,12 @@ public class JournalArticleExportImportContentProcessor
 		for (DDMFormFieldValue ddmFormFieldValue : ddmFormFieldValues) {
 			Value value = ddmFormFieldValue.getValue();
 
+			if (value == null) {
+				contents.add(null);
+
+				continue;
+			}
+
 			for (Locale locale : value.getAvailableLocales()) {
 				contents.add(value.getString(locale));
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86608

From @ajsampang67:

> In WCM, when importing WC with Separator fields, we got NullPointerException since separators have no value. Added a null check to fix this.

Passing tests here: https://github.com/ChrisKian/liferay-portal/pull/66#issuecomment-432357898