### PR TITLE
LPS-86907 Reset default value when toggled

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -638,6 +638,14 @@ if (portletTitleBasedNavigation) {
 		$('#<portlet:namespace />updateVersionDetails').on(
 			'click',
 			function(event) {
+				var inputValue = "<%= dlVersionNumberIncrease %>";
+
+				if (<%= dlVersionNumberIncrease == DLVersionNumberIncrease.AUTOMATIC %>) {
+					inputValue = "<%= DLVersionNumberIncrease.NONE %>";
+				}
+
+				$('input[value=' + inputValue + ']')[0].checked=true
+
 				$('#<portlet:namespace />versionDetails').toggle();
 			}
 		);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-86907

The issue is that when the toggle is off the options are not shown -- however they are still used on submission.  
The change is to reset the value to the default value on toggle.