### PR TITLE
LPS-87629

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1527,7 +1527,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 	@Override
 	public boolean hasDateRange() {
-		if (_startDate != null) {
+		if ((_startDate != null) && (_endDate != null)) {
 			return true;
 		}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1527,7 +1527,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 	@Override
 	public boolean hasDateRange() {
-		if ((_startDate != null) && (_endDate != null)) {
+		if ((_endDate != null) && (_startDate != null)) {
 			return true;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87629

Explanation from @nellyliupeng:

> DDMTemplates retrieved through PortletDisplayTemplate portlet are not shown when local staging is turned on from the second iteration and on.
> The date range criteria returns an invalid query statement and prevents proper retrieval of ADTs
> 
> From second iteration and onwards using local staging, the criteria would return ie. `(modifiedDate<=null and modifiedDate>=Tue Nov 20 17:59:42 GMT 2018)`, which returns no results due to the first invalid condition.

> This PR adds an additional check when retrieving date range, which is later added to the query used to retrieve ADTs

Essentially, null isn't a valid end date in a date range, so we check for it.

Also important:

> This isn't reproducible in Master due to the introduction of changesets fixing the underlying problem, but the code still exists thus the fix being sent to Master.

After testing, I've found if there is a startDate but no endDate, the modifiedDate is used as the startDate.  This squashed my concerns of a startDate from the future being used.  Also, the [validateDateRange()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextFactoryImpl.java#L339) method seems to imply we should have both a startDate and endDate, otherwise throw an exception.