### PR TITLE
LPS-87877

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutPrototypeMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutPrototypeMVCActionCommand.java
@@ -17,7 +17,6 @@ package com.liferay.layout.admin.web.internal.portlet.action;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateEntryException;
 import com.liferay.layout.page.template.exception.LayoutPageTemplateEntryNameException;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -86,9 +85,9 @@ public class UpdateLayoutPrototypeMVCActionCommand
 
 			jsonObject.put("redirectURL", redirect);
 		}
-		catch (PortalException pe) {
+		catch (Throwable t) {
 			if (_log.isDebugEnabled()) {
-				_log.debug(pe, pe);
+				_log.debug(t, t);
 			}
 
 			ThemeDisplay themeDisplay =
@@ -96,10 +95,14 @@ public class UpdateLayoutPrototypeMVCActionCommand
 
 			String errorMessage = "an-unexpected-error-occurred";
 
-			if (pe instanceof LayoutPageTemplateEntryNameException) {
+			Throwable cause = t.getCause();
+
+			if (cause instanceof LayoutPageTemplateEntryNameException) {
 				errorMessage = "please-enter-a-valid-name";
 			}
-			else if (pe instanceof DuplicateLayoutPageTemplateEntryException) {
+			else if (cause instanceof
+						DuplicateLayoutPageTemplateEntryException) {
+
 				errorMessage =
 					"a-page-template-entry-with-that-name-already-exists";
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87877

CC @wanderlast 
Notes from @jaclynong

> When fixing LPS-87055, I found this issue. In my original attempt to fix it, I found that the exception wasn't getting caught in the catch of PortalException in UpdateLayoutPrototypeMVCActionCommand.doProcessAction. The exception getting thrown is a ModelListenerException (which is not a PortalException) that has a DuplicateLayoutPageTemplateEntryException in its cause property. I changed the catch to catch a more generic Throwable to keep it consistent with AddLayoutPrototypeMVCActionCommand.java.
> 
> This fix is the same as original proposed fix to change the catch to Throwable instead of PortalException in e5bd0a660535acbc87b04c5ddd09420bb9e17338 - UpdateLayoutPrototypeMVCActionCommand.java.

Test failures look unrelated: https://github.com/wanderlast/liferay-portal/pull/13#issuecomment-442984107
Passing SF test: https://github.com/wanderlast/liferay-portal/pull/13#issuecomment-442957268