### PR TITLE
LPS-88170 Rename column and finder names to prevent syntax errors in …

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
+++ b/modules/util/portal-tools-service-builder/src/main/java/com/liferay/portal/tools/service/builder/ServiceBuilder.java
@@ -5431,6 +5431,7 @@ public class ServiceBuilder {
 				columnDBName = columnName;
 
 				if (_badColumnNames.contains(columnName)) {
+					columnName += StringPool.UNDERLINE;
 					columnDBName += StringPool.UNDERLINE;
 				}
 			}
@@ -5763,6 +5764,11 @@ public class ServiceBuilder {
 			for (Element finderColumnElement : finderColumnElements) {
 				String finderColumnName = finderColumnElement.attributeValue(
 					"name");
+
+				if (_badColumnNames.contains(finderColumnName)) {
+					finderColumnName += StringPool.UNDERLINE;
+				}
+
 				boolean finderColCaseSensitive = GetterUtil.getBoolean(
 					finderColumnElement.attributeValue("case-sensitive"), true);
 				String finderColComparator = GetterUtil.getString(

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/bad_column_names.txt
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/bad_column_names.txt
@@ -7,6 +7,7 @@ all
 alter
 analyze
 and
+array
 as
 asc
 asensitive
@@ -40,6 +41,8 @@ const
 constraint
 continue
 convert
+count
+counter
 create
 cross
 currency
@@ -89,6 +92,8 @@ fetch
 fields
 final
 finally
+finderArgs
+finderPath
 float
 float4
 float8
@@ -147,6 +152,7 @@ left
 like
 limit
 lines
+list
 load
 localtime
 localtimestamp
@@ -183,10 +189,14 @@ option
 optionally
 or
 order
+orderByComparator
+orderByConditionFields
+orderByFields
 out
 outer
 outfile
 package
+pagination
 password
 path
 precision
@@ -196,6 +206,8 @@ procedure
 protected
 public
 purge
+q
+query
 read
 reads
 real
@@ -220,6 +232,7 @@ second_microsecond
 select
 sensitive
 separator
+session
 set
 settings
 short
@@ -235,6 +248,7 @@ sql_big_result
 sql_calc_found_rows
 sql_small_result
 sqlexception
+sqlQuery
 sqlstate
 sqlwarning
 ssl
@@ -280,6 +294,7 @@ utc_date
 utc_time
 utc_timestamp
 uuid
+value
 values
 varbinary
 varchar


### PR DESCRIPTION
…generated classes

Resent from https://github.com/jonathanmccann/liferay-portal/pull/1728

https://issues.liferay.com/browse/LPS-88170

Syntax errors occur when building the service with certain column names. Instead of preventing these names from being used, modifying them will be less intrusive for the customer. Since bad_column_names already did this for database syntax, I added other words that would cause these errors in the generated classes. I modified the `columnName` which is used to create the `EntityColumn`. Also modified the `finderColumnName` in order to be able to find the correct entityColumn. 

Let me know if there are any questions or comments.
Thank you.
