### PR TITLE
LPS-88284

### DIFF
--- a/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
@@ -177,6 +177,7 @@ public class LayoutPrototypeStagedModelDataHandler
 		long groupId = portletDataContext.getGroupId();
 		boolean privateLayout = portletDataContext.isPrivateLayout();
 		long scopeGroupId = portletDataContext.getScopeGroupId();
+		String portletId = portletDataContext.getPortletId();
 
 		List<Layout> layouts = _layoutLocalService.getLayouts(
 			layoutPrototype.getGroupId(), true,
@@ -197,6 +198,7 @@ public class LayoutPrototypeStagedModelDataHandler
 			portletDataContext.setGroupId(groupId);
 			portletDataContext.setPrivateLayout(privateLayout);
 			portletDataContext.setScopeGroupId(scopeGroupId);
+			portletDataContext.setPortletId(portletId);
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-32406
https://issues.liferay.com/browse/LPS-88284

From @wanderlast:

> In 7.1, we added the concept of "display pages" and "content page templates" in addition to our pre-existing page templates -- now known as "widget page templates". To properly deal with the import/export of these templates, new infrastructure was created under the name LayoutPageTemplateEntry (among others) to handle these. These are exported under the GroupPages portlet.
> 
> Site templates can and should propagate page template content to a site created based on a site template. This functions properly when a combination of content page templates and/or display pages are present in the site template. However, no page template content is propagated when a widget page template is present. The underlying cause of this issue is that, when exported, the content is exported under the auspices of the GroupPages portlet. However, the portletID present in the corresponding LAR (if a WPT is present) is:
> 
> portlet-id value "com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet_INSTANCE_templateSearch"
> 
> This causes the import to be processed incorrectly and therefore for none of the templates to be properly imported into the database. This mislabled portletId originates in the LayoutPrototypeStagedModelDataHandler, which handles the export of widget page templates. During export, the portletdatacontext's portletId is changed during the running of StagedModelDataHandlerUtil.exportReferenceStagedModel() and is therefore propagated back incorrectly to PortletExportControllerImpl which uses the portletDataContext's portletID for the LAR file. The fix is therefore to save the original portletID and change it back to this value once processing of layout prototypes is done.
> 
> Please let me know if you have any questions or concerns. Thanks!