### PR TITLE
LPS-88265

### DIFF
--- a/modules/apps/apio-architect/.gitrepo
+++ b/modules/apps/apio-architect/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = true
 	cmdver = liferay
-	commit = 7de6728b72f6554f5c1b5fad094b32c1c38f5dca
+	commit = b974944ff9535332f11dfd9aae38071cc47ccb7b
 	mergebuttonmergecommits = false
 	mode = pull
-	parent = 17920c8d2d94e155e34b593a5389e49b8ae34e57
+	parent = bc30ccdd099178ebae0bc715deda69575f25eaf7
 	remote = git@github.com:liferay/com-liferay-apio-architect.git

--- a/modules/apps/apio-architect/apio-architect-api/src/main/java/com/liferay/apio/architect/resource/Resource.java
+++ b/modules/apps/apio-architect/apio-architect-api/src/main/java/com/liferay/apio/architect/resource/Resource.java
@@ -16,6 +16,7 @@ package com.liferay.apio.architect.resource;
 
 import aQute.bnd.annotation.ProviderType;
 
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -97,9 +98,14 @@ public class Resource {
 				return true;
 			}
 
-			if ((obj instanceof GenericParent) &&
-				getName().equals(((GenericParent)obj).getName()) &&
-				_parentName.equals(((GenericParent)obj)._parentName)) {
+			if (!(obj instanceof GenericParent)) {
+				return false;
+			}
+
+			GenericParent genericParent = (GenericParent)obj;
+
+			if (Objects.equals(getName(), genericParent.getName()) &&
+				Objects.equals(_parentName, genericParent._parentName)) {
 
 				return true;
 			}
@@ -129,7 +135,10 @@ public class Resource {
 		public int hashCode() {
 			int h = 5381;
 
-			h += (h << 5) + getName().hashCode();
+			String name = getName();
+
+			h += (h << 5) + name.hashCode();
+
 			h += (h << 5) + _parentName.hashCode();
 
 			return h;
@@ -137,8 +146,8 @@ public class Resource {
 
 		@Override
 		public String toString() {
-			return "GenericParent{name=" + getName() + ", parentName=" +
-				_parentName + ", parentId=" + _parentId + "}";
+			return "{name=" + getName() + ", parentId=" + _parentId +
+				", parentName=" + _parentName + "}";
 		}
 
 		/**
@@ -216,9 +225,14 @@ public class Resource {
 				return true;
 			}
 
-			if (obj instanceof Id &&
-				_objectVersion.equals(((Id)obj)._objectVersion) &&
-				_stringVersion.equals(((Id)obj)._stringVersion)) {
+			if (!(obj instanceof Id)) {
+				return false;
+			}
+
+			Id id = (Id)obj;
+
+			if (Objects.equals(_objectVersion, id._objectVersion) &&
+				Objects.equals(_stringVersion, id._stringVersion)) {
 
 				return true;
 			}
@@ -238,7 +252,7 @@ public class Resource {
 
 		@Override
 		public String toString() {
-			return "Id{" + _stringVersion + "}";
+			return "{" + _stringVersion + "}";
 		}
 
 		private Id(Object objectVersion, String stringVersion) {
@@ -287,9 +301,13 @@ public class Resource {
 				return true;
 			}
 
-			if (obj instanceof Item &&
-				getName().equals(((Item)obj).getName())) {
+			if (!(obj instanceof Item)) {
+				return false;
+			}
 
+			Item item = (Item)obj;
+
+			if (Objects.equals(getName(), item.getName())) {
 				return true;
 			}
 
@@ -311,7 +329,9 @@ public class Resource {
 		public int hashCode() {
 			int h = 5381;
 
-			h += (h << 5) + getName().hashCode();
+			String name = getName();
+
+			h += (h << 5) + name.hashCode();
 
 			return h;
 		}
@@ -319,10 +339,10 @@ public class Resource {
 		@Override
 		public String toString() {
 			if (_id != null) {
-				return "Item{name=" + getName() + ", id=" + _id + "}";
+				return "{id=" + _id + ", name=" + getName() + "}";
 			}
 
-			return "Item{name=" + getName() + "}";
+			return "{name=" + getName() + "}";
 		}
 
 		/**
@@ -385,9 +405,14 @@ public class Resource {
 				return true;
 			}
 
-			if ((obj instanceof Nested) &&
-				getName().equals(((Nested)obj).getName()) &&
-				_parentItem.equals(((Nested)obj)._parentItem)) {
+			if (!(obj instanceof Nested)) {
+				return false;
+			}
+
+			Nested nested = (Nested)obj;
+
+			if (Objects.equals(getName(), nested.getName()) &&
+				Objects.equals(_parentItem, nested._parentItem)) {
 
 				return true;
 			}
@@ -408,7 +433,10 @@ public class Resource {
 		public int hashCode() {
 			int h = 5381;
 
-			h += (h << 5) + getName().hashCode();
+			String name = getName();
+
+			h += (h << 5) + name.hashCode();
+
 			h += (h << 5) + _parentItem.hashCode();
 
 			return h;
@@ -416,7 +444,7 @@ public class Resource {
 
 		@Override
 		public String toString() {
-			return "Nested{name=" + getName() + ", parent=" + _parentItem + "}";
+			return "{name=" + getName() + ", parentItem=" + _parentItem + "}";
 		}
 
 		/**
@@ -468,9 +496,13 @@ public class Resource {
 				return true;
 			}
 
-			if (obj instanceof Paged &&
-				getName().equals(((Paged)obj).getName())) {
+			if (!(obj instanceof Paged)) {
+				return false;
+			}
 
+			Paged paged = (Paged)obj;
+
+			if (Objects.equals(getName(), paged.getName())) {
 				return true;
 			}
 
@@ -481,14 +513,16 @@ public class Resource {
 		public int hashCode() {
 			int h = 5381;
 
-			h += (h << 5) + getName().hashCode();
+			String name = getName();
+
+			h += (h << 5) + name.hashCode();
 
 			return h;
 		}
 
 		@Override
 		public String toString() {
-			return "Paged{name=" + getName() + "}";
+			return "{name=" + getName() + "}";
 		}
 
 		private Paged(String name) {

--- a/modules/apps/apio-architect/apio-architect-api/src/test/java/com/liferay/apio/architect/resource/ResourceTest.java
+++ b/modules/apps/apio-architect/apio-architect-api/src/test/java/com/liferay/apio/architect/resource/ResourceTest.java
@@ -66,12 +66,12 @@ public class ResourceTest {
 	public void testGenericParentWithParentIdCreatesValidGenericParentWithId() {
 		GenericParent genericParent = GenericParent.of("parent", "name");
 
-		GenericParent genericParentWithId = genericParent.withParentId(
+		GenericParent withIdGenericParent = genericParent.withParentId(
 			Id.of(42L, "42"));
 
-		assertThat(genericParentWithId.getName(), is("name"));
+		assertThat(withIdGenericParent.getName(), is("name"));
 
-		Optional<Id> idOptional = genericParentWithId.getParentIdOptional();
+		Optional<Id> idOptional = withIdGenericParent.getParentIdOptional();
 
 		Id expectedId = Id.of(42L, "42");
 

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/annotation/ActionRouterManager.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/annotation/ActionRouterManager.java
@@ -118,7 +118,7 @@ public class ActionRouterManager {
 			);
 
 			if (optionName.isEmpty()) {
-				_logger.warn("Unable to get name for ActionRouter {}", clazz);
+				_logger.warn("Unable to get name for action router {}", clazz);
 
 				continue;
 			}

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/jaxrs/mapper/WebApplicationExceptionMapper.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/jaxrs/mapper/WebApplicationExceptionMapper.java
@@ -44,8 +44,10 @@ public class WebApplicationExceptionMapper
 	implements ExceptionMapper<WebApplicationException> {
 
 	@Override
-	public Response toResponse(WebApplicationException exception) {
-		return _errorUtil.getErrorResponse(exception, _request);
+	public Response toResponse(
+		WebApplicationException webApplicationException) {
+
+		return _errorUtil.getErrorResponse(webApplicationException, _request);
 	}
 
 	@Reference

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/message/json/ld/JSONLDMessageMapperUtil.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/message/json/ld/JSONLDMessageMapperUtil.java
@@ -72,10 +72,10 @@ public class JSONLDMessageMapperUtil {
 	 * @review
 	 */
 	public static List<String> getActionTypes(String actionName) {
-		if ("create".equals(actionName)) {
+		if ("batch-create".equals(actionName)) {
 			return asList("CreateAction", "Operation");
 		}
-		else if ("batch-create".equals(actionName)) {
+		else if ("create".equals(actionName)) {
 			return asList("CreateAction", "Operation");
 		}
 		else if ("remove".equals(actionName)) {

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/routes/NestedCollectionRoutesImpl.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/routes/NestedCollectionRoutesImpl.java
@@ -253,10 +253,14 @@ public class NestedCollectionRoutesImpl<T, S, U>
 
 		private Resource _resourceWithParentId(Id id) {
 			if (_resource instanceof Nested) {
-				return ((Nested)_resource).withParentId(id);
+				Nested nested = (Nested)_resource;
+
+				return nested.withParentId(id);
 			}
 
-			return ((GenericParent)_resource).withParentId(id);
+			GenericParent genericParent = (GenericParent)_resource;
+
+			return genericParent.withParentId(id);
 		}
 
 		private <V> List<S> _transformList(

--- a/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/wiring/osgi/manager/cache/ManagerCache.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/main/java/com/liferay/apio/architect/internal/wiring/osgi/manager/cache/ManagerCache.java
@@ -95,7 +95,7 @@ public class ManagerCache {
 		_batchResultMessageMappers = null;
 		_representors = null;
 		_reusableNestedCollectionRoutes = null;
-		_rootResourceNamesSdk = null;
+		_rootResourceNameSdks = null;
 		_singleModelMessageMappers = null;
 	}
 
@@ -649,11 +649,11 @@ public class ManagerCache {
 	 * @review
 	 */
 	public void putRootResourceNameSdk(String rootResourceNameSdk) {
-		if (_rootResourceNamesSdk == null) {
-			_rootResourceNamesSdk = new ArrayList<>();
+		if (_rootResourceNameSdks == null) {
+			_rootResourceNameSdks = new ArrayList<>();
 		}
 
-		_rootResourceNamesSdk.add(rootResourceNameSdk);
+		_rootResourceNameSdks.add(rootResourceNameSdk);
 	}
 
 	/**
@@ -741,7 +741,7 @@ public class ManagerCache {
 	private Map<String, Representor> _representors;
 	private Map<String, Class<?>> _reusableIdentifierClasses;
 	private Map<String, NestedCollectionRoutes> _reusableNestedCollectionRoutes;
-	private List<String> _rootResourceNamesSdk;
+	private List<String> _rootResourceNameSdks;
 	private Map<MediaType, SingleModelMessageMapper> _singleModelMessageMappers;
 
 }

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/internal/annotation/form/FormTransformerTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/internal/annotation/form/FormTransformerTest.java
@@ -65,10 +65,10 @@ public class FormTransformerTest {
 				{
 					put("booleanListField1", asList("true", "false"));
 					put("booleanListField2", asList("false", "true"));
-					put("stringListField1", asList("one", "two"));
-					put("stringListField2", asList("three", "four"));
 					put("numberListField1", asList("1", "2"));
 					put("numberListField2", asList("3", "4"));
+					put("stringListField1", asList("one", "two"));
+					put("stringListField2", asList("three", "four"));
 				}
 			};
 
@@ -98,10 +98,10 @@ public class FormTransformerTest {
 	public void testListFields() {
 		assertThat(_dummy.getBooleanListField1(), is(asList(true, false)));
 		assertThat(_dummy.getBooleanListField2(), is(asList(false, true)));
-		assertThat(_dummy.getStringListField1(), is(asList("one", "two")));
-		assertThat(_dummy.getStringListField2(), is(asList("three", "four")));
 		assertThat(_dummy.getNumberListField1(), is(asList(1L, 2L)));
 		assertThat(_dummy.getNumberListField2(), is(asList(3L, 4L)));
+		assertThat(_dummy.getStringListField1(), is(asList("one", "two")));
+		assertThat(_dummy.getStringListField2(), is(asList("three", "four")));
 	}
 
 	@Test

--- a/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/internal/message/json/ld/JSONLDMessageMapperUtilTest.java
+++ b/modules/apps/apio-architect/apio-architect-impl/src/test/java/com/liferay/apio/architect/internal/message/json/ld/JSONLDMessageMapperUtilTest.java
@@ -54,34 +54,34 @@ public class JSONLDMessageMapperUtilTest {
 
 	@Test
 	public void testGetActionId() {
-		Paged paged = Paged.of("paged");
-
 		Item item = Item.of("item");
 
 		Nested nested = Nested.of(item, "nested");
 
-		String pagedId = getActionId(paged, "retrieve");
+		Paged paged = Paged.of("paged");
+
 		String itemId = getActionId(item, "remove");
 		String nestedId = getActionId(nested, "create");
+		String pagedId = getActionId(paged, "retrieve");
 
-		assertThat(pagedId, is("_:paged/retrieve"));
 		assertThat(itemId, is("_:item/remove"));
 		assertThat(nestedId, is("_:item/nested/create"));
+		assertThat(pagedId, is("_:paged/retrieve"));
 	}
 
 	@Test
 	public void testGetActionType() {
-		List<String> retrieveTypes = getActionTypes("retrieve");
 		List<String> createTypes = getActionTypes("create");
+		List<String> customActionTypes = getActionTypes("subscribe");
 		List<String> removeTypes = getActionTypes("remove");
 		List<String> replaceTypes = getActionTypes("replace");
-		List<String> customActionTypes = getActionTypes("subscribe");
+		List<String> retrieveTypes = getActionTypes("retrieve");
 
-		assertThat(retrieveTypes, contains("Operation"));
 		assertThat(createTypes, contains("CreateAction", "Operation"));
+		assertThat(customActionTypes, contains("Operation"));
 		assertThat(removeTypes, contains("DeleteAction", "Operation"));
 		assertThat(replaceTypes, contains("ReplaceAction", "Operation"));
-		assertThat(customActionTypes, contains("Operation"));
+		assertThat(retrieveTypes, contains("Operation"));
 	}
 
 }

--- a/modules/apps/apio-architect/apio-architect-sample/src/main/java/com/liferay/apio/architect/sample/internal/jaxrs/AvatarResource.java
+++ b/modules/apps/apio-architect/apio-architect-sample/src/main/java/com/liferay/apio/architect/sample/internal/jaxrs/AvatarResource.java
@@ -75,7 +75,7 @@ public class AvatarResource {
 			).build()
 		).orElseThrow(
 			() -> new NotFoundException(
-				"Unable to find the image of user with id " + id)
+				"Unable to find image for user " + id)
 		);
 	}
 

--- a/modules/apps/apio-architect/apio-architect-sample/src/main/java/com/liferay/apio/architect/sample/internal/jaxrs/AvatarResource.java
+++ b/modules/apps/apio-architect/apio-architect-sample/src/main/java/com/liferay/apio/architect/sample/internal/jaxrs/AvatarResource.java
@@ -74,8 +74,7 @@ public class AvatarResource {
 				"image/jpg"
 			).build()
 		).orElseThrow(
-			() -> new NotFoundException(
-				"Unable to find image for user " + id)
+			() -> new NotFoundException("Unable to find image for user " + id)
 		);
 	}
 

--- a/modules/apps/apio-architect/apio-architect-test-fragment/build.gradle
+++ b/modules/apps/apio-architect/apio-architect-test-fragment/build.gradle
@@ -1,1 +1,3 @@
-deploy.enabled = false
+deploy {
+	enabled = false
+}

--- a/modules/apps/apio-architect/apio-architect-test/src/main/java/com/liferay/apio/architect/internal/test/jaxrs/filter/HTTPMethodOverrideFilterTest.java
+++ b/modules/apps/apio-architect/apio-architect-test/src/main/java/com/liferay/apio/architect/internal/test/jaxrs/filter/HTTPMethodOverrideFilterTest.java
@@ -73,7 +73,7 @@ public class HTTPMethodOverrideFilterTest extends BaseTest {
 
 		assertThat(response.getStatus(), is(200));
 
-		String expected = "Hello World! Method = GREET";
+		String expected = "Hello World! Method GREET.";
 
 		assertThat(response.readEntity(String.class), is(expected));
 	}
@@ -88,7 +88,7 @@ public class HTTPMethodOverrideFilterTest extends BaseTest {
 
 		@CUSTOM
 		public String hello(@Context HttpServletRequest request) {
-			return "Hello World! Method = " + request.getMethod();
+			return "Hello World! Method " + request.getMethod() + ".";
 		}
 
 	}

--- a/modules/apps/apio-architect/apio-architect-test/src/main/java/com/liferay/apio/architect/internal/test/sample/jaxrs/AvatarResourceTest.java
+++ b/modules/apps/apio-architect/apio-architect-test/src/main/java/com/liferay/apio/architect/internal/test/sample/jaxrs/AvatarResourceTest.java
@@ -51,7 +51,7 @@ public class AvatarResourceTest extends BaseTest {
 			builder -> builder.put(
 				"@type", "not-found"
 			).put(
-				"description", "Unable to find the image of user with id 9999"
+				"description", "Unable to find image for user 9999"
 			).put(
 				"statusCode", 404
 			).put(

--- a/modules/apps/apio-architect/build-ext.gradle
+++ b/modules/apps/apio-architect/build-ext.gradle
@@ -17,27 +17,49 @@ allprojects {
 }
 
 configure(subprojects.findAll {!it.childProjects}) {
-	test.ignoreFailures = false
+	test {
+		ignoreFailures = false
+	}
 
-	buildCSS.enabled = false
+	buildCSS {
+		enabled = false
+	}
 
-	processResources.enabled = false
+	processResources {
+		enabled = false
+	}
 
-	transpileJS.enabled = false
+	transpileJS {
+		enabled = false
+	}
 
-	configJSModules.enabled = false
+	configJSModules {
+		enabled = false
+	}
 
-	copyLibs.enabled = false
+	copyLibs {
+		enabled = false
+	}
 
-	replaceSoyTranslation.enabled = false
+	replaceSoyTranslation {
+		enabled = false
+	}
 
-	wrapSoyAlloyTemplate.enabled = false
+	wrapSoyAlloyTemplate {
+		enabled = false
+	}
 
-	setUpTestableTomcat.enabled = false
+	setUpTestableTomcat {
+		enabled = false
+	}
 
-	startTestableTomcat.enabled = false
+	startTestableTomcat {
+		enabled = false
+	}
 
-	stopTestableTomcat.enabled = false
+	stopTestableTomcat {
+		enabled = false
+	}
 }
 
 task codeCoverageReport(type: JacocoReport)
@@ -59,9 +81,17 @@ codeCoverageReport {
 	}
 
 	reports {
-		csv.enabled = false
-		html.enabled = false
-		xml.destination "${buildDir}/reports/jacoco/report.xml"
-		xml.enabled = true
+		csv {
+			enabled = false
+		}
+
+		html {
+			enabled = false
+		}
+
+		xml {
+			enabled = true
+			destination "${buildDir}/reports/jacoco/report.xml"
+		}
 	}
 }

--- a/modules/apps/apio-architect/build-ext.gradle
+++ b/modules/apps/apio-architect/build-ext.gradle
@@ -29,10 +29,6 @@ configure(subprojects.findAll {!it.childProjects}) {
 		enabled = false
 	}
 
-	processResources {
-		enabled = false
-	}
-
 	replaceSoyTranslation {
 		enabled = false
 	}

--- a/modules/apps/apio-architect/build-ext.gradle
+++ b/modules/apps/apio-architect/build-ext.gradle
@@ -48,7 +48,14 @@ codeCoverageReport {
 	subprojects.findAll { !it.childProjects }.each { sourceSets it.sourceSets.main }
 
 	afterEvaluate {
-		classDirectories = files(classDirectories.files.collect { fileTree(dir: it, exclude: ["**/com/liferay/apio/architect/internal/test/**"]) })
+		classDirectories = files(
+			classDirectories.files.collect {
+				fileTree(
+					dir: it,
+					exclude: [
+						"**/com/liferay/apio/architect/internal/test/**"
+					])
+			})
 	}
 
 	reports {

--- a/modules/apps/apio-architect/build-ext.gradle
+++ b/modules/apps/apio-architect/build-ext.gradle
@@ -48,7 +48,7 @@ codeCoverageReport {
 	subprojects.findAll { !it.childProjects }.each { sourceSets it.sourceSets.main }
 
 	afterEvaluate {
-		classDirectories = files(classDirectories.files.collect { fileTree(dir: it, exclude: ['**/com/liferay/apio/architect/internal/test/**']) })
+		classDirectories = files(classDirectories.files.collect { fileTree(dir: it, exclude: ["**/com/liferay/apio/architect/internal/test/**"]) })
 	}
 
 	reports {

--- a/modules/apps/apio-architect/build-ext.gradle
+++ b/modules/apps/apio-architect/build-ext.gradle
@@ -17,19 +17,7 @@ allprojects {
 }
 
 configure(subprojects.findAll {!it.childProjects}) {
-	test {
-		ignoreFailures = false
-	}
-
 	buildCSS {
-		enabled = false
-	}
-
-	processResources {
-		enabled = false
-	}
-
-	transpileJS {
 		enabled = false
 	}
 
@@ -41,11 +29,11 @@ configure(subprojects.findAll {!it.childProjects}) {
 		enabled = false
 	}
 
-	replaceSoyTranslation {
+	processResources {
 		enabled = false
 	}
 
-	wrapSoyAlloyTemplate {
+	replaceSoyTranslation {
 		enabled = false
 	}
 
@@ -58,6 +46,18 @@ configure(subprojects.findAll {!it.childProjects}) {
 	}
 
 	stopTestableTomcat {
+		enabled = false
+	}
+
+	test {
+		ignoreFailures = false
+	}
+
+	transpileJS {
+		enabled = false
+	}
+
+	wrapSoyAlloyTemplate {
 		enabled = false
 	}
 }

--- a/modules/apps/apio-architect/source-formatter.properties
+++ b/modules/apps/apio-architect/source-formatter.properties
@@ -5,14 +5,18 @@
 ## for available properties.
 ##
 
-    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
-
-    checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
-
-    checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget
-
 ##
 ## Git
 ##
 
     git.liferay.portal.branch=master
+
+##
+## Checkstyle Properties
+##
+
+    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
+
+	checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
+
+	checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget

--- a/modules/apps/apio-architect/source-formatter.properties
+++ b/modules/apps/apio-architect/source-formatter.properties
@@ -5,18 +5,14 @@
 ## for available properties.
 ##
 
+    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
+
+    checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
+
+    checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget
+
 ##
 ## Git
 ##
 
     git.liferay.portal.branch=master
-
-##
-## Checkstyle Properties
-##
-
-    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
-
-	checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
-
-	checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget

--- a/modules/apps/apio-architect/source-formatter.properties
+++ b/modules/apps/apio-architect/source-formatter.properties
@@ -16,7 +16,5 @@
 ##
 
     checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
-
-	checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
-
-	checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget
+    checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
+    checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget

--- a/modules/apps/apio-architect/source-formatter.properties
+++ b/modules/apps/apio-architect/source-formatter.properties
@@ -5,8 +5,8 @@
 ## for available properties.
 ##
 
-    checkstyle.chaining.check.allowedClassNames=Either,.*Function.*,List,Option
-    checkstyle.chaining.check.allowedMethodNames=filter,params,ofResource
+    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
+    checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
     checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget
 
 ##

--- a/modules/apps/apio-architect/source-formatter.properties
+++ b/modules/apps/apio-architect/source-formatter.properties
@@ -5,12 +5,18 @@
 ## for available properties.
 ##
 
-    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
-    checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
-    checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget
-
 ##
 ## Git
 ##
 
     git.liferay.portal.branch=master
+
+##
+## Checkstyle Properties
+##
+
+    checkstyle.chaining.check.allowedClassNames=.*Function.*,Either,List,Option
+
+	checkstyle.chaining.check.allowedMethodNames=filter,ofResource,params
+
+	checkstyle.chaining.check.allowedVariableTypeNames=.*Function.*,WebTarget

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -1336,7 +1336,9 @@ AUI.add(
 
 						var titleNode = A.one('#' + instance.getInputName() + 'Title');
 
-						titleNode.val(parsedValue.title || '');
+						if (parsedValue.title != null) {
+							titleNode.val(parsedValue.title);
+						}
 
 						var clearButtonNode = A.one('#' + instance.getInputName() + 'ClearButton');
 

--- a/modules/test/jenkins-results-parser/bnd.bnd
+++ b/modules/test/jenkins-results-parser/bnd.bnd
@@ -1,3 +1,3 @@
 Bundle-Name: Liferay Jenkins Results Parser
 Bundle-SymbolicName: com.liferay.jenkins.results.parser
-Bundle-Version: 1.0.395
+Bundle-Version: 1.0.396

--- a/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
+++ b/modules/test/jenkins-results-parser/src/main/java/com/liferay/jenkins/results/parser/GitWorkingDirectory.java
@@ -1120,7 +1120,7 @@ public class GitWorkingDirectory {
 
 		StringBuilder sb = new StringBuilder();
 
-		sb.append("git diff --diff-filter=AMR --name-only ");
+		sb.append("git diff --diff-filter=ADMR --name-only ");
 
 		sb.append(
 			_getMergeBaseCommitSHA(

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
@@ -148,6 +148,10 @@ definition {
 	}
 
 	macro viewNewSharedDocument {
+		var key_assetSharingPermission = "${assetSharingPermission}";
+		var key_dmDocumentTitle = "${dmDocumentTitle}";
+		var key_ownerName = "${ownerName}";
+		
 		AssertTextEquals(
 			locator1 = "DocumentsAndMediaShare#NOTIFICATIONS_TITLE",
 			value1 = "${ownerName} has shared ${dmDocumentTitle} with you for ${assetSharingPermission}."

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
@@ -150,7 +150,7 @@ definition {
 	macro viewNewSharedDocument {
 		AssertTextEquals(
 			locator1 = "DocumentsAndMediaShare#NOTIFICATIONS_TITLE",
-			value1 = "${user} has shared ${dmDocumentTitle} with you for ${assetSharingPermission}."
+			value1 = "${ownerName} has shared ${dmDocumentTitle} with you for ${assetSharingPermission}."
 		);
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
@@ -151,7 +151,7 @@ definition {
 		var key_assetSharingPermission = "${assetSharingPermission}";
 		var key_dmDocumentTitle = "${dmDocumentTitle}";
 		var key_ownerName = "${ownerName}";
-		
+
 		AssertTextEquals(
 			locator1 = "DocumentsAndMediaShare#NOTIFICATIONS_TITLE",
 			value1 = "${ownerName} has shared ${dmDocumentTitle} with you for ${assetSharingPermission}."

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Notifications.macro
@@ -149,7 +149,7 @@ definition {
 
 	macro viewNewSharedDocument {
 		AssertTextEquals(
-			locator1 = "Notifications#NOTIFICATIONS_TITLE",
+			locator1 = "DocumentsAndMediaShare#NOTIFICATIONS_TITLE",
 			value1 = "${user} has shared ${dmDocumentTitle} with you for ${assetSharingPermission}."
 		);
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/documentsandmedia/DocumentsAndMediaShare.path
@@ -44,6 +44,17 @@
 	<td>//li/div[contains(.,'${key_userName}')]//div[4]/button[//*[name()='svg'][contains(@class,'lexicon-icon')]]</td>
 	<td></td>
 </tr>
+<tr>
+	<td></td>
+	<td></td>
+	<td></td>
+</tr>
+<!--NOTIFICATIONS-->
+<tr>
+	<td>NOTIFICATIONS_TITLE</td>
+	<td>//h4/a[contains(.,'${key_ownerName} has shared ${key_dmDocumentTitle} with you for ${key_assetSharingPermission}')]</td>
+	<td></td>
+</tr>
 </tbody>
 </table>
 </body>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
@@ -108,7 +108,7 @@ definition {
 		Notifications.viewNewSharedDocument(
 			assetSharingPermission = "viewing",
 			dmDocumentTitle = "DM Document Title",
-			user = "Test Test"
+			ownerName = "Test Test"
 		);
 
 		User.logoutPG();
@@ -136,7 +136,7 @@ definition {
 		Notifications.viewNewSharedDocument(
 			assetSharingPermission = "viewing",
 			dmDocumentTitle = "DM Document Title",
-			user = "Test Test"
+			ownerName = "Test Test"
 		);
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/documentmanagement/assetsharing/DMSharing.testcase
@@ -129,7 +129,7 @@ definition {
 
 		User.loginUserPG(password = "test", userEmailAddress = "userea@liferay.com");
 
-		Notifications.viewBadgeCount(notificationCount = "0");
+		Notifications.viewBadgeCount(notificationCount = "1");
 
 		Notifications.gotoNotifications();
 


### PR DESCRIPTION
CC @wanderlast 
From @nellyliupeng

> LPS: https://issues.liferay.com/browse/LPS-88265
> 
> This issue is reproducible in master, but it works fine in 7.0.x.
> 
> When the syncUI function is executed in ddm_form.js, the title of the web content field is displayed properly but is soon filled with "" because the parsedValue retrieved is missing its predefined title of the field. Fix was made so that it performs the check before it overrides the field.
> 
> Additional findings:
> Comparing this to 7.0.x (which does not use of a titleNode variable in its syncUI function), this fix also makes sure that an updated title still displays if the user chooses to select a new web content (at this point, parsedValue does contain a title).
> 
> Comparison to 7.0.x:
> 7.0.x does not retrieve a titleNode when syncUI is called. In fact, title is being stored as a separate attribute instead of as a value, (see _handleSelectButtonClick):
> instance.setTitle(selectedWebContent.assettitle || '');