### PR TITLE
LPS-88633 Updated from LPS-87985

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -11,6 +11,18 @@ AUI.add(
 			dateFormat = customDateFormat;
 		}
 
+		var dateDelimiter = '/';
+		var endDelimiter = false;
+		if (dateFormat.indexOf('.') != -1) {
+			dateDelimiter = '.';
+			if (dateFormat.lastIndexOf('.') == dateFormat.length - 1) {
+				endDelimiter = true;
+			}
+		}
+		if (dateFormat.indexOf('-') != -1) {
+			dateDelimiter = '-';
+		}
+
 		var DateField = A.Component.create(
 			{
 				ATTRS: {
@@ -90,7 +102,7 @@ AUI.add(
 
 						var dateMask = [];
 
-						var items = mask.split('/');
+						var items = mask.split(dateDelimiter);
 
 						items.forEach(
 							function(item, index) {
@@ -101,11 +113,15 @@ AUI.add(
 									dateMask.push(/\d/, /\d/);
 								}
 
-								if (index < (items.length - 1)) {
-									dateMask.push('/');
+								if (index < 2) {
+									dateMask.push(dateDelimiter);
 								}
 							}
 						);
+
+						if (endDelimiter) {
+							dateMask.push(dateDelimiter);
+						}
 
 						return dateMask;
 					},

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -3,22 +3,28 @@ AUI.add(
 	function(A) {
 		var isArray = Array.isArray;
 
-		var langId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
-		var customDateFormat = A.Intl.get('datatype-date-format', 'x', langId);
-		var dateFormat = Liferay.AUI.getDateFormat();
+		var languageId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
+		var dateFormat;
+		var customDateFormat = A.Intl.get('datatype-date-format', 'x', languageId);
 
 		if (customDateFormat) {
 			dateFormat = customDateFormat;
 		}
+		else {
+			dateFormat = Liferay.AUI.getDateFormat();
+		}
 
 		var dateDelimiter = '/';
 		var endDelimiter = false;
+
 		if (dateFormat.indexOf('.') != -1) {
 			dateDelimiter = '.';
+
 			if (dateFormat.lastIndexOf('.') == dateFormat.length - 1) {
 				endDelimiter = true;
 			}
 		}
+
 		if (dateFormat.indexOf('-') != -1) {
 			dateDelimiter = '-';
 		}
@@ -109,7 +115,7 @@ AUI.add(
 								if (item == '%Y') {
 									dateMask.push(/\d/, /\d/, /\d/, /\d/);
 								}
-								else {
+								else if (item) {
 									dateMask.push(/\d/, /\d/);
 								}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js
@@ -3,6 +3,14 @@ AUI.add(
 	function(A) {
 		var isArray = Array.isArray;
 
+		var langId = Liferay.ThemeDisplay.getLanguageId().replace('_', '-');
+		var customDateFormat = A.Intl.get('datatype-date-format', 'x', langId);
+		var dateFormat = Liferay.AUI.getDateFormat();
+
+		if (customDateFormat) {
+			dateFormat = customDateFormat;
+		}
+
 		var DateField = A.Component.create(
 			{
 				ATTRS: {
@@ -11,7 +19,7 @@ AUI.add(
 					},
 
 					mask: {
-						value: Liferay.AUI.getDateFormat()
+						value: dateFormat
 					},
 
 					predefinedValue: {

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -589,15 +589,48 @@ private static String _getDateFormatPattern(Locale locale) {
 		SimpleDateFormat simpleDateFormat = (SimpleDateFormat)DateFormat.getDateInstance(DateFormat.SHORT, locale);
 
 		dateFormatPattern = simpleDateFormat.toPattern();
+		String lowerCaseDFP = StringUtil.toLowerCase(dateFormatPattern);
 
-		if (dateFormatPattern.indexOf("y") == 0) {
-			dateFormatPattern = "%Y/%m/%d";
+		boolean endDelimiter = false;
+		char dateFormatSymbol = CharPool.FORWARD_SLASH;
+
+		for (char dateDelimiter : _DATE_DELIMITERS) {
+			if (lowerCaseDFP.indexOf(dateDelimiter) != -1) {
+				dateFormatSymbol = dateDelimiter;
+
+				if (lowerCaseDFP.lastIndexOf(dateDelimiter) ==
+					lowerCaseDFP.length() - 1) {
+
+					endDelimiter = true;
+				}
+			}
 		}
-		else if (dateFormatPattern.indexOf("d") == 0) {
-			dateFormatPattern = "%d/%m/%Y";
+
+		int dayOrder = lowerCaseDFP.indexOf("d");
+		int monthOrder = lowerCaseDFP.indexOf("m");
+		int yearOrder = lowerCaseDFP.indexOf("y");
+
+		if ((yearOrder < dayOrder) && (yearOrder < monthOrder)) {
+			dateFormatPattern =
+				"%y" + dateFormatSymbol + "%m" + dateFormatSymbol + "%d";
+		}
+		else if (dayOrder < monthOrder) {
+			dateFormatPattern =
+				"%d" + dateFormatSymbol + "%m" + dateFormatSymbol + "%y";
 		}
 		else {
-			dateFormatPattern = "%m/%d/%Y";
+			dateFormatPattern =
+				"%m" + dateFormatSymbol + "%d" + dateFormatSymbol + "%y";
+		}
+
+		if (endDelimiter) {
+			dateFormatPattern += dateFormatSymbol;
+		}
+
+		boolean fullYear = lowerCaseDFP.contains("yyyy");
+
+		if (fullYear) {
+			dateFormatPattern.replace("y", "Y");
 		}
 
 		_dateFormatPatterns.put(languageId, dateFormatPattern);
@@ -629,6 +662,10 @@ private static boolean _isAnalyticsTrackingEnabled(String liferayAnalyticsKey, S
 
 	return false;
 }
+
+private static final char[] _DATE_DELIMITERS = {
+	CharPool.DASH, CharPool.FORWARD_SLASH, CharPool.PERIOD
+};
 
 private static final Map<String, String> _dateFormatPatterns = new ConcurrentHashMap<>();
 %>

--- a/portal-web/docroot/html/common/themes/top_js.jspf
+++ b/portal-web/docroot/html/common/themes/top_js.jspf
@@ -586,51 +586,40 @@ private static String _getDateFormatPattern(Locale locale) {
 	String dateFormatPattern = _dateFormatPatterns.get(languageId);
 
 	if (dateFormatPattern == null) {
+		boolean endDelimiter = false;
+
+		String delimiterString = StringPool.FORWARD_SLASH;
+
 		SimpleDateFormat simpleDateFormat = (SimpleDateFormat)DateFormat.getDateInstance(DateFormat.SHORT, locale);
 
 		dateFormatPattern = simpleDateFormat.toPattern();
-		String lowerCaseDFP = StringUtil.toLowerCase(dateFormatPattern);
-
-		boolean endDelimiter = false;
-		char dateFormatSymbol = CharPool.FORWARD_SLASH;
 
 		for (char dateDelimiter : _DATE_DELIMITERS) {
-			if (lowerCaseDFP.indexOf(dateDelimiter) != -1) {
-				dateFormatSymbol = dateDelimiter;
+			if (dateFormatPattern.indexOf(dateDelimiter) != -1) {
+				delimiterString = String.valueOf(dateDelimiter);
 
-				if (lowerCaseDFP.lastIndexOf(dateDelimiter) ==
-					lowerCaseDFP.length() - 1) {
+				endDelimiter = dateFormatPattern.endsWith(delimiterString);
 
-					endDelimiter = true;
-				}
+				break;
 			}
 		}
 
-		int dayOrder = lowerCaseDFP.indexOf("d");
-		int monthOrder = lowerCaseDFP.indexOf("m");
-		int yearOrder = lowerCaseDFP.indexOf("y");
+		int dayOrder = dateFormatPattern.indexOf('d');
+		int monthOrder = dateFormatPattern.indexOf('M');
+		int yearOrder = dateFormatPattern.indexOf('y');
 
 		if ((yearOrder < dayOrder) && (yearOrder < monthOrder)) {
-			dateFormatPattern =
-				"%y" + dateFormatSymbol + "%m" + dateFormatSymbol + "%d";
+			dateFormatPattern = StringBundler.concat("%Y", delimiterString, "%m", delimiterString, "%d");
 		}
 		else if (dayOrder < monthOrder) {
-			dateFormatPattern =
-				"%d" + dateFormatSymbol + "%m" + dateFormatSymbol + "%y";
+			dateFormatPattern = StringBundler.concat("%d", delimiterString, "%m", delimiterString, "%Y");
 		}
 		else {
-			dateFormatPattern =
-				"%m" + dateFormatSymbol + "%d" + dateFormatSymbol + "%y";
+			dateFormatPattern = StringBundler.concat("%m", delimiterString, "%d", delimiterString, "%Y");
 		}
 
 		if (endDelimiter) {
-			dateFormatPattern += dateFormatSymbol;
-		}
-
-		boolean fullYear = lowerCaseDFP.contains("yyyy");
-
-		if (fullYear) {
-			dateFormatPattern.replace("y", "Y");
+			dateFormatPattern += delimiterString;
 		}
 
 		_dateFormatPatterns.put(languageId, dateFormatPattern);


### PR DESCRIPTION
Ticket:
https://issues.liferay.com/browse/LPS-88633

Previous conversation: https://github.com/jonathanmccann/liferay-portal/pull/1733

YUI ticket: 
https://issues.liferay.com/browse/AUI-3163
Code change:
https://github.com/jonmak08/yui3/pull/41
Update in Liferay:
https://github.com/brianchandotcom/liferay-portal/pull/66043

I have not changed the code from the last PR, but YUI has been updated within Liferay so that the "datatype-date-format" module default date formats use 4-digit year notation. This resolves the formatting discrepancy in [date_field.js](https://github.com/ricky-pan/liferay-portal/blob/LPS-88633/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/date/date_field.js#L8), where the "datatype-date-format" module will by default load a date format that overwrites the format sent from the backend.