### PR TITLE
LPS-88576

### DIFF
--- a/modules/apps/portal-store/portal-store-jcr/src/main/java/com/liferay/portal/store/jcr/JCRStore.java
+++ b/modules/apps/portal-store/portal-store-jcr/src/main/java/com/liferay/portal/store/jcr/JCRStore.java
@@ -241,6 +241,8 @@ public class JCRStore extends BaseStore {
 		catch (RepositoryException re) {
 			String message = GetterUtil.getString(re.getMessage());
 
+			message = StringUtil.toLowerCase(message);
+
 			if (message.contains("failed to resolve path")) {
 				logFailedDeletion(companyId, repositoryId, dirName, re);
 			}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88576

From @ajsampang67:

> Exception was previously handled incorrectly, as the message had "Failed" whereas the code was searching for "failed"