### PR TITLE
LPS-88701 Updated portlet anchoring

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -334,6 +334,10 @@
 
 					instance.refreshLayout(portletBound);
 
+					if (window.location.hash) {
+						window.location.hash = 'p_' + portletId;
+					}
+
 					portletBoundary = portletBound;
 
 					var Layout = Liferay.Layout;

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/portlet.js
@@ -335,7 +335,7 @@
 					instance.refreshLayout(portletBound);
 
 					if (window.location.hash) {
-						window.location.hash = 'p_' + portletId;
+						window.location.href = window.location.hash;
 					}
 
 					portletBoundary = portletBound;


### PR DESCRIPTION
**Relevant tickets:**
https://issues.liferay.com/browse/LPS-88701
https://issues.liferay.com/browse/LPS-85800

**Explanation:**
- Reverted LPS-85800; the removal of this block of code resulted in the bug described in LPS-88701
- Changed `'... = p_' + portletId` to `... = window.location.hash`, this fixes the bug described in LPS-85800
- Changed `window.location.hash = ...` to `window.location.href = ...`, this fixes the anchoring for Chrome browser
