### PR TITLE
LPS-41848 - Service Builder fails to generate code when Blob and composite key are both present

### DIFF
--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/blob_model.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/blob_model.ftl
@@ -1,5 +1,9 @@
 package ${apiPackagePath}.model;
 
+<#if entity.hasCompoundPK()>
+	import ${apiPackagePath}.service.persistence.${entity.name}PK;
+</#if>
+
 import aQute.bnd.annotation.ProviderType;
 
 import java.sql.Blob;
@@ -17,27 +21,42 @@ public class ${entity.name}${column.methodName}BlobModel {
 	public ${entity.name}${column.methodName}BlobModel() {
 	}
 
-	<#assign pkEntityColumn = entity.PKEntityColumns?first />
+	<#if entity.hasCompoundPK()>
+		<#assign
+			pkEntityMethodName = entity.PKClassName
+			pkEntityType = entity.PKClassName
+			pkEntityVarName = entity.PKVarName
+		/>
+
+	<#else>
+		<#assign
+			pkEntityColumn = entity.PKEntityColumns?first
+
+			pkEntityMethodName = pkEntityColumn.methodName
+			pkEntityType = pkEntityColumn.type
+			pkEntityVarName = pkEntityColumn.name
+		/>
+	</#if>
 
 	public ${entity.name}${column.methodName}BlobModel(
-		${pkEntityColumn.type} ${pkEntityColumn.name}) {
+		${pkEntityType} ${pkEntityVarName}) {
 
-		_${pkEntityColumn.name} = ${pkEntityColumn.name};
+		_${pkEntityVarName} = ${pkEntityVarName};
 	}
 
 	public ${entity.name}${column.methodName}BlobModel(
-		${pkEntityColumn.type} ${pkEntityColumn.name}, Blob ${column.name}Blob) {
+		${pkEntityType} ${pkEntityVarName}, Blob ${column.name}Blob) {
 
-		_${pkEntityColumn.name} = ${pkEntityColumn.name};
+		_${pkEntityVarName} = ${pkEntityVarName};
 		_${column.name}Blob = ${column.name}Blob;
 	}
 
-	public ${entity.PKClassName} get${pkEntityColumn.methodName}() {
-		return _${entity.PKVarName};
+	public ${pkEntityType} get${pkEntityMethodName}() {
+		return _${pkEntityVarName};
 	}
 
-	public void set${pkEntityColumn.methodName}(${entity.PKClassName} ${entity.PKVarName}) {
-		_${entity.PKVarName} = ${entity.PKVarName};
+	public void set${pkEntityMethodName}(${pkEntityType} ${pkEntityVarName}) {
+		_${pkEntityVarName} = ${pkEntityVarName};
 	}
 
 	public Blob get${column.methodName}Blob() {
@@ -48,11 +67,7 @@ public class ${entity.name}${column.methodName}BlobModel {
 		_${column.name}Blob = ${column.name}Blob;
 	}
 
-	<#if entity.hasCompoundPK()>
-		private ${entity.PKClassName} _${entity.PKVarName};
-	<#else>
-		private ${pkEntityColumn.type} _${pkEntityColumn.name};
-	</#if>
+	private ${pkEntityType} _${pkEntityVarName};
 
 	private Blob _${column.name}Blob;
 

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/hbm_xml.ftl
@@ -131,11 +131,41 @@
 			>
 				<#assign entityColumn = entity.PKEntityColumns?first />
 
-				<id column="${entityColumn.DBName}" name="${entityColumn.name}">
-					<generator class="foreign">
-						<param name="property">${packagePath}.model.impl.${entity.name}Impl</param>
-					</generator>
-				</id>
+				<#if entity.hasCompoundPK()>
+					<composite-id class="${apiPackagePath}.service.persistence.${entity.name}PK" name="${entity.PKClassName}">
+						<#list entity.PKEntityColumns as entityColumn>
+							<key-property
+
+							<#if serviceBuilder.isHBMCamelCasePropertyAccessor(entityColumn.name)>
+								access="com.liferay.portal.dao.orm.hibernate.CamelCasePropertyAccessor"
+							<#elseif serviceBuilder.isVersionGTE_7_1_0()>
+								access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor"
+							</#if>
+
+							<#if entityColumn.name != entityColumn.DBName>
+								column="${entityColumn.DBName}"
+							</#if>
+
+								name="${entityColumn.name}"
+
+							<#if entityColumn.isPrimitiveType() || stringUtil.equals(entityColumn.type, "Map") || stringUtil.equals(entityColumn.type, "String")>
+								type="com.liferay.portal.dao.orm.hibernate.${serviceBuilder.getPrimitiveObj("${entityColumn.type}")}Type"
+							</#if>
+
+							<#if stringUtil.equals(entityColumn.type, "Date")>
+								type="org.hibernate.type.TimestampType"
+							</#if>
+
+							/>
+						</#list>
+					</composite-id>
+				<#else>
+					<id column="${entityColumn.DBName}" name="${entityColumn.name}">
+						<generator class="foreign">
+							<param name="property">${packagePath}.model.impl.${entity.name}Impl</param>
+						</generator>
+					</id>
+				</#if>
 
 				<property column="${blobEntityColumn.DBName}" name="${blobEntityColumn.name}Blob" type="blob" />
 			</class>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-41848

Hi @jonathanmccann ,

Currently, the code generated by ServiceBuilder does not compile if a service contains a **Blob** column and a **composite key**. 

The generated **Blob model** does not properly account for composite keys.
The goal of this pr is to provide proper handling for those composite keys.

**Notes**
I ran `ant build-service` in `portal-impl` with the deployed changes and no additional class files were generated.

Please let me know if you have any questions.
Thanks!