### PR TITLE
LPS-88702 - Revert LPS-86846 Change the favicon link to IE with only …

### DIFF
--- a/portal-web/docroot/html/common/themes/top_head.jsp
+++ b/portal-web/docroot/html/common/themes/top_head.jsp
@@ -20,7 +20,7 @@
 
 <liferay-util:dynamic-include key="/html/common/themes/top_head.jsp#pre" />
 
-<link href="<%= BrowserSnifferUtil.isIe(request) ? StringPool.BLANK : themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
+<link href="<%= themeDisplay.getPathThemeImages() %>/<%= PropsValues.THEME_SHORTCUT_ICON %>" rel="icon" />
 
 <%-- Available Translations --%>
 


### PR DESCRIPTION
…/favicon.ico

https://issues.liferay.com/browse/LPS-88702

Reversion of https://issues.liferay.com/browse/LPS-86846

Reason is here: https://github.com/gregory-bretall/liferay-portal/pull/138#issue-241233300

Test Results: https://github.com/gregory-bretall/liferay-portal/pull/138#issuecomment-450242795
https://github.com/gregory-bretall/liferay-portal/pull/138#issuecomment-450256665

Issue described was separately fixed by changes to senna.js here https://github.com/liferay/senna.js/issues/285.

Do note: this fix only applies to browsers that are NOT IE11 or Edge. Both of those browsers are documented as having this issue, labelled as a Won't Fix by Microsoft as indicated in this comment https://github.com/liferay/senna.js/issues/228#issuecomment-327658741

The outbound link there is dead, but it can be found here https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/9383036/. Note that the IE11 issue is a platform issue with the browser that will not be fixed as IE11 is on limited support.

The Edge version of the issue is still ongoing here https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/18341040/

Let me know if you think we can't push this through due to the regressions it would cause on IE11/Edge due to these platform issues with those browsers.