### PR TITLE
LPS-88862

### DIFF
--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCRenderCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/CreateAccountMVCRenderCommand.java
@@ -16,8 +16,6 @@ package com.liferay.login.web.internal.portlet.action;
 
 import com.liferay.login.web.internal.constants.LoginPortletKeys;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
@@ -40,11 +38,6 @@ public class CreateAccountMVCRenderCommand implements MVCRenderCommand {
 	@Override
 	public String render(
 		RenderRequest renderRequest, RenderResponse renderResponse) {
-
-		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		renderResponse.setTitle(themeDisplay.translate("create-account"));
 
 		return "/create_account.jsp";
 	}

--- a/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCRenderCommand.java
+++ b/modules/apps/login/login-web/src/main/java/com/liferay/login/web/internal/portlet/action/ForgotPasswordMVCRenderCommand.java
@@ -51,8 +51,6 @@ public class ForgotPasswordMVCRenderCommand implements MVCRenderCommand {
 			return "/login.jsp";
 		}
 
-		renderResponse.setTitle(themeDisplay.translate("forgot-password"));
-
 		return "/forgot_password.jsp";
 	}
 

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -27,6 +27,8 @@ Calendar birthdayCalendar = CalendarFactoryUtil.getCalendar();
 birthdayCalendar.set(Calendar.MONTH, Calendar.JANUARY);
 birthdayCalendar.set(Calendar.DATE, 1);
 birthdayCalendar.set(Calendar.YEAR, 1970);
+
+renderResponse.setTitle(themeDisplay.translate("create-account"));
 %>
 
 <portlet:actionURL name="/login/create_account" secure="<%= PropsValues.COMPANY_SECURITY_AUTH_REQUIRES_HTTPS || request.isSecure() %>" var="createAccountURL" windowState="<%= LiferayWindowState.MAXIMIZED.toString() %>">

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -28,6 +28,8 @@ Integer reminderAttempts = (Integer)portletSession.getAttribute(WebKeys.FORGOT_P
 if (reminderAttempts == null) {
 	reminderAttempts = 0;
 }
+
+renderResponse.setTitle(themeDisplay.translate("forgot-password"));
 %>
 
 <portlet:actionURL name="/login/forgot_password" var="forgotPasswordURL">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88862

From @nellyliupeng, CC @wanderlast 

> Currently, "Sign In" is being used as portlet title as it is the display name for the Login Portlet.
> However, there is an issue as the portlet title does not update when action commands such as "create account" and "forgot Password" within the portlet are called. This fix was made to update the portlet title accordingly. 

Passing SF test: https://github.com/wanderlast/liferay-portal/pull/18#issuecomment-452135677
Passing Relevant tests: https://github.com/wanderlast/liferay-portal/pull/18#issuecomment-452156279