### PR TITLE
LPS-88551

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/service/impl/AssetDisplayPageEntryLocalServiceImpl.java
@@ -23,8 +23,10 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.util.Portal;
@@ -165,8 +167,24 @@ public class AssetDisplayPageEntryLocalServiceImpl
 				groupId, classNameId, assetEntry.getClassTypeId())
 		);
 
+		if (layoutPageTemplateEntry == null) {
+			String layoutUuid = assetEntry.getLayoutUuid();
+			long companyId = assetEntry.getCompanyId();
+
+			List<Layout> layoutList =
+				_layoutLocalService.getLayoutsByUuidAndCompanyId(
+					layoutUuid, companyId);
+
+			Layout layout = layoutList.get(0);
+
+			return layout.getPlid();
+		}
+
 		return layoutPageTemplateEntry.getPlid();
 	}
+
+	@ServiceReference(type = LayoutLocalService.class)
+	private LayoutLocalService _layoutLocalService;
 
 	@ServiceReference(type = LayoutPageTemplateEntryService.class)
 	private LayoutPageTemplateEntryService _layoutPageTemplateEntryService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -1508,10 +1508,6 @@ public class JournalPortlet extends MVCPortlet {
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		if (layoutPageTemplateEntryId == 0) {
-			return;
-		}
-
 		long classNameId = _portal.getClassNameId(JournalArticle.class);
 		long classPK = article.getResourcePrimKey();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88551

From @wanderlast:

> In 7.1 the user has the option to add a regular layout/page as a default display page to a web content structure. However, currently, the process fails in two different places which causes the display page setting to not save properly. The first was introduced in commit c2ddb3ed68aec3b08d7606394781f1b29459a507. This commit adds a logic check for a layoutPageTemplateEntryId == 0. Structure Default Values always have this value so this automatically preempts any attempt to reach the logic to add the assetDisplayPage seen in lines 1524-1527. I'm uncertain why this check was added, but the reasoning on the commit does not seem relevant to it (this is more than a rename) so it seems reasonable to remove.
> 
> Second, when the method addAssetDisplayPageEntry() is reached, anattempt to retrive a Plid using _getPlid() will be made. However, it will not be able to fetch a LayoutPageTemplateEntry, returning null and returning an error at the end of _getPlid() due to attempting to use getPlid() on a null entry. Logic is added in the null case to check for a Layout not just a LayoutPageTemplateEntry. The specific logic being used is due to the constraints of the information present which is that we have the layout's UUID, groupID, and companyID, but not any record of whether it is a private layout or not. Since the layout plid appears to be identical in all cases that the layout's uuid is the same, I don't believe this logic should cause any errors.
> 
> Please let me know if you have any questions or concerns. Thanks!