### PR TITLE
LPS-88860 Remove draggable attribute in repeatable fields

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/resources/META-INF/resources/js/ddm_form.js
@@ -3252,6 +3252,12 @@ AUI.add(
 							repeatableInstance.add(fieldContainer);
 						}
 
+						var fieldAttributes = fieldContainer._node.attributes;
+
+						if (fieldAttributes.draggable) {
+							fieldAttributes.removeNamedItem('draggable');
+						}
+
 						var drag = A.DD.DDM.getDrag(fieldContainer);
 
 						drag.addInvalid('.alloy-editor');


### PR DESCRIPTION
Explanation of changes https://github.com/gregory-bretall/liferay-portal/pull/139#issue-243116067

https://issues.liferay.com/browse/LPS-88860

Test Results: 
https://github.com/gregory-bretall/liferay-portal/pull/139#issuecomment-452454394
https://github.com/gregory-bretall/liferay-portal/pull/139#issuecomment-452825996

In my own testing it doesn't seem that removing the draggable attribute impacts the ability to drag and drop text from HTML fields on any browser and I found a lot of forum posts and the like pointing to similar issues with draggable not working without extra jury-rigging on non-Chrome browsers.