### PR TITLE
LPS-87946 update jodconverter dependency

### DIFF
--- a/modules/apps/document-library/document-library-document-conversion/build.gradle
+++ b/modules/apps/document-library/document-library-document-conversion/build.gradle
@@ -1,7 +1,7 @@
 task deployConfigs(type: Copy)
 
 dependencies {
-	compileInclude group: "com.artofsolving", name: "jodconverter", version: "2.2.0"
+	compileInclude group: "com.liferay", name: "com.artofsolving.jodconverter", version: "2.2.2"
 	compileInclude group: "org.openoffice", name: "juh", version: "2.3.0"
 	compileInclude group: "org.openoffice", name: "jurt", version: "2.3.0"
 	compileInclude group: "org.openoffice", name: "ridl", version: "2.3.0"


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-87946

Hi @jonathanmccann ,

This pr is pretty straight-forward, an older dependency ended up being used during modularization. 

I'm not exactly sure why an older version was used, but my guess is because version 2.2.2 is not available in the maven repository.

- https://mvnrepository.com/artifact/com.artofsolving/jodconverter 

Liferay portal has a dependency on version 2.2.2 and it looks like we have it somewhere in our own repository.

- https://github.com/liferay/liferay-portal/blob/7.1.1-ga2/lib/portal/dependencies.properties#L96

This commit just makes it so that we use our version of jodconverter.

Please let me know if you have any questions.
Thanks!