### PR TITLE
LPS-88421

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/background/task/LayoutRemoteStagingBackgroundTaskExecutor.java
@@ -33,6 +33,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.security.auth.HttpPrincipal;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
@@ -93,6 +94,23 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 		long stagingRequestId = 0L;
 
 		try {
+			Map<String, Serializable> settingsMap =
+				exportImportConfiguration.getSettingsMap();
+
+			long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
+			long sourceGroupId = MapUtil.getLong(settingsMap, "sourceGroupId");
+			String remoteAddress = MapUtil.getString(
+				settingsMap, "remoteAddress");
+			int remotePort = MapUtil.getInteger(settingsMap, "remotePort");
+			String remotePathContext = MapUtil.getString(
+				settingsMap, "remotePathContext");
+			boolean secureConnection = MapUtil.getBoolean(
+				settingsMap, "secureConnection");
+
+			GroupLocalServiceUtil.validateRemote(
+				sourceGroupId, remoteAddress, remotePort, remotePathContext,
+				secureConnection, targetGroupId);
+
 			currentThread.setContextClassLoader(
 				PortalClassLoaderUtil.getClassLoader());
 
@@ -107,10 +125,6 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 					exportImportConfiguration.getExportImportConfigurationId()),
 				exportImportConfiguration);
 
-			Map<String, Serializable> settingsMap =
-				exportImportConfiguration.getSettingsMap();
-
-			long sourceGroupId = MapUtil.getLong(settingsMap, "sourceGroupId");
 			boolean privateLayout = MapUtil.getBoolean(
 				settingsMap, "privateLayout");
 
@@ -118,7 +132,6 @@ public class LayoutRemoteStagingBackgroundTaskExecutor
 
 			Map<Long, Boolean> layoutIdMap =
 				(Map<Long, Boolean>)settingsMap.get("layoutIdMap");
-			long targetGroupId = MapUtil.getLong(settingsMap, "targetGroupId");
 
 			Map<String, Serializable> taskContextMap =
 				backgroundTask.getTaskContextMap();

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -525,10 +525,6 @@ public class StagingImpl implements Staging {
 			long remoteGroupId, boolean remotePrivateLayout)
 		throws PortalException {
 
-		_groupLocalService.validateRemote(
-			sourceGroupId, remoteAddress, remotePort, remotePathContext,
-			secureConnection, remoteGroupId);
-
 		PermissionChecker permissionChecker =
 			PermissionThreadLocal.getPermissionChecker();
 
@@ -3659,6 +3655,8 @@ public class StagingImpl implements Staging {
 		taskContextMap.put("httpPrincipal", httpPrincipal);
 
 		taskContextMap.put("privateLayout", remotePrivateLayout);
+
+		taskContextMap.put("remotePathContext", remotePathContext);
 
 		BackgroundTask backgroundTask =
 			_backgroundTaskManager.addBackgroundTask(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88408

From @ajsampang67: 

> **Explanation:**
> Error was that when scheduling a publish for remote staging, if the remote server is down at the scheduled time of publish, we will get a ConnectionException in the logs but no error in the Processes list of the UI. 
> 
> **Cause:**
> We were calling [`validateRemote`](https://github.com/liferay/liferay-portal/blob/1a439bbf693c7afbf0a8fc7b3dfd09fd1f3694b3/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L528) in `copyRemoteLayouts`, where the exception was "caught" by [`doReceive()`](https://github.com/liferay/liferay-portal/blob/1a439bbf693c7afbf0a8fc7b3dfd09fd1f3694b3/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/messaging/LayoutsRemotePublisherMessageListener.java#L124) in the `LayoutsRemotePublisherMessageListener`. Since the exception was caught so early on, the BackgroundTask was never created and never logged in the process list.
> 
> **Solution:**
> Moving this check to `LayoutRemoteStagingBackgroundTaskExecutor` allows us to catch and handle this exception cleanly (placing a `FAILED` entry in the Processes list), while still preserving the logic to validate the remote server.

Passing SF test: https://github.com/ChrisKian/liferay-portal/pull/88#issuecomment-455378074
Seemingly unrelated Relevant test failure: https://github.com/ChrisKian/liferay-portal/pull/88#issuecomment-455394226