### PR TITLE
LPS-89290

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/constants/UsersAdminWebKeys.java
+++ b/modules/apps/users-admin/users-admin-web/src/main/java/com/liferay/users/admin/web/internal/constants/UsersAdminWebKeys.java
@@ -39,7 +39,7 @@ public class UsersAdminWebKeys {
 
 	public static final String SHOW_TITLE = "SHOW_TITLE";
 
-	public static final String STATUS = "STATUS";
+	public static final String STATUS = "status";
 
 	public static final String USER_ACTION_CONTRIBUTORS =
 		"USER_ACTION_CONTRIBUTORS";

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
@@ -57,11 +57,11 @@ request.setAttribute(UsersAdminWebKeys.STATUS, status);
 
 ViewUsersManagementToolbarDisplayContext viewUsersManagementToolbarDisplayContext = new ViewUsersManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle, navigation, status);
 
-SearchContainer searchContainer = viewUsersManagementToolbarDisplayContext.getSearchContainer();
-
 PortletURL portletURL = viewUsersManagementToolbarDisplayContext.getPortletURL();
 
 portletURL.setParameter("status", String.valueOf(status));
+
+SearchContainer searchContainer = viewUsersManagementToolbarDisplayContext.getSearchContainer();
 
 boolean showDeleteButton = viewUsersManagementToolbarDisplayContext.isShowDeleteButton();
 boolean showRestoreButton = viewUsersManagementToolbarDisplayContext.isShowRestoreButton();

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
@@ -22,10 +22,6 @@ int status = GetterUtil.getInteger(request.getAttribute("view.jsp-status"));
 String usersListView = GetterUtil.getString(request.getAttribute("view.jsp-usersListView"));
 String viewUsersRedirect = GetterUtil.getString(request.getAttribute("view.jsp-viewUsersRedirect"));
 
-if (!ParamUtil.getBoolean(renderRequest, "advancedSearch")) {
-	currentURLObj.setParameter("status", String.valueOf(status));
-}
-
 String displayStyle = ParamUtil.getString(request, "displayStyle");
 
 if (Validator.isNull(displayStyle)) {
@@ -51,6 +47,10 @@ else if (status == WorkflowConstants.STATUS_INACTIVE) {
 }
 else {
 	navigation = "active";
+}
+
+if (!ParamUtil.getBoolean(renderRequest, "advancedSearch")) {
+	currentURLObj.setParameter("status", String.valueOf(status));
 }
 
 request.setAttribute(UsersAdminWebKeys.STATUS, status);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
@@ -37,7 +37,7 @@ else {
 	request.setAttribute(WebKeys.SINGLE_PAGE_APPLICATION_CLEAR_CACHE, Boolean.TRUE);
 }
 
-String navigation = ParamUtil.getString(request, "navigation", "active");
+String navigation = ParamUtil.getString(request, "navigation");
 String toolbarItem = ParamUtil.getString(request, "toolbarItem", "view-all-users");
 
 ViewUsersManagementToolbarDisplayContext viewUsersManagementToolbarDisplayContext = new ViewUsersManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle, navigation, status);

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/view_flat_users.jsp
@@ -40,18 +40,24 @@ else {
 String navigation = ParamUtil.getString(request, "navigation");
 String toolbarItem = ParamUtil.getString(request, "toolbarItem", "view-all-users");
 
-ViewUsersManagementToolbarDisplayContext viewUsersManagementToolbarDisplayContext = new ViewUsersManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle, navigation, status);
-
-SearchContainer searchContainer = viewUsersManagementToolbarDisplayContext.getSearchContainer();
-
 if (navigation.equals("active")) {
 	status = WorkflowConstants.STATUS_APPROVED;
 }
 else if (navigation.equals("inactive")) {
 	status = WorkflowConstants.STATUS_INACTIVE;
 }
+else if (status == WorkflowConstants.STATUS_INACTIVE) {
+	navigation = "inactive";
+}
+else {
+	navigation = "active";
+}
 
 request.setAttribute(UsersAdminWebKeys.STATUS, status);
+
+ViewUsersManagementToolbarDisplayContext viewUsersManagementToolbarDisplayContext = new ViewUsersManagementToolbarDisplayContext(request, renderRequest, renderResponse, displayStyle, navigation, status);
+
+SearchContainer searchContainer = viewUsersManagementToolbarDisplayContext.getSearchContainer();
 
 PortletURL portletURL = viewUsersManagementToolbarDisplayContext.getPortletURL();
 

--- a/portal-impl/src/com/liferay/portlet/usersadmin/search/UserDisplayTerms.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/search/UserDisplayTerms.java
@@ -17,7 +17,6 @@ package com.liferay.portlet.usersadmin.search;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import javax.portlet.PortletRequest;
@@ -48,11 +47,9 @@ public class UserDisplayTerms extends DisplayTerms {
 	public UserDisplayTerms(PortletRequest portletRequest) {
 		super(portletRequest);
 
-		String statusString = ParamUtil.getString(portletRequest, STATUS);
-
-		if (Validator.isNotNull(statusString)) {
-			status = GetterUtil.getInteger(statusString);
-		}
+		status = GetterUtil.getInteger(
+			portletRequest.getAttribute(STATUS),
+			WorkflowConstants.STATUS_APPROVED);
 
 		emailAddress = ParamUtil.getString(portletRequest, EMAIL_ADDRESS);
 		firstName = ParamUtil.getString(portletRequest, FIRST_NAME);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89290

The underlying problem is when a user navigates to view Inactive users, all the search container navigation links on the page (like delta and current page) will set the status param to 0 (which is Active) instead of 5 (Inactive).  The Navigation param is only used directly after clicking to view Active/Inactive users, but not again, so it cannot be placed into the search container nav links.

The solution is to make sure we are passing in the correct status value.  We assume the status value is the current page and will remain so UNLESS the navigation value is present.  In this case, we change status to the corresponding navigation value, and create all the links for the page we are rendering.

Please let me know if you have any questions, or if I can clear anything up.  Thanks!