### PR TITLE
LPS-88275 Clear index before reindexing, since LDAP configurations ap…

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/search/ConfigurationModelIndexer.java
@@ -287,6 +287,10 @@ public class ConfigurationModelIndexer extends BaseIndexer<ConfigurationModel> {
 		Map<String, ConfigurationModel> configurationModels =
 			_configurationModelRetriever.getConfigurationModels();
 
+		_indexWriterHelper.deleteEntityDocuments(
+			getSearchEngineId(), CompanyConstants.SYSTEM, getClassName(),
+			isCommitImmediately());
+
 		for (ConfigurationModel configurationModel :
 				configurationModels.values()) {
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-88275

Multiple LDAP elastic search indicies gives duplicate search results - clear all indices before reindexing, preventing duplicates.
More details : https://github.com/SpencerWoo/liferay-portal/pull/36

tests : https://github.com/SpencerWoo/liferay-portal/pull/36#issuecomment-456657722

