### PR TITLE
LPS-89561 We need the delta here because the SearchContainer can't ad…

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java
@@ -366,8 +366,6 @@ public class SearchResultsPortlet extends MVCPortlet {
 			renderRequest);
 
 		urlString = http.removeParameter(
-			urlString, paginationDeltaParameterName);
-		urlString = http.removeParameter(
 			urlString, paginationStartParameterName);
 
 		return urlString;


### PR DESCRIPTION
…d the delta to the NullPortletURL being returned
https://issues.liferay.com/browse/LPS-89561

Resending - it seems that the SearchResultsPortlet uses a NullPortletURL [here](https://github.com/liferay/liferay-portal/blob/2ecdf7230bcbb4509bcc3be4eed38606bab29dac/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/results/portlet/SearchResultsPortlet.java#L345-L352) which disables the SearchContainer from adding the usual delta parameter. I considered leaving the paginationStartParameter, but it doesn't seem useful. The other option is to not use the NullPortletURL - but that is going against the developer's intent even more.