### PR TITLE
LPS-90129 remove HTML escape

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -168,7 +168,7 @@
 					<liferay-ui:search-container-column-text
 						name="description"
 						truncate="<%= true %>"
-						value="<%= HtmlUtil.escape(assetRenderer.getSummary(renderRequest, renderResponse)) %>"
+						value="<%= assetRenderer.getSummary(renderRequest, renderResponse) %>"
 					/>
 
 					<liferay-ui:search-container-column-text


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90129

@ryannealeigh1 

> Is there a reason we aren't also changing the other escapes?

> I looked into this and even if you put newlines in the title field of the Web Content, the same error does not occur, so it is unnecessary to remove those escapes. I also just tested using other special characters and there are no issues.