### PR TITLE
LPS-90129 remove HTML escape

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -133,7 +133,7 @@
 					<liferay-ui:search-container-column-text
 						name="description"
 						truncate="<%= true %>"
-						value="<%= HtmlUtil.escape(assetRenderer.getSummary(renderRequest, renderResponse)) %>"
+						value="<%= assetRenderer.getSummary(renderRequest, renderResponse) %>"
 					/>
 
 					<liferay-ui:search-container-column-text


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-90129

Based on my testing, this fix does not regress [LPS-71236](https://issues.liferay.com/browse/LPS-71236) as [JournalArticleAssetRenderer.getSummary()](https://github.com/liferay/liferay-portal/blob/839539a1cdbbf054641736e2fee4898fa58eeb99/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/asset/JournalArticleAssetRenderer.java#L208-L243) already returns escaped text, thus creating a double escape situation.