### PR TITLE
LPS-92135

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderService.java
@@ -77,6 +77,10 @@ public interface JournalFolderService extends BaseService {
 	public JournalFolder fetchFolder(long folderId) throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JournalFolder fetchFolder(long folderId, String actionId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<DDMStructure> getDDMStructures(
 			long[] groupIds, long folderId, int restrictionType)
 		throws PortalException;

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceUtil.java
@@ -69,6 +69,13 @@ public class JournalFolderServiceUtil {
 		return getService().fetchFolder(folderId);
 	}
 
+	public static com.liferay.journal.model.JournalFolder fetchFolder(
+			long folderId, String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().fetchFolder(folderId, actionId);
+	}
+
 	public static java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMStructure> getDDMStructures(
 				long[] groupIds, long folderId, int restrictionType)

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalFolderServiceWrapper.java
@@ -67,6 +67,14 @@ public class JournalFolderServiceWrapper
 	}
 
 	@Override
+	public com.liferay.journal.model.JournalFolder fetchFolder(
+			long folderId, String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalFolderService.fetchFolder(folderId, actionId);
+	}
+
+	@Override
 	public java.util.List<com.liferay.dynamic.data.mapping.model.DDMStructure>
 			getDDMStructures(
 				long[] groupIds, long folderId, int restrictionType)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceHttp.java
@@ -201,6 +201,44 @@ public class JournalFolderServiceHttp {
 		}
 	}
 
+	public static com.liferay.journal.model.JournalFolder fetchFolder(
+			HttpPrincipal httpPrincipal, long folderId, String actionId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalFolderServiceUtil.class, "fetchFolder",
+				_fetchFolderParameterTypes4);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, folderId, actionId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					e);
+			}
+
+			return (com.liferay.journal.model.JournalFolder)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static java.util.List
 		<com.liferay.dynamic.data.mapping.model.DDMStructure> getDDMStructures(
 				HttpPrincipal httpPrincipal, long[] groupIds, long folderId,
@@ -210,7 +248,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getDDMStructures",
-				_getDDMStructuresParameterTypes4);
+				_getDDMStructuresParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, folderId, restrictionType);
@@ -249,7 +287,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolder",
-				_getFolderParameterTypes5);
+				_getFolderParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -287,7 +325,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolderIds",
-				_getFolderIdsParameterTypes6);
+				_getFolderIdsParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -324,7 +362,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes7);
+				_getFoldersParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -355,7 +393,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes8);
+				_getFoldersParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId);
@@ -388,7 +426,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes9);
+				_getFoldersParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, status);
@@ -421,7 +459,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes10);
+				_getFoldersParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, start, end);
@@ -454,7 +492,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFolders",
-				_getFoldersParameterTypes11);
+				_getFoldersParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, status, start, end);
@@ -487,7 +525,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticles",
-				_getFoldersAndArticlesParameterTypes12);
+				_getFoldersAndArticlesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status, start, end, obc);
@@ -518,7 +556,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticles",
-				_getFoldersAndArticlesParameterTypes13);
+				_getFoldersAndArticlesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, start, end, obc);
@@ -550,7 +588,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticles",
-				_getFoldersAndArticlesParameterTypes14);
+				_getFoldersAndArticlesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, folderId, status, start, end, obc);
@@ -582,7 +620,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticles",
-				_getFoldersAndArticlesParameterTypes15);
+				_getFoldersAndArticlesParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, folderId, status, locale, start,
@@ -614,7 +652,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes16);
+				_getFoldersAndArticlesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderIds, status);
@@ -644,7 +682,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes17);
+				_getFoldersAndArticlesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -674,7 +712,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes18);
+				_getFoldersAndArticlesCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -705,7 +743,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes19);
+				_getFoldersAndArticlesCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, folderId, status);
@@ -735,7 +773,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes20);
+				_getFoldersCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId);
@@ -766,7 +804,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getFoldersCount",
-				_getFoldersCountParameterTypes21);
+				_getFoldersCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, parentFolderId, status);
@@ -797,7 +835,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes22);
+				_getSubfolderIdsParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderIds, groupId, folderId);
@@ -824,7 +862,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes23);
+				_getSubfolderIdsParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderIds, groupId, folderId, recurse);
@@ -851,7 +889,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "getSubfolderIds",
-				_getSubfolderIdsParameterTypes24);
+				_getSubfolderIdsParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, recurse);
@@ -883,7 +921,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolder",
-				_moveFolderParameterTypes25);
+				_moveFolderParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -922,7 +960,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolderFromTrash",
-				_moveFolderFromTrashParameterTypes26);
+				_moveFolderFromTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId, parentFolderId, serviceContext);
@@ -960,7 +998,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "moveFolderToTrash",
-				_moveFolderToTrashParameterTypes27);
+				_moveFolderToTrashParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -998,7 +1036,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "restoreFolderFromTrash",
-				_restoreFolderFromTrashParameterTypes28);
+				_restoreFolderFromTrashParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, folderId);
@@ -1039,7 +1077,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "searchDDMStructures",
-				_searchDDMStructuresParameterTypes29);
+				_searchDDMStructuresParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupIds, folderId, restrictionType,
@@ -1079,7 +1117,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "subscribe",
-				_subscribeParameterTypes30);
+				_subscribeParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1113,7 +1151,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes31);
+				_unsubscribeParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1150,7 +1188,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes32);
+				_updateFolderParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, parentFolderId, name, description,
@@ -1193,7 +1231,7 @@ public class JournalFolderServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalFolderServiceUtil.class, "updateFolder",
-				_updateFolderParameterTypes33);
+				_updateFolderParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, parentFolderId, name, description,
@@ -1242,110 +1280,113 @@ public class JournalFolderServiceHttp {
 	private static final Class<?>[] _fetchFolderParameterTypes3 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getDDMStructuresParameterTypes4 =
+	private static final Class<?>[] _fetchFolderParameterTypes4 = new Class[] {
+		long.class, String.class
+	};
+	private static final Class<?>[] _getDDMStructuresParameterTypes5 =
 		new Class[] {long[].class, long.class, int.class};
-	private static final Class<?>[] _getFolderParameterTypes5 = new Class[] {
+	private static final Class<?>[] _getFolderParameterTypes6 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getFolderIdsParameterTypes6 = new Class[] {
+	private static final Class<?>[] _getFolderIdsParameterTypes7 = new Class[] {
 		long.class, long.class
-	};
-	private static final Class<?>[] _getFoldersParameterTypes7 = new Class[] {
-		long.class
 	};
 	private static final Class<?>[] _getFoldersParameterTypes8 = new Class[] {
-		long.class, long.class
+		long.class
 	};
 	private static final Class<?>[] _getFoldersParameterTypes9 = new Class[] {
-		long.class, long.class, int.class
+		long.class, long.class
 	};
 	private static final Class<?>[] _getFoldersParameterTypes10 = new Class[] {
-		long.class, long.class, int.class, int.class
+		long.class, long.class, int.class
 	};
 	private static final Class<?>[] _getFoldersParameterTypes11 = new Class[] {
+		long.class, long.class, int.class, int.class
+	};
+	private static final Class<?>[] _getFoldersParameterTypes12 = new Class[] {
 		long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _getFoldersAndArticlesParameterTypes12 =
+	private static final Class<?>[] _getFoldersAndArticlesParameterTypes13 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFoldersAndArticlesParameterTypes13 =
+	private static final Class<?>[] _getFoldersAndArticlesParameterTypes14 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFoldersAndArticlesParameterTypes14 =
+	private static final Class<?>[] _getFoldersAndArticlesParameterTypes15 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFoldersAndArticlesParameterTypes15 =
+	private static final Class<?>[] _getFoldersAndArticlesParameterTypes16 =
 		new Class[] {
 			long.class, long.class, long.class, int.class,
 			java.util.Locale.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes16 = new Class[] {
+		_getFoldersAndArticlesCountParameterTypes17 = new Class[] {
 			long.class, java.util.List.class, int.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes17 = new Class[] {
+		_getFoldersAndArticlesCountParameterTypes18 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes18 = new Class[] {
+		_getFoldersAndArticlesCountParameterTypes19 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes19 = new Class[] {
+		_getFoldersAndArticlesCountParameterTypes20 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
-	private static final Class<?>[] _getFoldersCountParameterTypes20 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getFoldersCountParameterTypes21 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _getFoldersCountParameterTypes22 =
 		new Class[] {long.class, long.class, int.class};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes22 =
-		new Class[] {java.util.List.class, long.class, long.class};
 	private static final Class<?>[] _getSubfolderIdsParameterTypes23 =
+		new Class[] {java.util.List.class, long.class, long.class};
+	private static final Class<?>[] _getSubfolderIdsParameterTypes24 =
 		new Class[] {
 			java.util.List.class, long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _getSubfolderIdsParameterTypes24 =
+	private static final Class<?>[] _getSubfolderIdsParameterTypes25 =
 		new Class[] {long.class, long.class, boolean.class};
-	private static final Class<?>[] _moveFolderParameterTypes25 = new Class[] {
+	private static final Class<?>[] _moveFolderParameterTypes26 = new Class[] {
 		long.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _moveFolderFromTrashParameterTypes26 =
+	private static final Class<?>[] _moveFolderFromTrashParameterTypes27 =
 		new Class[] {
 			long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveFolderToTrashParameterTypes27 =
+	private static final Class<?>[] _moveFolderToTrashParameterTypes28 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreFolderFromTrashParameterTypes28 =
+	private static final Class<?>[] _restoreFolderFromTrashParameterTypes29 =
 		new Class[] {long.class};
-	private static final Class<?>[] _searchDDMStructuresParameterTypes29 =
+	private static final Class<?>[] _searchDDMStructuresParameterTypes30 =
 		new Class[] {
 			long.class, long[].class, long.class, int.class, String.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _subscribeParameterTypes30 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes31 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _unsubscribeParameterTypes31 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes32 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _updateFolderParameterTypes32 =
+	private static final Class<?>[] _updateFolderParameterTypes33 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateFolderParameterTypes33 =
+	private static final Class<?>[] _updateFolderParameterTypes34 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, String.class,
 			long[].class, int.class, boolean.class,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceSoap.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalFolderServiceSoap.java
@@ -129,6 +129,24 @@ public class JournalFolderServiceSoap {
 		}
 	}
 
+	public static com.liferay.journal.model.JournalFolderSoap fetchFolder(
+			long folderId, String actionId)
+		throws RemoteException {
+
+		try {
+			com.liferay.journal.model.JournalFolder returnValue =
+				JournalFolderServiceUtil.fetchFolder(folderId, actionId);
+
+			return com.liferay.journal.model.JournalFolderSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.dynamic.data.mapping.model.DDMStructureSoap[]
 			getDDMStructures(
 				long[] groupIds, long folderId, int restrictionType)

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -91,6 +91,20 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 	}
 
 	@Override
+	public JournalFolder fetchFolder(long folderId, String actionId)
+		throws PortalException {
+
+		JournalFolder folder = journalFolderLocalService.fetchFolder(folderId);
+
+		if (folder != null) {
+			_journalFolderModelResourcePermission.check(
+				getPermissionChecker(), folder, actionId);
+		}
+
+		return folder;
+	}
+
+	@Override
 	public List<DDMStructure> getDDMStructures(
 			long[] groupIds, long folderId, int restrictionType)
 		throws PortalException {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -80,14 +80,7 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 
 	@Override
 	public JournalFolder fetchFolder(long folderId) throws PortalException {
-		JournalFolder folder = journalFolderLocalService.fetchFolder(folderId);
-
-		if (folder != null) {
-			_journalFolderModelResourcePermission.check(
-				getPermissionChecker(), folder, ActionKeys.VIEW);
-		}
-
-		return folder;
+		return fetchFolder(folderId, ActionKeys.VIEW);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/JournalPortlet.java
@@ -99,6 +99,7 @@ import com.liferay.portal.kernel.portlet.PortletRequestModel;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
@@ -1302,21 +1303,30 @@ public class JournalPortlet extends MVCPortlet {
 			RenderRequest renderRequest, RenderResponse renderResponse)
 		throws IOException, PortletException {
 
-		try {
-			ActionUtil.getFolder(renderRequest);
+		String path = getPath(renderRequest, renderResponse);
 
-			String path = getPath(renderRequest, renderResponse);
+		if (Objects.equals(path, "/edit_article.jsp") ||
+			Objects.equals(path, "/view_article_history.jsp")) {
 
-			if (Objects.equals(path, "/edit_article.jsp") ||
-				Objects.equals(path, "/view_article_history.jsp")) {
-
+			try {
+				ActionUtil.getFolder(renderRequest, ActionKeys.ACCESS);
 				ActionUtil.getArticle(renderRequest);
 			}
-		}
-		catch (Exception e) {
-			_log.error(e.getMessage());
+			catch (Exception e) {
+				_log.error(e.getMessage());
 
-			SessionErrors.add(renderRequest, e.getClass());
+				SessionErrors.add(renderRequest, e.getClass());
+			}
+		}
+		else {
+			try {
+				ActionUtil.getFolder(renderRequest);
+			}
+			catch (Exception e) {
+				_log.error(e.getMessage());
+
+				SessionErrors.add(renderRequest, e.getClass());
+			}
 		}
 
 		if (SessionErrors.contains(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
@@ -383,25 +383,7 @@ public class ActionUtil {
 	public static JournalFolder getFolder(HttpServletRequest request)
 		throws PortalException {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
-		long folderId = ParamUtil.getLong(request, "folderId");
-
-		JournalFolder folder = null;
-
-		if ((folderId > 0) &&
-			(folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
-
-			folder = JournalFolderServiceUtil.fetchFolder(folderId);
-		}
-		else {
-			JournalPermission.check(
-				themeDisplay.getPermissionChecker(),
-				themeDisplay.getScopeGroup(), ActionKeys.VIEW);
-		}
-
-		return folder;
+		return getFolder(request, ActionKeys.VIEW);
 	}
 
 	public static JournalFolder getFolder(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
@@ -404,6 +404,31 @@ public class ActionUtil {
 		return folder;
 	}
 
+	public static JournalFolder getFolder(
+			HttpServletRequest request, String actionId)
+		throws PortalException {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)request.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		long folderId = ParamUtil.getLong(request, "folderId");
+
+		JournalFolder folder = null;
+
+		if ((folderId > 0) &&
+			(folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+
+			folder = JournalFolderServiceUtil.fetchFolder(folderId, actionId);
+		}
+		else {
+			JournalPermission.check(
+				themeDisplay.getPermissionChecker(),
+				themeDisplay.getScopeGroup(), ActionKeys.VIEW);
+		}
+
+		return folder;
+	}
+
 	public static JournalFolder getFolder(PortletRequest portletRequest)
 		throws PortalException {
 
@@ -411,6 +436,16 @@ public class ActionUtil {
 			portletRequest);
 
 		return getFolder(request);
+	}
+
+	public static JournalFolder getFolder(
+			PortletRequest portletRequest, String actionId)
+		throws PortalException {
+
+		HttpServletRequest request = PortalUtil.getHttpServletRequest(
+			portletRequest);
+
+		return getFolder(request, actionId);
 	}
 
 	public static List<JournalFolder> getFolders(ResourceRequest request)

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -160,6 +160,7 @@ page import="com.liferay.portal.kernel.exception.LocaleException" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchImageException" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchLayoutException" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchWorkflowDefinitionLinkException" %><%@
+page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.log.Log" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -128,7 +128,7 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 								</aui:a>
 							</h2>
 
-							<c:if test="<%= (journalDisplayContext.isSearch()) && (curArticleFolder != null) %>">
+							<c:if test="<%= journalDisplayContext.isSearch() && (curArticleFolder != null) %>">
 								<h5>
 									<%= JournalHelperUtil.getAbsolutePath(liferayPortletRequest, curArticleFolder.getFolderId()) %>
 								</h5>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -56,7 +56,22 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 				rowData.put("actions", journalManagementToolbarDisplayContext.getAvailableActions(curArticle));
 				rowData.put("draggable", JournalArticlePermission.contains(permissionChecker, curArticle, ActionKeys.DELETE) || JournalArticlePermission.contains(permissionChecker, curArticle, ActionKeys.UPDATE));
 
+				JournalFolder curArticleFolder = null;
+
 				String title = curArticle.getTitle(locale);
+
+				try {
+					if ((curArticle.getFolderId() > 0) && (curArticle.getFolderId() != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID)) {
+						curArticleFolder = JournalFolderServiceUtil.fetchFolder(curArticle.getFolderId());
+					}
+					else {
+						JournalPermission.check(themeDisplay.getPermissionChecker(), themeDisplay.getScopeGroup(), ActionKeys.VIEW);
+
+						curArticleFolder = curArticle.getFolder();
+					}
+				}
+				catch (PortalException e) {
+				}
 
 				if (Validator.isNull(title)) {
 					title = curArticle.getTitle(LocaleUtil.fromLanguageId(curArticle.getDefaultLanguageId()));
@@ -113,9 +128,9 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 								</aui:a>
 							</h2>
 
-							<c:if test="<%= journalDisplayContext.isSearch() %>">
+							<c:if test="<%= (journalDisplayContext.isSearch()) && (curArticleFolder != null) %>">
 								<h5>
-									<%= JournalHelperUtil.getAbsolutePath(liferayPortletRequest, curArticle.getFolderId()) %>
+									<%= JournalHelperUtil.getAbsolutePath(liferayPortletRequest, curArticleFolder.getFolderId()) %>
 								</h5>
 							</c:if>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
@@ -111,10 +111,7 @@ public class FolderSearchFacetDisplayBuilder {
 			folderSearchFacetTermDisplayContext =
 				new FolderSearchFacetTermDisplayContext();
 
-		if (!displayName.equals(StringPool.BLANK)) {
-			folderSearchFacetTermDisplayContext.setDisplayName(displayName);
-		}
-
+		folderSearchFacetTermDisplayContext.setDisplayName(displayName);
 		folderSearchFacetTermDisplayContext.setFolderId(folderId);
 		folderSearchFacetTermDisplayContext.setFrequency(frequency);
 		folderSearchFacetTermDisplayContext.setFrequencyVisible(
@@ -131,7 +128,7 @@ public class FolderSearchFacetDisplayBuilder {
 
 		String displayName = getDisplayName(folderId);
 
-		if ((folderId == 0) || (displayName == null)) {
+		if ((folderId == 0) || displayName.equals(StringPool.BLANK)) {
 			return null;
 		}
 
@@ -186,7 +183,7 @@ public class FolderSearchFacetDisplayBuilder {
 			return title;
 		}
 
-		return null;
+		return StringPool.BLANK;
 	}
 
 	protected FolderSearchFacetTermDisplayContext

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/facet/display/builder/FolderSearchFacetDisplayBuilder.java
@@ -111,7 +111,10 @@ public class FolderSearchFacetDisplayBuilder {
 			folderSearchFacetTermDisplayContext =
 				new FolderSearchFacetTermDisplayContext();
 
-		folderSearchFacetTermDisplayContext.setDisplayName(displayName);
+		if (!displayName.equals(StringPool.BLANK)) {
+			folderSearchFacetTermDisplayContext.setDisplayName(displayName);
+		}
+
 		folderSearchFacetTermDisplayContext.setFolderId(folderId);
 		folderSearchFacetTermDisplayContext.setFrequency(frequency);
 		folderSearchFacetTermDisplayContext.setFrequencyVisible(
@@ -126,12 +129,14 @@ public class FolderSearchFacetDisplayBuilder {
 
 		long folderId = GetterUtil.getLong(termCollector.getTerm());
 
-		if (folderId == 0) {
+		String displayName = getDisplayName(folderId);
+
+		if ((folderId == 0) || (displayName == null)) {
 			return null;
 		}
 
 		return buildFolderSearchFacetTermDisplayContext(
-			folderId, getDisplayName(folderId), termCollector.getFrequency(),
+			folderId, displayName, termCollector.getFrequency(),
 			isSelected(folderId));
 	}
 
@@ -181,7 +186,7 @@ public class FolderSearchFacetDisplayBuilder {
 			return title;
 		}
 
-		return StringPool.OPEN_BRACKET + folderId + StringPool.CLOSE_BRACKET;
+		return null;
 	}
 
 	protected FolderSearchFacetTermDisplayContext


### PR DESCRIPTION
Hello @jonathanmccann ,

https://issues.liferay.com/browse/LPS-92135

Currently, the behavior of search results for a web content with a parent folder and the behavior of accessing web content with a parent folder are both inconsistent.

The more detailed information can be found in the LPS ticket as the inconsistency is extensive.

I have resolved the inconsistency as guided by the PTR for LPS-92135.

Resending from https://github.com/jonathanmccann/liferay-portal/pull/1788 to address your concerns:
> [1983014](https://github.com/jonathanmccann/liferay-portal/commit/1983014da808f61bf736fae18eb709a61c998c88) - This seems a little strange to me to be passing around `null` ([1983014#diff-51b0fa7e3d7b2046879f598d8e2a28d0R189](https://github.com/jonathanmccann/liferay-portal/commit/1983014da808f61bf736fae18eb709a61c998c88#diff-51b0fa7e3d7b2046879f598d8e2a28d0R189)) and not using `Validator.isNotNull` ([1983014#diff-51b0fa7e3d7b2046879f598d8e2a28d0R114](https://github.com/jonathanmccann/liferay-portal/commit/1983014da808f61bf736fae18eb709a61c998c88#diff-51b0fa7e3d7b2046879f598d8e2a28d0R114)). In the former, if you still want to return `null` then simply return `_folderTitleLookup.getFolderTitle(folderId)` because it's either returning a string or null.
> 
> [7f26282](https://github.com/jonathanmccann/liferay-portal/commit/7f26282fb317110cdabe44c48c6739197acd61aa) - The logic added is almost a complete duplication of the previous methods. The previous ones should be updated to call the new methods passing in `VIEW` for the `actionId` to limit the amount of duplication.
> 
> Please resend and let me know if you have any questions.



Sincerely,
Brian Kim