### PR TITLE
LPS-95122 Remove addition of data-senna-track from doEndTag so that a…

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/ProductMenuProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/ProductMenuProductNavigationControlMenuEntry.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.ServerDetector;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -97,7 +98,31 @@ public class ProductMenuProductNavigationControlMenuEntry
 			return false;
 		}
 
-		BodyBottomTag bodyBottomTag = new BodyBottomTag();
+		BodyBottomTag bodyBottomTag = new BodyBottomTag() {
+
+			@Override
+			public int doEndTag() throws JspException {
+				try {
+					String bodyContentString =
+						getBodyContentAsStringBundler().toString();
+
+					JspWriter jspWriter = pageContext.getOut();
+
+					jspWriter.write(bodyContentString);
+
+					return EVAL_PAGE;
+				}
+				catch (Exception e) {
+					throw new JspException(e);
+				}
+				finally {
+					if (!ServerDetector.isResin()) {
+						cleanUp();
+					}
+				}
+			}
+
+		};
 
 		bodyBottomTag.setOutputKey("productMenu");
 


### PR DESCRIPTION
…ui:script tags in product menu don't execute twice

https://issues.liferay.com/browse/LPS-95122

The problem seems to be caused by the interactions between BodyBottomTag (the tag that adds data-senna-track=permanent) and runtimetag. I couldn't find any other instances of this interaction in the portal so I decided to make the fix specifically here.