### PR TITLE
LPS-93851 Avoid removing FieldSettings

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form_context_support.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/form_context_support.js
@@ -5,6 +5,10 @@ AUI.add(
 		var AObject = A.Object;
 		var Renderer = Liferay.DDM.Renderer;
 
+		var FieldSettings = ['autosaveEnabled', 'emailFromAddress', 'emailFromName',
+							 'emailSubject', 'emailToAddress', 'published', 'redirectURL',
+							 'requireAuthentication', 'requireCaptcha', 'sendEmailNotification',
+							 'storageType', 'workflowDefinition'];
 		var FieldTypes = Renderer.FieldTypes;
 		var Util = Renderer.Util;
 
@@ -240,20 +244,23 @@ AUI.add(
 				});
 
 				columnFieldContexts.forEach(function(columnFieldContext) {
-					var foundFieldContext = AArray.find(
-						repeatedContext,
-						function(repeatedContext) {
-							return (
-								columnFieldContext.fieldName ===
+					if (FieldSettings.indexOf(columnFieldContext.fieldName) ===
+						-1) {
+						var foundFieldContext = AArray.find(
+							repeatedContext,
+							function(repeatedContext) {
+								return (
+									columnFieldContext.fieldName ===
 									repeatedContext.fieldName &&
-								columnFieldContext.instanceId ===
+									columnFieldContext.instanceId ===
 									repeatedContext.instanceId
-							);
-						}
-					);
+								);
+							}
+						);
 
-					if (!foundFieldContext) {
-						removeContext.push(columnFieldContext);
+						if (!foundFieldContext) {
+							removeContext.push(columnFieldContext);
+						}
 					}
 				});
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-96425

When creating a form, the `FieldSettings` are being checked for repeatable context and are removed in `_removeFieldContexts` which is causing issues while creating a form.

To prevent this, we check if `columnFieldContext.fieldName` can be found in the `FieldSettings` and we can skip it in the remove process.
Let me know if there are any questions or comments about this.
Thank you!