### PR TITLE
LPS-96596 add pathProxy only once when needed

### DIFF
--- a/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolver.java
+++ b/modules/apps/frontend-js/frontend-js-loader-modules-extender/src/main/java/com/liferay/frontend/js/loader/modules/extender/internal/resolution/BrowserModulesResolver.java
@@ -30,6 +30,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -185,7 +186,23 @@ public class BrowserModulesResolver {
 
 		browserModulesResolution.putDependenciesMap(
 			moduleName, dependenciesMap);
-		browserModulesResolution.putPath(moduleName, browserModule.getPath());
+
+		String browserModulePath = browserModule.getPath();
+
+		String pathProxy = _portal.getPathProxy();
+
+		if (Validator.isNotNull(pathProxy) &&
+			!browserModulePath.startsWith(_portal.getPathProxy())) {
+
+			StringBundler sb = new StringBundler(2);
+
+			sb.append(pathProxy);
+			sb.append(browserModulePath);
+
+			browserModulePath = sb.toString();
+		}
+
+		browserModulesResolution.putPath(moduleName, browserModulePath);
 
 		browserModulesResolution.addResolvedModuleName(moduleName);
 

--- a/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-top-head-extender/src/main/java/com/liferay/frontend/js/top/head/extender/internal/servlet/taglib/TopHeadDynamicInclude.java
@@ -205,8 +205,13 @@ public class TopHeadDynamicInclude implements DynamicInclude {
 				try {
 					String proxyPath = _portal.getPathProxy();
 
-					String servletContextPath = proxyPath.concat(
-						topHeadResources.getServletContextPath());
+					String servletContextPath =
+						topHeadResources.getServletContextPath();
+
+					if (!servletContextPath.startsWith(proxyPath)) {
+						servletContextPath = proxyPath.concat(
+							servletContextPath);
+					}
 
 					for (String jsResourcePath :
 							topHeadResources.getJsResourcePaths()) {

--- a/modules/apps/portal-url-builder/portal-url-builder-impl/src/main/java/com/liferay/portal/url/builder/internal/AbsolutePortalURLBuilderImpl.java
+++ b/modules/apps/portal-url-builder/portal-url-builder-impl/src/main/java/com/liferay/portal/url/builder/internal/AbsolutePortalURLBuilderImpl.java
@@ -222,8 +222,12 @@ public class AbsolutePortalURLBuilderImpl implements AbsolutePortalURLBuilder {
 			sb.append(_getCDNHost(_httpServletRequest));
 		}
 
-		if (!ignorePathProxy) {
-			sb.append(_getPathProxy());
+		String pathProxy = _getPathProxy();
+
+		if (!ignorePathProxy && !pathPrefix.startsWith(pathProxy) &&
+			!relativeURL.startsWith(pathProxy)) {
+
+			sb.append(pathProxy);
 		}
 
 		if (!Validator.isBlank(pathPrefix)) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-96596

@ryannealeigh

> Notes
> This one was challenging to track down. There are many places in the portal where the pathProxy is being added to the URL, and this resulted in some situations where it was being appended 2x. I added some error checking to catch the cases where it doesn't need to be added again, but I'm not sure if I handled everything exactly how engineering would want it.
> 
> I'm not positive, as I haven't tested this, but it also seems like there might be some issues with double proxy that appear when loading themes other than the default theme, as many of the themes have some form of TopHeadDynamicInclude that deals with pathProxy. But that is probably outside the scope of this issue and would need to be investigated separately.