### PR TITLE
LPS-99587 Generate digest on password update

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -5260,7 +5260,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 
 			password = newPassword1;
 
-			user.setDigest(StringPool.BLANK);
+			user.setDigest(user.getDigest(password));
 		}
 
 		if (user.getContactId() <= 0) {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-99587

This creates a digest when we have a password instead of requiring a valid authentication before generating a digest.  In viewing the history this behavior didn't appear intentional so I've made this change for better digest support however interested in whether reviewers believe there is an SSO security concern with this