### PR TITLE
LPS-99455 Unable to assign user group to a user when setting users.search.with.index=false & user.groups.search.with.index=false

### DIFF
--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
@@ -15,6 +15,7 @@
 package com.liferay.user.groups.admin.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Role;
@@ -31,7 +32,10 @@ import com.liferay.portal.kernel.test.util.UserGroupTestUtil;
 import com.liferay.portal.service.persistence.constants.UserGroupFinderConstants;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
+
+import java.lang.reflect.Field;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -140,6 +144,32 @@ public class UserGroupLocalServiceTest {
 		List<UserGroup> userGroups = _search(keywords, emptyParams);
 
 		Assert.assertEquals(userGroups.toString(), 1, userGroups.size());
+	}
+
+	@Test
+	public void testSearchUserGroupsWithNullParamsAndIndexerDisabled()
+		throws Exception {
+
+		Field field = ReflectionUtil.getDeclaredField(
+			PropsValues.class, "USER_GROUPS_SEARCH_WITH_INDEX");
+
+		Object value = field.get(null);
+
+		try {
+			field.set(null, Boolean.FALSE);
+
+			LinkedHashMap<String, Object> nullParams = null;
+
+			String keywords = null;
+
+			List<UserGroup> userGroups = _search(keywords, nullParams);
+
+			Assert.assertEquals(
+				userGroups.toString(), _count + 2, userGroups.size());
+		}
+		finally {
+			field.set(null, value);
+		}
 	}
 
 	@Test

--- a/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-test/src/testIntegration/java/com/liferay/user/groups/admin/service/test/UserGroupLocalServiceTest.java
@@ -15,7 +15,6 @@
 package com.liferay.user.groups.admin.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Role;
@@ -25,6 +24,7 @@ import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SortFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
@@ -34,8 +34,6 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
-
-import java.lang.reflect.Field;
 
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -150,14 +148,10 @@ public class UserGroupLocalServiceTest {
 	public void testSearchUserGroupsWithNullParamsAndIndexerDisabled()
 		throws Exception {
 
-		Field field = ReflectionUtil.getDeclaredField(
-			PropsValues.class, "USER_GROUPS_SEARCH_WITH_INDEX");
-
-		Object value = field.get(null);
+		Object value = ReflectionTestUtil.getAndSetFieldValue(
+			PropsValues.class, "USER_GROUPS_SEARCH_WITH_INDEX", Boolean.FALSE);
 
 		try {
-			field.set(null, Boolean.FALSE);
-
 			LinkedHashMap<String, Object> nullParams = null;
 
 			String keywords = null;
@@ -168,7 +162,8 @@ public class UserGroupLocalServiceTest {
 				userGroups.toString(), _count + 2, userGroups.size());
 		}
 		finally {
-			field.set(null, value);
+			ReflectionTestUtil.setFieldValue(
+				PropsValues.class, "USER_GROUPS_SEARCH_WITH_INDEX", value);
 		}
 	}
 


### PR DESCRIPTION
This is an update for [LPS-99455](https://issues.liferay.com/browse/LPS-99455).<br><br>Hey Jonathan, can you please double-check that this works? If so feel free to send to Brian and CC me.<br><br>/cc @pei-jung @alee8888 @ChrisKian @dejuknow