### PR TITLE
J cords lps 99857

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6930,7 +6930,9 @@ public class JournalArticleLocalServiceImpl
 
 			// Subscriptions
 
-			if ((article.getVersion() == 1.0) &&
+			if (article.equals(
+					getOldestArticle(
+						article.getGroupId(), article.getArticleId())) &&
 				isLatestVersion(
 					article.getGroupId(), article.getArticleId(),
 					article.getVersion())) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -8309,9 +8309,15 @@ public class JournalArticleLocalServiceImpl
 			article);
 
 		try {
-			PortletRequestModel portletRequestModel = new PortletRequestModel(
-				serviceContext.getLiferayPortletRequest(),
-				serviceContext.getLiferayPortletResponse());
+			PortletRequestModel portletRequestModel = null;
+
+			if ((serviceContext.getLiferayPortletRequest() != null) &&
+				(serviceContext.getLiferayPortletResponse() != null)) {
+
+				portletRequestModel = new PortletRequestModel(
+					serviceContext.getLiferayPortletRequest(),
+					serviceContext.getLiferayPortletResponse());
+			}
 
 			JournalArticleDisplay articleDisplay = getArticleDisplay(
 				article, article.getDDMTemplateKey(), Constants.VIEW,


### PR DESCRIPTION
[LPS-99857](https://issues.liferay.com/browse/LPS-99857)
[LPP-34711](https://issues.liferay.com/browse/LPP-34711)

**Problems:** The first time an article appears on a site, the notification template used should be "added". In the case of staging to a live site - if the article was modified in the staging site and then published, the notification template used was "updated".
Additionally, when staging the PortletRequestModel was null, jumping out of the try even though the articleContent and articleDiffs could still be retrieved. This caused the "updated" template to be missing that information in the email.

**Solutions:** Check to see is the article is the oldest article version instead of version 1.0. 
Surround the PortletRequestModel in a try.