### PR TITLE
LPS-100347 Title needs to be escaped for both title and subtitle.

### DIFF
--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/edit_user_navigation.jsp
@@ -27,7 +27,7 @@ User selUser = PortalUtil.getSelectedUser(request);
 request.setAttribute(UsersAdminWebKeys.SELECTED_USER, selUser);
 
 if (selUser != null) {
-	PortalUtil.setPageSubtitle(selUser.getFullName(), request);
+	PortalUtil.setPageSubtitle(HtmlUtil.escape(selUser.getFullName()), request);
 }
 
 long selUserId = (selUser != null) ? selUser.getUserId() : 0;
@@ -45,7 +45,7 @@ if (!portletName.equals(UsersAdminPortletKeys.MY_ACCOUNT)) {
 	portletDisplay.setShowBackIcon(true);
 	portletDisplay.setURLBack(backURL);
 
-	renderResponse.setTitle((selUser == null) ? LanguageUtil.get(request, "add-user") : LanguageUtil.format(request, "edit-user-x", selUser.getFullName(), false));
+	renderResponse.setTitle((selUser == null) ? LanguageUtil.get(request, "add-user") : LanguageUtil.format(request, "edit-user-x", HtmlUtil.escape(selUser.getFullName()), false));
 }
 %>
 


### PR DESCRIPTION
Hello @jonathanmccann ,

https://issues.liferay.com/browse/LPS-100347

The issue here is that we are vulnerable to the end title tag XSS vulnerability (https://www.owasp.org/index.php/XSS_Filter_Evasion_Cheat_Sheet#End_title_tag) when we are editing users.

The fix is to ensure we escape the user name for both page sub title and title.

Please let me know if you have any questions. Thanks.

Sincerely,
Brian Kim