### PR TITLE
LPS-92572

### DIFF
--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/java/com/liferay/frontend/js/spa/web/internal/servlet/taglib/SPATopHeadJSPDynamicInclude.java
@@ -19,6 +19,7 @@ import com.liferay.frontend.js.spa.web.internal.servlet.taglib.util.SPAUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.servlet.BrowserSnifferUtil;
 import com.liferay.portal.kernel.servlet.taglib.BaseJSPDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
@@ -55,6 +56,12 @@ public class SPATopHeadJSPDynamicInclude extends BaseJSPDynamicInclude {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse, String key)
 		throws IOException {
+
+		if (BrowserSnifferUtil.isIe(httpServletRequest) &&
+			BrowserSnifferUtil.getMajorVersion(httpServletRequest) == 11.0) {
+
+			return;
+		}
 
 		ScriptData scriptData = new ScriptData();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-92572

The issue is that IE11 doesn't handle media queries well if the transition is done using the same approach that senna.js uses, causing the page to render incorrectly.

The senna.js team believes there is nothing that can be done on the senna.js side to resolve the issue, and it affects more than just Liferay .css files (third-party .css loaded on the page is also affected).

Additionally, there was a page rendering time performance regression introduced by https://github.com/liferay/senna.js/issues/124 (to summarize, a side-effect of that fix is that IE11 will always re-download every CSS file on every senna-managed page navigation), which means that pages load more slowly with senna.js in IE11 than without it.

Given all that, it makes sense to simply disable senna.js on IE11.