### PR TITLE
LPS-103604 Add try catch

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1224,8 +1224,14 @@ public class LayoutsAdminDisplayContext {
 		String layoutFullURL = PortalUtil.getLayoutFullURL(
 			layout, _themeDisplay);
 
-		layoutFullURL = HttpUtil.setParameter(
-			layoutFullURL, "p_l_back_url", _themeDisplay.getURLCurrent());
+		try {
+			layoutFullURL = HttpUtil.setParameter(
+				layoutFullURL, "p_l_back_url", _themeDisplay.getURLCurrent());
+		}
+		catch (Exception e) {
+			_log.error(
+				"Unable to generate view layout URL for " + layoutFullURL, e);
+		}
 
 		return layoutFullURL;
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-103604
https://issues.liferay.com/browse/LPP-35434

**Problem:** HttpUtil.setParameter() throws an exception if the url has a # before a ? (an improper format according to https://tools.ietf.org/html/rfc3986#section-3). This causes the Layout Admin Display to crash and no pages are visible.

**Solution:** The HttpUtil.setParameter() should throw exceptions when encountering bad URLs, but if a bad URL is set, it should not prevent the Display to crash. Instead throw an exception.