### PR TITLE
[TS] LPS-116250 Keep passwordModifiedDate update, but only update when password changes

### DIFF
--- a/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
+++ b/modules/apps/portal-security/portal-security-ldap-impl/src/main/java/com/liferay/portal/security/ldap/internal/exportimport/LDAPUserImporterImpl.java
@@ -1797,11 +1797,9 @@ public class LDAPUserImporterImpl implements LDAPUserImporter, UserImporter {
 
 			if (passwordGenerated) {
 				user.setDigest(StringPool.BLANK);
+
+				_userLocalService.updateUser(user);
 			}
-
-			user.setPasswordModifiedDate(modifiedDate);
-
-			_userLocalService.updateUser(user);
 		}
 		finally {
 			ServiceContextThreadLocal.popServiceContext();


### PR DESCRIPTION
Hi Jonathan. Can you please test this solution?
It's a small extension to your proposal, to maintain the logic of updating passwordModifiedDate when the password actually changes. Which it doesn't during the first step of authenticating the current password when trying to change password. Nor when logging in (unless it changed in LDAP in the meantime). So it should still fix [LPS-116251](https://issues.liferay.com/browse/LPS-116250) also.

p.s. The extended solution ensures that if you change your LDAP password and then log into portal, all sessions authenticated with the previous password will be invalidated.