### PR TITLE
LPS-117968 Changing a Web Content article's template removes some of …

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -23,6 +23,7 @@ import com.liferay.asset.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.asset.taglib.internal.util.AssetCategoryUtil;
 import com.liferay.asset.taglib.internal.util.AssetVocabularyUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -214,12 +215,13 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 				}
 
 				if (!_ignoreRequestValue) {
-					String categoryIdsParam = request.getParameter(
+					String[] categoryIdsParam = request.getParameterValues(
 						_hiddenInput + StringPool.UNDERLINE +
 							vocabulary.getVocabularyId());
 
-					if (Validator.isNotNull(categoryIdsParam)) {
-						categoryIds = categoryIdsParam;
+					if (categoryIdsParam != null) {
+						categoryIds = StringUtil.merge(
+							categoryIdsParam, StringPool.COMMA);
 					}
 				}
 

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -246,10 +246,10 @@ public class AssetTagsSelectorTag extends IncludeTag {
 		}
 
 		if (!_ignoreRequestValue) {
-			String curTagsParam = request.getParameter(_hiddenInput);
+			String[] curTagsParam = request.getParameterValues(_hiddenInput);
 
-			if (Validator.isNotNull(curTagsParam)) {
-				return StringUtil.split(curTagsParam);
+			if (curTagsParam != null) {
+				return ListUtil.toList(curTagsParam);
 			}
 		}
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelector.es.js
@@ -33,13 +33,14 @@ function AssetCategoriesSelector({
 				const label = vocabulary.group
 					? `${vocabulary.title} (${vocabulary.group})`
 					: vocabulary.title;
+				const vocabularyInputName = inputName + vocabulary.id;
 
 				return (
 					<AssetVocabularyCategoriesSelector
 						eventName={eventName}
 						groupIds={groupIds}
 						id={`namespace_assetCategoriesSelector_${vocabulary.id}`}
-						inputName={inputName}
+						inputName={vocabularyInputName}
 						key={vocabulary.id}
 						label={label}
 						onSelectedItemsChange={(selectedItems) => {


### PR DESCRIPTION
…its categories

https://issues.liferay.com/browse/LPS-117968
https://issues.liferay.com/browse/LPP-38288

cc @maipham135
Notes:
> The issue was starting 72x, LPS-90509 changed the way asset category Ids and tag's name get stored. We used to store all of them in the first index of an array. However, starting 72x, each category ids/tag name get stored in its own index. Therefore, when retrieve asset category Ids and tags name, the method being used only return the first index of the array. This is the reason why when changing a Web Content article's template, only one category Id and one tag name remain display while the rest disappear. To fix this issue, I changed to call a different method that return the whole array instead. Also in master, asset categories are stored incorrectly, without the vocabulary id. This get fix by appended vocabulary id after inputName.