### PR TITLE
LPS-123448 Keep the page at the same position after clicking on a use…

### DIFF
--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view.jsp
@@ -494,8 +494,6 @@ portletURL.setWindowState(WindowState.NORMAL);
 						.then(function (data) {
 							contactsCenter.renderContent(data, true);
 
-							window.scrollTo(0, 0);
-
 							contactsContainer.loadingmask.hide();
 						})
 						.catch(function () {


### PR DESCRIPTION
…r's name

Notes from @noornajj : 
> https://issues.liferay.com/browse/LPS-123448
> 
> The issue was that the page would scroll to the top every time a contact's name would be clicked to be viewed.
> I fixed the issue by removing the line that caused the page to scroll to the top.

Test result: https://github.com/brianikim/liferay-portal/pull/122#issuecomment-736058026