### PR TITLE
LPS-124261 Reset the system configuration for blogs when the configurations are updated

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/BlogsAdminConfigurationAction.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/BlogsAdminConfigurationAction.java
@@ -14,7 +14,9 @@
 
 package com.liferay.blogs.web.internal.portlet.action;
 
+import com.liferay.blogs.configuration.BlogsGroupServiceOverriddenConfiguration;
 import com.liferay.blogs.constants.BlogsPortletKeys;
+import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
 import com.liferay.portal.kernel.portlet.BaseJSPSettingsConfigurationAction;
 import com.liferay.portal.kernel.portlet.ConfigurationAction;
 import com.liferay.portal.kernel.util.Constants;
@@ -59,6 +61,11 @@ public class BlogsAdminConfigurationAction
 			validateEmail(actionRequest, "emailEntryAdded");
 			validateEmail(actionRequest, "emailEntryUpdated");
 			validateEmailFrom(actionRequest);
+		}
+
+		if (cmd.equals("update")) {
+			ConfigurationProviderUtil.resetSystemConfiguration(
+				BlogsGroupServiceOverriddenConfiguration.class);
 		}
 
 		super.processAction(portletConfig, actionRequest, actionResponse);

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationInvocationHandler.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationInvocationHandler.java
@@ -72,6 +72,10 @@ public class ConfigurationInvocationHandler<S> implements InvocationHandler {
 		}
 	}
 
+	public void resetSystemConfiguration(Class<S> clazz) {
+		ConfigurationOverrideInstance.resetConfiguration(clazz);
+	}
+
 	private Object _getValue(Class<?> returnType, String key)
 		throws ReflectiveOperationException {
 

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationOverrideInstance.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationOverrideInstance.java
@@ -42,7 +42,7 @@ public class ConfigurationOverrideInstance {
 
 		Class<?> configurationOverrideClass = _getOverrideClass(clazz);
 
-		if (configurationOverrideClass == null) {
+		if ((configurationOverrideClass == null) || (typedSettings == null)) {
 			return null;
 		}
 
@@ -58,6 +58,14 @@ public class ConfigurationOverrideInstance {
 		}
 
 		return configurationOverrideInstance;
+	}
+
+	public static void resetConfiguration(Class<?> clazz) {
+		Class<?> configurationOverrideClass = _getOverrideClass(clazz);
+
+		if (configurationOverrideClass != null) {
+			_configurationOverrideInstances.remove(configurationOverrideClass);
+		}
 	}
 
 	public Object invoke(Method method) throws ReflectiveOperationException {

--- a/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationProviderImpl.java
+++ b/modules/apps/portal-configuration/portal-configuration-module-configuration/src/main/java/com/liferay/portal/configuration/module/configuration/internal/ConfigurationProviderImpl.java
@@ -170,6 +170,26 @@ public class ConfigurationProviderImpl implements ConfigurationProvider {
 	}
 
 	@Override
+	public <T> void resetSystemConfiguration(Class<T> clazz)
+		throws ConfigurationException {
+
+		try {
+			ConfigurationInvocationHandler<T> configurationInvocationHandler =
+				new ConfigurationInvocationHandler<>(clazz, null);
+
+			configurationInvocationHandler.resetSystemConfiguration(clazz);
+		}
+		catch (ReflectiveOperationException reflectiveOperationException) {
+			throw new ConfigurationException(
+				"Unable to load configuration of type " + clazz.getName(),
+				reflectiveOperationException);
+		}
+	}
+
+	{
+	}
+
+	@Override
 	public <T> void saveCompanyConfiguration(
 			Class<T> clazz, long companyId,
 			Dictionary<String, Object> properties)

--- a/portal-kernel/src/com/liferay/portal/kernel/module/configuration/ConfigurationProvider.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/configuration/ConfigurationProvider.java
@@ -57,6 +57,9 @@ public interface ConfigurationProvider {
 	public <T> T getSystemConfiguration(Class<T> clazz)
 		throws ConfigurationException;
 
+	public <T> void resetSystemConfiguration(Class<T> clazz)
+		throws ConfigurationException;
+
 	public <T> void saveCompanyConfiguration(
 			Class<T> clazz, long companyId,
 			Dictionary<String, Object> properties)

--- a/portal-kernel/src/com/liferay/portal/kernel/module/configuration/ConfigurationProviderUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/module/configuration/ConfigurationProviderUtil.java
@@ -118,6 +118,15 @@ public class ConfigurationProviderUtil {
 		return configurationProvider.getSystemConfiguration(clazz);
 	}
 
+	public static <T> void resetSystemConfiguration(Class<T> clazz)
+		throws ConfigurationException {
+
+		ConfigurationProvider configurationProvider =
+			getConfigurationProvider();
+
+		configurationProvider.resetSystemConfiguration(clazz);
+	}
+
 	public static <T> void saveCompanyConfiguration(
 			Class<T> clazz, long companyId,
 			Dictionary<String, Object> properties)


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-124261

The issue here was that the RSS toggle for blogs configuration was not being updated. This was caused by the typeSettings not getting updated because the old settings were overridding it.
To fix the issue, I created a resetConfiguration method for ConfigurationOverrideInstance and made a call to that method in processAction() for BlogsAdminConfigurationAction when the action is "update".