### PR TITLE
LPS-133146 Only return locales that are available in the current site

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-values-factory/src/main/java/com/liferay/dynamic/data/mapping/form/values/factory/internal/DDMFormValuesFactoryImpl.java
@@ -531,9 +531,22 @@ public class DDMFormValuesFactoryImpl implements DDMFormValuesFactory {
 			}
 		}
 		else {
+			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
+
+			Set<Locale> siteAvailableLocales = LanguageUtil.getAvailableLocales(
+				groupId);
+
+			String[] siteAvailableLocalesString = LocaleUtil.toLanguageIds(
+				siteAvailableLocales);
+
 			for (String availableLocaleString : availableLocalesString) {
-				ddmFormValues.addAvailableLocale(
-					LocaleUtil.fromLanguageId(availableLocaleString));
+				if (ArrayUtil.contains(
+						siteAvailableLocalesString, availableLocaleString,
+						false)) {
+
+					ddmFormValues.addAvailableLocale(
+						LocaleUtil.fromLanguageId(availableLocaleString));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-133146

The issue here was that after removing a language from site settings, an article's content translation was retained when the web content is updated. 
To fix the issue, I had the ddmFormValues return only the locales that are currently available in the site.