### PR TITLE
LPS-158192 - HRG_09

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler.js
@@ -721,6 +721,21 @@ AUI.add(
 
 				queue: null,
 
+				renderButtonGroup() {
+					const instance = this;
+
+					Scheduler.superclass.renderButtonGroup.apply(
+						this,
+						arguments
+					);
+
+					instance.viewsNode.setAttribute('role', 'tablist');
+
+					instance.viewsNode
+						.all('button')
+						.setAttribute('role', 'tab');
+				},
+
 				renderUI() {
 					const instance = this;
 


### PR DESCRIPTION
## Proposed solution

Visually, Calendar Views is a tablist of tabs, but it is implemented as a listbox of buttons due to ButtonGroup implicitly assuming that everything is a listbox of buttons.

https://github.com/liferay/alloy-ui/blob/master-deprecated/src/aui-button/js/aui-button-core.js#L450-L453

We can update the template to use something other than listbox, but aui-button-core.js will force it back to listbox after we call renderButtonGroup. As such, the solution that seemed to work was to reset it to tablist after the call to renderButtonGroup.

## Steps to verify

1. Add an instance of the calendar portlet to a widget page
2. Open the instance of the calendar portlet in `pop_up` state
3. Select one of the Calendar Views (Agenda, Day, Week, Month)
4. Enable the JAWS screen reader

:heavy_check_mark:  Expected result is that the screen reader assumes that Calendar Views is a list of tabs.
:heavy_multiplication_x: Actual result is that the screen reader assumes that Calendar Views is a list of options.