### PR TITLE
LPS-158192 - HRG_03

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_list.js
@@ -263,12 +263,17 @@ AUI.add(
 
 					const calendars = instance.get('calendars');
 					const contentBox = instance.get('contentBox');
+					const simpleMenu = instance.get('simpleMenu');
 
 					instance.items = A.NodeList.create(
 						TPL_CALENDAR_LIST_ITEM.parse({
 							calendars,
 						})
 					);
+
+					instance.items
+						.all(STR_DOT + CSS_CALENDAR_LIST_ITEM_ARROW)
+						.setAttribute('aria-controls', simpleMenu.id);
 
 					contentBox.setContent(instance.items);
 				},

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -103,7 +103,7 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 							</div>
 
 							<c:if test="<%= userCalendarResource != null %>">
-								<span aria-label="<liferay-ui:message key="manage-calendars" />" class="calendar-list-item-arrow calendar-resource-arrow" data-calendarResourceId="<%= userCalendarResource.getCalendarResourceId() %>" tabindex="0"><clay:icon symbol="caret-bottom" /></span>
+								<span aria-controls="<portlet:namespace />calendarsMenu" aria-label="<liferay-ui:message key="manage-calendars" />" class="calendar-list-item-arrow calendar-resource-arrow" data-calendarResourceId="<%= userCalendarResource.getCalendarResourceId() %>" role="button" tabindex="0"><clay:icon symbol="caret-bottom" /></span>
 							</c:if>
 						</c:if>
 

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar_menus.jspf
@@ -160,6 +160,7 @@
 	}).render();
 
 	window.<portlet:namespace />calendarsMenu = {
+		id: '<portlet:namespace />calendarsMenu',
 		items: [
 			{
 				caption: '<liferay-ui:message key="add-calendar-booking" />',


### PR DESCRIPTION
## Proposed solution

`simple_menu` is implemented as a floating menu that re-aligns itself to whatever menu was selected, causing issues recognizing that it shows up with screen readers, because it is not part of the tab focus cycle. To work around that, this solution makes it `aria-live="polite"`, forces focus onto the floating menu, and then focuses on the first menu item.

`simple_menu` also was not written with accessibility in mind, so you cannot interact with it using a keyboard. The solution adds keydown listeners so that various common actions (enter, escape, tab, up, down) will result in the expected behavior.

## Steps to verify

1. Add an instance of the calendar portlet to a widget page
2. Open the instance of the calendar portlet in `pop_up` state
3. Select one of the Calendar Views (Agenda, Day, Week, Month)
4. Enable the JAWS screen reader
5. Use keyboard to navigate to the calendar actions menus (manage calendars, actual calendar actions, etc.).

:heavy_check_mark:  Expected result is that the screen reader tells you how to interact with the simple menu
:heavy_multiplication_x: Actual result is that the screen reader knows nothing about the simple menu