### PR TITLE
LPS-158192 Make calendarResourceName available for calendar-web

### DIFF
--- a/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/util/CalendarUtil.java
+++ b/modules/apps/calendar/calendar-web/src/main/java/com/liferay/calendar/web/internal/util/CalendarUtil.java
@@ -22,6 +22,7 @@ import com.liferay.calendar.recurrence.Recurrence;
 import com.liferay.calendar.recurrence.RecurrenceSerializer;
 import com.liferay.calendar.service.CalendarBookingService;
 import com.liferay.calendar.service.CalendarResourceLocalService;
+import com.liferay.calendar.service.CalendarResourceLocalServiceUtil;
 import com.liferay.calendar.service.CalendarService;
 import com.liferay.calendar.util.JCalendarUtil;
 import com.liferay.calendar.util.RecurrenceUtil;
@@ -168,6 +169,15 @@ public class CalendarUtil {
 			"calendarBookingId", calendarBooking.getCalendarBookingId()
 		).put(
 			"calendarId", calendarBooking.getCalendarId()
+		).put(
+			"calendarResourceName",
+			() -> {
+				CalendarResource calendarResource =
+					CalendarResourceLocalServiceUtil.getCalendarResource(
+						calendarBooking.getCalendarResourceId());
+
+				return calendarResource.getName(themeDisplay.getLocale());
+			}
 		).put(
 			"description",
 			calendarBooking.getDescription(themeDisplay.getLocale())

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -215,6 +215,7 @@
 	}
 
 	.scheduler-event-content,
+	.scheduler-event-name,
 	.scheduler-event-title {
 		font-family: inherit;
 		font-size: inherit;

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/calendar_util.js
@@ -94,6 +94,7 @@ AUI.add(
 					allDay: calendarBooking.allDay,
 					calendarBookingId: calendarBooking.calendarBookingId,
 					calendarId: calendarBooking.calendarId,
+					calendarResourceName: calendarBooking.calendarResourceName,
 					content: calendarBooking.title,
 					description: calendarBooking.description,
 					endDate: endDate.getTime(),

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/js/scheduler_models.js
@@ -75,6 +75,12 @@ AUI.add(
 					value: 0,
 				},
 
+				calendarResourceName: {
+					setter: String,
+					validator: isValue,
+					value: STR_BLANK,
+				},
+
 				content: {
 					getter(val) {
 						let content = val;

--- a/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
+++ b/modules/apps/calendar/calendar-web/src/main/resources/META-INF/resources/view_calendar.jsp
@@ -373,6 +373,15 @@ boolean columnOptionsVisible = GetterUtil.getBoolean(SessionClicks.get(request, 
 				'title',
 				Liferay.Util.unescapeHTML(schedulerEvent.get('content'))
 			);
+
+		schedulerEvent
+			.get('node')
+			.attr(
+				'calendarResourceName',
+				Liferay.Util.unescapeHTML(
+					schedulerEvent.get('calendarResourceName')
+				)
+			);
 	};
 
 	<portlet:namespace />scheduler.after(['scheduler-events:load'], (event) => {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-158192
This fix adds the necessary components on the Liferay side and the rest of the fix needs to be completed by https://issues.liferay.com/browse/AUI-3212

This fix is to resolve HRG_16, in calendar the Event Cards do not display the owner's name. This is an accessibility issue for people with color deficiency since it will be hard to identify which event correlates with users calendar.

The following fix has been approved here: https://issues.liferay.com/browse/PTR-3217?focusedCommentId=2722985&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2722985
I added `.scheduler-event-name` since this is needed for the event card display.

Let me know if there are any questions or comments about this.
Thank you!