### PR TITLE
LPS-158192 HRG_13

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/menu.js
@@ -440,22 +440,24 @@ AUI.add(
 			},
 
 			_setARIARoles(trigger, menu) {
-				const links = menu.all(SELECTOR_ANCHOR);
+				const links = menu.all(SELECTOR_ANCHOR).filter(':not([aria-haspopup="dialog"]');
 
 				const searchContainer = menu.one(SELECTOR_SEARCH_CONTAINER);
 
 				const listNode = menu.one('ul');
 
-				const ariaLinksAttr = 'menuitem';
+				let ariaLinksAttr = 'menuitem';
 				let ariaListNodeAttr = 'menu';
 
 				if (searchContainer) {
+					ariaLinksAttr = 'option';
 					ariaListNodeAttr = 'listbox';
-					ariaListNodeAttr = 'option';
 				}
 
-				listNode.setAttribute(ARIA_ATTR_ROLE, ariaListNodeAttr);
-				links.set(ARIA_ATTR_ROLE, ariaLinksAttr);
+				if (links.size() > 0) {
+					listNode.setAttribute(ARIA_ATTR_ROLE, ariaListNodeAttr);
+					links.set(ARIA_ATTR_ROLE, ariaLinksAttr);
+				}
 
 				trigger.attr({
 					'aria-haspopup': true,

--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -18,14 +18,24 @@
 
 <%
 boolean urlIsNotNull = Validator.isNotNull(url);
+
+String listItemAnchorAriaHasPopup = "false";
+String listItemAnchorAriaRole = "menuitem";
+String listItemAriaRole = "presentation";
+
+if (useDialog || urlIsNotNull && url.startsWith("javascript:")) {
+	listItemAnchorAriaHasPopup = "dialog";
+	listItemAnchorAriaRole = null;
+	listItemAriaRole = "";
+}
 %>
 
 <c:choose>
 	<c:when test="<%= (iconListIconCount != null) && ((iconListSingleIcon == null) || iconListShowWhenSingleIcon) %>">
-		<li class="<%= cssClass %>" role="presentation">
+		<li class="<%= cssClass %>" role="<%= listItemAriaRole %>">
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
-					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
+					<aui:a aria-haspopup="<%= listItemAnchorAriaHasPopup %>" ariaRole="<%= listItemAnchorAriaRole %>" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
 						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
 					</aui:a>
 				</c:when>
@@ -36,10 +46,10 @@ boolean urlIsNotNull = Validator.isNotNull(url);
 		</li>
 	</c:when>
 	<c:when test="<%= (iconMenuIconCount != null) && ((iconMenuSingleIcon == null) || iconMenuShowWhenSingleIcon) %>">
-		<li class="<%= cssClass %>" role="presentation">
+		<li class="<%= cssClass %>" role="<%= listItemAriaRole %>">
 			<c:choose>
 				<c:when test="<%= urlIsNotNull %>">
-					<aui:a ariaRole="menuitem" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
+					<aui:a aria-haspopup="<%= listItemAnchorAriaHasPopup %>" ariaRole="<%= listItemAnchorAriaRole %>" cssClass="<%= linkCssClass %>" data="<%= data %>" href="<%= url %>" id="<%= id %>" lang="<%= lang %>" onClick="<%= onClick %>" target="<%= target %>">
 						<%@ include file="/html/taglib/ui/icon/link_content.jspf" %>
 					</aui:a>
 				</c:when>

--- a/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
+++ b/util-taglib/src/com/liferay/taglib/ui/IconMenuTag.java
@@ -365,7 +365,7 @@ public class IconMenuTag extends BaseBodyTagSupport implements BodyTag {
 
 					jspWriter.write("\" href=\"javascript:void(0);\" id=\"");
 					jspWriter.write(_id);
-					jspWriter.write("\" title=\"");
+					jspWriter.write("\" role=\"button\" title=\"");
 					jspWriter.write(message);
 					jspWriter.write("\">");
 


### PR DESCRIPTION
## Proposed solution

Liferay menus that open dialogs don't announce that they open dialogs in JAWS. Semantically, the solution would be to add `aria-popup="dialog"` to the existing `a[role="menuitem"]`.

However, JAWS (which has 50% of the screen reader market share) has a limitation where a menuitem that opens a dialog will not announce itself as such (most likely because there's too many adjectives, it does not mention the dialog). To address that, this solution the unimportant semantic role information so that the important popup information, telling the blind person how to interact with the option and what to expect from the interaction, is read aloud instead.

## Steps to verify

1. Choose to add a new to a calendar
2. Expand the Related Assets section
3. Enable a screen reader
4. Use the tab key to navigate to the Select button

:heavy_check_mark:  Expected result is that the screen reader tells you that you can press a button to activate
:heavy_multiplication_x: Actual result is that the screen reader doesn't say anything

5. Expand the menu

:heavy_check_mark: Expected result is that as you navigate the links, the screen reader announces that these are links that open dialogs
:heavy_multiplication_x: Actual result is that the screen reader just announces them as list items
